### PR TITLE
Problem: cfgen failed to retrieve drive facts if hostname is other than localhost

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -213,9 +213,7 @@ def validate_cluster_desc(desc: Dict[str, Any]) -> None:
 def run_command(hostname: str, *args: str) -> str:
     assert hostname
 
-    cmd: List[str] = []
-    if hostname not in ('localhost', '127.0.0.1'):
-        cmd = ['ssh', hostname]
+    cmd: List[str] = ['ssh', hostname]
     cmd.extend(args)
     return subprocess.check_output(cmd, timeout=15).decode()
 
@@ -257,7 +255,7 @@ def get_disks(hostname: str, mock_p: bool, path_glob: str) -> List[Disk]:
     if not paths:
         return []
 
-    cmd = ['sudo', 'python3', '-c', f"""\
+    cmd = ['sudo', 'python3', '-c', f"""\"\
 import io
 import os
 
@@ -271,7 +269,7 @@ print([dict(path=path,
             size=blockdev_size(path),
             blksize=os.stat(path).st_blksize)
        for path in {paths!r}])
-"""]
+\""""]
     return [Disk(**kwargs) for kwargs in
             ast.literal_eval(run_command(hostname, *cmd))]
 


### PR DESCRIPTION
Solution: Quotes added to python script string.
          Also removed special handling for localhost.