### PR TITLE
kv_schema: rename next-fid-key to last_fidk

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -762,7 +762,7 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('leader', ''),
         ('epoch', 1),
-        ('next-fid-key', _fid_keygen),
+        ('last_fidk', _fid_keygen),
         *[(f'node/{x.node_name}/service/{x.svc_type}/{x.proc_id.fidk}', '')
           for x in services()])],
                       indent=2) + "\n"

--- a/fid-gen
+++ b/fid-gen
@@ -21,4 +21,4 @@ TYPE=$1
 
 export SRC_DIR="$(dirname $(readlink -f $0))"
 
-printf "0x%02x00000000000001:0x%x\n" $TYPE $($SRC_DIR/next-gen fid 16)
+printf "0x%02x00000000000001:0x%x\n" $TYPE $($SRC_DIR/next-gen last_fidk 16)

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -17,8 +17,8 @@ Key | Value | Description
 `epoch` | current epoch | Atomically incremented counter, which is used to generate unique ordered identifiers for EQ and BQ entries.  Natural number.
 `eq/<epoch>` | event | `eq/*` items are collectively referred to as the EQ (Event Queue).  Events are consumed and dequeued by the RC script.
 `leader` | node name | This key is used for RC leader election.  Created with [`consul lock`](https://www.consul.io/docs/commands/lock.html) command.
-`next-fid-key` | max(fid.key) + 1 | Atomically incremented counter that is used to generate fids.  Natural number.
-`node/<name>/service/<service-type>/<fid-key>` | `""` | The data contained in the key is being used during update of Consul configuration files.  Supported values of \<service-type\>: `confd`, `ios`.
+`last_fidk` | last genarated FID key | Atomically incremented counter that is used to generate fids.  Natural number.
+`node/<name>/service/<service_type>/<fid_key>` | `""` | The data contained in the key is being used during update of Consul configuration files.  Supported values of \<service_type\>: `confd`, `ios`.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
 `timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.
 


### PR DESCRIPTION
When we generate FIDs with Consul, we use it as the last
generated fid key, so the new name will express the semantics
more adequately.