### PR TITLE
elect-rc-leader: fix race - always cleanup old RC leader 1st

### DIFF
--- a/elect-rc-leader
+++ b/elect-rc-leader
@@ -18,12 +18,12 @@ get_session_id() {
     consul kv get -detailed leader | awk '/Session/ {print $2}'
 }
 
+# Cleanup EQ watcher and currently running RC handler (if any).
+pkill -f -9 proto-rc || true
+
 # If the session is already set - the leader is elected, so
 # there is nothing for us to do.
 get_session_id | grep -q ^- || exit 0
-
-# Cleanup EQ watcher and currently running RC handler (if any).
-pkill -f -9 proto-rc || true
 
 # Create session with the service:confd Health Checker:
 PAYLD='{"Name": "leader", "Checks": ["serfHealth", "service:confd"]}'


### PR DESCRIPTION
We used to check for the session first (and exit if it already
aquired the "leader" key) before making the cleanup after the
old RC leader. But the lock with the new session may be already
taken on some another node by the time of the check. This would
leave stale RC handler and EQ watcher running along with the
new one on another node.

So we should run the cleanup 1st and then the session check.