### PR TITLE
consul-srv-conf.json: add correctly elect-rc-leader watch

### DIFF
--- a/consul-srv-conf.json
+++ b/consul-srv-conf.json
@@ -1,5 +1,12 @@
 {
   "server" : true,
+  "watches": [
+    {
+      "type": "key",
+      "key": "leader",
+      "args": ["sh", "-c", "/opt/seagate/consul/elect-rc-leader &>/dev/null"]
+    }
+  ],
   "enable_local_script_checks" : true,
   "service": {
     "id": "confd",


### PR DESCRIPTION
stdout should be redirected to file or /dev/null - otherwise
the handler will be killed on the 1st printout.