### PR TITLE
rfc (4/KV): Simplify documentation of `processes/<fid>` key

### DIFF
--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -17,6 +17,25 @@ Key | Value | Description
 `epoch` | current epoch (natural number) | Atomically incremented counter, which is used to generate unique ordered identifiers for EQ and BQ entries.
 `eq/<epoch>` | event | `eq/*` items are collectively referred to as the EQ (Event Queue).  Events are consumed and dequeued by the RC script.
 `leader` | node name | This key is used for RC leader election.  Created with [`consul lock`](https://www.consul.io/docs/commands/lock.html) command.
-`processes/<fid>` | `{ "state" : "<HA state>" }` | HA state as reported by the callback via `ha link`. Possible string values are as follows: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
-`timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.
+`processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
+<!--
+  XXX TODO: s/processes/m0-servers/
 
+  Word "process" is ambiguous, we should be more specific.
+  We are dealing with a subset of m0_conf_process objects.
+  The items correspond to m0d processes --- Mero servers.
+
+  'm0-processes' is also slightly more greppable.
+-->
+<!--
+  XXX Problem: How will `bootstrap` be able to tell whether given fid
+  corresponds to m0mkfs or m0d?
+
+  Solution: We could use optional `"is-m0mkfs": true` field...
+
+  Right now we don't know for sure if this will actually be a problem.
+  The [specification of `bootstrap` script](rfc/6/README.md) should
+  cover this topic.
+
+-->
+`timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.


### PR DESCRIPTION
+ Add comments to be addressed later.