### PR TITLE
check-confd: use /tmp/confd during bootstrap

### DIFF
--- a/check-confd
+++ b/check-confd
@@ -4,4 +4,14 @@ set -eu -o pipefail
 #
 # This is the Health Check for the Mero confd service.
 #
-test $(consul kv get processes/0x7200000000000001:0x1 | jq '.state' -r) = "M0_CONF_HA_PROCESS_STARTED"
+if [ $(consul kv get processes/0x7200000000000001:0x1 | jq '.state' -r) = "M0_CONF_HA_PROCESS_STARTED" ]
+then
+  rm -f /tmp/confd # cleanup after the bootstrap stage
+  exit 0
+else
+  if [ -f /tmp/confd ]; then
+    exit 0 # bootstrap stage
+  else
+    exit 2
+  fi
+fi


### PR DESCRIPTION
This resolves the chicken-and-egg problem when we cannot
elect RC leader because confd process is not there yet and
the latter can not be started because we cannot serve
EP replies without the RC leader.