### PR TITLE
Revert "elect-rc-leader: fix race - always cleanup old RC leader 1st"

### DIFF
--- a/elect-rc-leader
+++ b/elect-rc-leader
@@ -18,14 +18,14 @@ get_session_id() {
     consul kv get -detailed leader | awk '/Session/ {print $2}'
 }
 
+# If the session is already set - the leader is elected, so
+# there is nothing for us to do.
+get_session_id | grep -q ^- || exit 0
+
 # Stop the EQ watcher (if any):
 pkill -9 -f 'consul watch.*prefix eq' || true
 # Nicely stop currently running RC handler (if any):
 pkill -f 'proto-rc' || true
-
-# If the session is already set - the leader is elected, so
-# there is nothing for us to do.
-get_session_id | grep -q ^- || exit 0
 
 # Create session with the service:confd Health Checker:
 PAYLD='{"Name": "leader", "Checks": ["serfHealth", "service:confd"]}'


### PR DESCRIPTION
This reverts commit 37515578150cfb0d83c5936170b5ec03fd8fd1a3.

The problem was a bogus one (it was misunderstood and mixed with another
one - https://github.com/hashicorp/consul/issues/6103) and the "fix"
introduced another issue - endless leader election (because the
current leader was always killed on the next handler call after
the election).

Conflicts:
	elect-rc-leader