### PR TITLE
hax/Makefile: Consider source file dependencies

### DIFF
--- a/hax/Makefile
+++ b/hax/Makefile
@@ -12,9 +12,36 @@ CFLAGS += -fPIC
 LDFLAGS = -shared
 LDLIBS = $(shell python-config --libs) -L$(M0_SRC_DIR)/mero/.libs -lmero
 
+SRC = hax.c
+
+SONAMES := $(SRC:%.c=lib%.so.0)
+SYMLINKS := $(basename $(SONAMES))  # strip version suffix
+
+all: $(SONAMES) $(SYMLINKS)
+
+OBJ := $(SRC:.c=.o)
+-include $(OBJ:.o=.d)
+
+# Generate dependencies.
+%.d: %.c
+	cpp -MM -MG $(CPPFLAGS) $< |\
+ sed -r 's%^(.+)\.o:%$(@D)/\1.d $(@D)/\1.o:%' >$@
+
+%.so: %.so.0
+	ln -s $^ $@
+
+lib%.so.0: %.o
+	$(CC) $(LDFLAGS) -Wl,-soname,$@ $^ -o $@
+# Output file should be versioned.
+# See http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html#AEN95
+
 hax.so: hax.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(LDLIBS) $^ -o $@
 
+.PHONY: mostlyclean
+mostlyclean:
+	rm -f $(OBJ) $(OBJ:.o=.d)
+
 .PHONY: clean
-clean:
-	rm -f hax.so
+clean: mostlyclean
+	rm -f $(SONAMES) $(SYMLINKS)


### PR DESCRIPTION
The Makefile looks hairy now, but the resulting .so file will be rebuilt
properly whenever any of its dependencies changes. (Old version of the
Makefile took only `hax.c` into consideration, ignoring header files.)

TODO: Uncomment `-Wall -Wextra` line in the Makefile and fix compiler warnings.