### PR TITLE
rfc (3/CFGEN): Upgrade the status to "draft"

### DIFF
--- a/rfc/3/README.md
+++ b/rfc/3/README.md
@@ -2,7 +2,7 @@
 domain: gitlab.mero.colo.seagate.com
 shortname: 3/CFGEN
 name: Configuration Generation
-status: raw
+status: draft
 editor: Valery V. Vorotyntsev <valery.vorotyntsev@seagate.com>
 ---
 

--- a/rfc/SUMMARY.md
+++ b/rfc/SUMMARY.md
@@ -2,10 +2,11 @@
 
 * [Introduction](README.md)
 * Raw
-  * [3/CFGEN](3/README.md)
   * [4/KV](4/README.md)
   * [5/HAX](5/README.md)
   * [6/BOOT](6/README.md)
   * [7/FAIL](7/README.md)
   * [8/COSTY](8/README.md)
   * [9/PC3](9/README.md)
+* Draft
+  * [3/CFGEN](3/README.md)


### PR DESCRIPTION
[COSS](https://rfc.unprotocols.org/spec:2/COSS/#draft-specifications):

> When raw specifications can be demonstrated, they become draft
> specifications.  Changes to draft specifications should be done
> in consultation with users.  Draft specifications are contracts
> between the editors and implementers.

`cfgen` [_had been_ demonstrated](http://gitlab.mero.colo.seagate.com/mero/hare/wikis/demos/cfgen-PR).  There are two `cfgen` users
so far (Andriy and I), and it won't be particularly hard for us
to consult with each other.  We also happen to be the implementers...
With all that, I see no problem with upgrading the status of this RFC.