### PR TITLE
Problem: 9/PC3 is too strict w.r.t. merge commits

### DIFF
--- a/rfc/9/README.md
+++ b/rfc/9/README.md
@@ -143,7 +143,7 @@ specific goals:
 10. To discuss a patch, people MAY comment on the Platform pull request,
     on the commit, or elsewhere.
 
-11. To accept or reject a patch, a Maintainer SHALL use the Platform
+11. To accept or reject a patch, a Maintainer SHOULD use the Platform
     interface.
 
 12. Maintainers SHOULD NOT merge their own patches except in


### PR DESCRIPTION
> 11. To accept or reject a patch, a Maintainer SHALL use the Platform
>     interface.

Solution: s/SHALL/SHOULD/

GitLab UI provides the following options for handling merge requests:

* Merge commit
  A merge commit is created for every merge, and merging is allowed
  as long as there are no conflicts.
* Merge commit with semi-linear history
  A merge commit is created for every merge, but merging is only allowed
  if fast-forward merge is possible. This way you could make sure that
  if this merge request would build, after merging to target branch it
  would also build.
  When fast-forward merge is not possible, the user is given the option
  to rebase.
* Fast-forward merge
  No merge commits are created and all merges are fast-forwarded, which
  means that merging is only allowed if the branch could be fast-forwarded.
  When fast-forward merge is not possible, the user is given the option
  to rebase.

Creating a merge commit for every click of `Merge` button pollutes
`git log` output with noise.

The "Fast-forward merge" option does not let one create merge commits
at all.  This is too limiting.

Merge commits are useful in some cases.  E.g., if a MR consists of many
commits, we might want to `git merge --no-ff` them instead of rebasing.
It might be simpler to merge, or we might want to put an informative
commit message into the merge commit.  Considered use of merge commits
lets one see related groups of commits in `git log --graph` output.