### PR TITLE
cfgen: Export fid key counter as `next-fid-key`

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -742,7 +742,7 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
     del fid_keygen
 
     ConsulService = NamedTuple('ConsulService', [
-        ('node_name', str), ('proc_id', Oid), ('svc_t', SvcT)])
+        ('node_name', str), ('proc_id', Oid), ('svc_type', str)])
 
     def services() -> Iterator[ConsulService]:
         for node_id, node in m0conf.items():
@@ -754,16 +754,17 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
                     assert svc_id.type is ObjT.service
                     svc = m0conf[svc_id]
                     if svc.type in (SvcT.M0_CST_CONFD, SvcT.M0_CST_IOS):
+                        svc_type = svc.type.name[len('M0_CST_'):].lower()
                         yield ConsulService(node_name=node.hostname,
                                             proc_id=proc_id,
-                                            svc_t=svc.type)
+                                            svc_type=svc_type)
 
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('leader', ''),
         ('epoch', 1),
-        ('fid_keygen', _fid_keygen),
-        *[(f'node/{x.node_name}/service/{x.svc_t.name}/{x.proc_id.fidk}',
-           '') for x in services()])],
+        ('next-fid-key', _fid_keygen),
+        *[(f'node/{x.node_name}/service/{x.svc_type}/{x.proc_id.fidk}', '')
+          for x in services()])],
                       indent=2) + "\n"
 
 

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -14,13 +14,13 @@ contributors:
 Key | Value | Description
 --- | --- | ---
 `bq/<epoch>` | (conf object fid, HA state) | `bq/*` items are collectively referred to as the BQ (Broadcast Queue).  The items - HA state updates - are produced by the RC (Recovery Coordinator) script.
-`epoch` | current epoch (natural number) | Atomically incremented counter, which is used to generate unique ordered identifiers for EQ and BQ entries.
-`last_fid` | last generated FID (natural number) | Atomically incremented counter, which is used to generate unique FIDs.
+`epoch` | current epoch | Atomically incremented counter, which is used to generate unique ordered identifiers for EQ and BQ entries.  Natural number.
 `eq/<epoch>` | event | `eq/*` items are collectively referred to as the EQ (Event Queue).  Events are consumed and dequeued by the RC script.
 `leader` | node name | This key is used for RC leader election.  Created with [`consul lock`](https://www.consul.io/docs/commands/lock.html) command.
+`next-fid-key` | max(fid.key) + 1 | Atomically incremented counter that is used to generate fids.  Natural number.
+`node/<name>/service/<service-type>/<fid-key>` | `""` | The data contained in the key is being used during update of Consul configuration files.  Supported values of \<service-type\>: `confd`, `ios`.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
 `timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.
-`node/<name>/service/<confd\|ios>/<fid>` | N/A | Used to update Consul configuration files with services and their FIDs.
 
 <!--
   XXX TODO: s/processes/m0-servers/


### PR DESCRIPTION
* cfgen, 4/KV: Rename `fid_keygen` to `next-fid-key`.
* cfgen: Use human-friendly names of service types in `consul-kv.json`:
  M0_CST_CONFD -> confd; M0_CST_IOS -> ios.
* 4/KV: Sort keys alphabetically.