### PR TITLE
hax: Python code edits

### DIFF
--- a/ha-notifier/bq/emitter.py
+++ b/ha-notifier/bq/emitter.py
@@ -3,7 +3,7 @@ import base64
 
 
 # FIXME not finished
-class Queue(object):
+class Queue:
     def __init__(self):
         self.client = consul.Consul()
 

--- a/hax/hax/ffi.py
+++ b/hax/hax/ffi.py
@@ -21,7 +21,7 @@ def make_array(ctr, some_list):
     return arr_type(*some_list)
 
 
-class HaxFFI(object):
+class HaxFFI:
     def __init__(self):
         dirname = os.path.dirname(os.path.abspath(__file__))
         lib_path = '{}/../libhax.so'.format(dirname)

--- a/hax/hax/halink.py
+++ b/hax/hax/halink.py
@@ -18,7 +18,7 @@ def log_exception(fn):
     return wrapper
 
 
-class HaLink(object):
+class HaLink:
     def __init__(self, node_uuid='', ffi=None, queue=None, rm_fid=None):
         self._ffi = ffi or HaxFFI()
         self._ha_ctx = self._ffi.init_halink(self, make_c_str(node_uuid))

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -1,4 +1,4 @@
-class BaseMessage(object):
+class BaseMessage:
     pass
 
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -52,7 +52,7 @@ class HaNoteStruct(c.Structure):
 
 
 # Mostly duplicates mero/conf/ha.h:m0_conf_ha_process
-class ConfHaProcess(object):
+class ConfHaProcess:
     def __init__(self, chp_event=0, chp_type=0, chp_pid=0, fid=None):
         self.chp_event = chp_event
         self.chp_type = chp_type
@@ -61,7 +61,7 @@ class ConfHaProcess(object):
 
 
 # Duplicates mero/fid/fid.h
-class Fid(object):
+class Fid:
     def __init__(self, container, key):
         self.container = container
         self.key = key
@@ -85,7 +85,7 @@ class Fid(object):
             other.container == self.container and other.key == self.key
 
 
-class Uint128(object):
+class Uint128:
     def __init__(self, hi, lo):
         self.hi = hi
         self.lo = lo

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -6,7 +6,7 @@ from hax.types import Fid
 SERVICE_CONTAINER = 0x7300000000000001
 
 
-class ConsulUtil(object):
+class ConsulUtil:
     def __init__(self):
         self.cns = c.Consul()
         self.event_map = {


### PR DESCRIPTION
* Do not inherit from `object`.
* Fix Fid.__eq__ to accept non-Fid argument.
* Improve readability of `broadcast_ha_states`.