### PR TITLE
fid-gen: Remove unneeded zeros in hexadecimal integers

### DIFF
--- a/fid-gen
+++ b/fid-gen
@@ -21,4 +21,4 @@ TYPE=$1
 
 export SRC_DIR="$(dirname $(readlink -f $0))"
 
-printf "0x%02x00000000000001:0x%04x\n" $TYPE $($SRC_DIR/next-gen fid 16)
+printf "0x%02x00000000000001:0x%x\n" $TYPE $($SRC_DIR/next-gen fid 16)


### PR DESCRIPTION
Before:
```
    0x7200000000000001:0x007d
```
After:
```
    0x7200000000000001:0x7d
```