### PR TITLE
kv_schema: update services IDs layout

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -9,12 +9,10 @@ sudo rm -rf /tmp/consul*
 
 touch /tmp/confd
 
-cd $SRC_DIR
-cfgen/cfgen -D cfgen/dhall/ -o /tmp/ < cfgen/_misc/singlenode.yaml
-
 sudo systemctl start consul-agent
 
-sleep 2
+cd $SRC_DIR
+cfgen/cfgen -D cfgen/dhall/ -o /tmp/ < cfgen/_misc/singlenode.yaml
 
 cat /tmp/consul-kv.json | jq '[.[] | {key, value: (.value | @base64)}]' | consul kv import -
 consul reload

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1108,7 +1108,7 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
     del fid_keygen
 
     ConsulService = NamedTuple('ConsulService', [
-        ('node_name', str), ('proc_id', Oid), ('svc_type', str)])
+        ('node_name', str), ('proc_id', Oid), ('svc_types', str)])
 
     def services() -> Iterator[ConsulService]:
         for node_id, node in m0conf.items():
@@ -1116,20 +1116,19 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
                 continue
             for proc_id in node.processes:
                 assert proc_id.type is ObjT.process
-                for svc_id in m0conf[proc_id].services:
-                    assert svc_id.type is ObjT.service
-                    svc = m0conf[svc_id]
-                    if svc.type in (SvcT.M0_CST_CONFD, SvcT.M0_CST_IOS):
-                        svc_type = svc.type.name[len('M0_CST_'):].lower()
-                        yield ConsulService(node_name=node.hostname,
-                                            proc_id=proc_id,
-                                            svc_type=svc_type)
+                stypes = ' '.join(
+                    m0conf[svc_id].type.name[len('M0_CST_'):].lower()
+                    for svc_id in m0conf[proc_id].services)
+                yield ConsulService(node_name=node.hostname,
+                                    proc_id=proc_id,
+                                    svc_types=stypes)
 
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('leader', ''),
         ('epoch', 1),
         ('last_fidk', _fid_keygen),
-        *[(f'node/{x.node_name}/service/{x.svc_type}/{x.proc_id.fidk}', '')
+        *[(f'node/{x.node_name}/service/{x.proc_id.fidk}/types',
+           f'{x.svc_types}')
           for x in services()])],
                       indent=2) + "\n"
 

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -18,7 +18,8 @@ Key | Value | Description
 `eq/<epoch>` | event | `eq/*` items are collectively referred to as the EQ (Event Queue).  Events are consumed and dequeued by the RC script.
 `leader` | node name | This key is used for RC leader election.  Created with [`consul lock`](https://www.consul.io/docs/commands/lock.html) command.
 `last_fidk` | last genarated FID key | Atomically incremented counter that is used to generate fids.  Natural number.
-`node/<name>/service/<service_type>/<fid_key>` | `""` | The data contained in the key is being used during update of Consul configuration files.  Supported values of \<service_type\>: `confd`, `ios`.
+`node/<name>/service/<fid_key>/types` | `<Mero_service_types>` | Used during update of Consul configuration files with the services (Merp processes) information (like IDs).  \<Mero_service_types\> value is the list of Mero service types enabled in the particular Mero process (e.g `ha rms confd ios`).
+`node/<name>/service/<fid_key>/ep` | endpoint address | Endpoint address of the service (Mero process). E.g `192.168.180.162@tcp:12345:44:101`.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
 `timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.
 

--- a/update-consul-conf
+++ b/update-consul-conf
@@ -4,10 +4,13 @@ set -eu -o pipefail
 SRC_DIR="$(dirname $(readlink -f $0))"
 
 get_service_ids() {
-  consul kv get -recurse node/`hostname`/service/$1 | sed 's;.*/\|:;;g'
+  local cmd="consul kv get -recurse node/`hostname`/service/ \
+                | $1 | sed -r 's;.*/(.+)/types:.*;\1;g'"
+  eval $cmd || echo ''
 }
-CONFD_IDs=$(get_service_ids confd)
-IOS_IDs=$(get_service_ids ios)
+
+CONFD_IDs=$(get_service_ids 'grep -i confd')
+IOS_IDs=$(get_service_ids 'grep -i ios | grep -iv confd')
 
 if [[ $CONFD_IDs ]]; then
   CONF_FILE=$SRC_DIR/consul-server-conf.json


### PR DESCRIPTION
cfgen now generates Consul services (Mero processes)
in the following format:

```
$ consul kv get -recurse node/`hostname`/service/
node/node1/service/10/types:ha rms confd ios sns_rep sns_reb addb2 cas iscs
node/node1/service/44/types:ha rms
node/node1/service/47/types:ha rms
node/node1/service/7/types:ha rms
```

cfgen now will be able to put the endpoint address also to each service in the convenient format, like this:

```
node/node1/service/44/ep:<addr>
```

This information will be used when updating services in Consul configuration file. (Will be added soon.)