### PR TITLE
Update README.md - there is no EP reply key anticipated in the KV-store

### DIFF
--- a/rfc/1/README.md
+++ b/rfc/1/README.md
@@ -4,6 +4,8 @@ shortname: 1/EPS
 name: Entrypoint Server
 status: raw
 editor: Valery V. Vorotyntsev <valery.vorotyntsev@seagate.com>
+contributors:
+  - Andriy Tkachuk <andriy.tkachuk@seagate.com>
 ---
 
 ## eps: Entrypoint Server
@@ -13,5 +15,13 @@ editor: Valery V. Vorotyntsev <valery.vorotyntsev@seagate.com>
 ### Data flow
 
 1. `m0d` sends entrypoint request to `eps` via ha-link.
-2. `eps` gets entrypoint reply data from the "entrypoint" key in Consul KV.
+2. `eps` gets entrypoint reply data from the Consul KV store:
+   * list on confd services -- from `consul catalog nodes -service=confd`
+   * principal RM is co-located with the RC leader node:
+     ```bash
+     # get session id from the "leader" key
+     consul kv get -detailed -recurse leader/ | grep Session
+     # use session id to find the leader
+     curl -sX GET http://localhost:8500/v1/session/info/<session-id> | jq -r '.[].Node'
+     ```
 3. `eps` sends entrypoint reply to `eps` via ha-link.


### PR DESCRIPTION
There is no key entry for EP anticipated. The data for EP reply should be collected from the configuration (list of confd services) and the current RC-leader. Refer to https://docs.google.com/document/d/1cR-BbxtMjGuZPj8NOc95RyFjqmeFsYf4JJ5Hw_tL1zA/edit#heading=h.qrpx4vru855f and to https://docs.google.com/document/d/1cR-BbxtMjGuZPj8NOc95RyFjqmeFsYf4JJ5Hw_tL1zA/edit#bookmark=id.43okz4b9kkz2.