### PR TITLE
Problem: systemd/consul doesn't conform to 8/COSTY

### DIFF
--- a/systemd/consul
+++ b/systemd/consul
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
-exec consul agent -bind $BIND -client "$CLIENT" $JOIN -config-file=/opt/seagate/consul/consul-$MODE-conf.json -data-dir=/tmp/consul $OPTS
+exec consul agent -bind $BIND -client "$CLIENT" $JOIN \
+     -config-file=/opt/seagate/consul/consul-$MODE-conf.json \
+     -data-dir=/tmp/consul $OPTS


### PR DESCRIPTION
Solution: edit the shebang; split the long line.

See [8/COSTY — Coding Style Guidelines](rfc/8/README.md).