### PR TITLE
Problem: asserts in cfgen/dhall/ are disabled

### DIFF
--- a/cfgen/dhall/render/Named.dhall
+++ b/cfgen/dhall/render/Named.dhall
@@ -6,10 +6,7 @@ let renderNamed
  ->
     "${name}=${f x}"
 
--- -- XXX-UNCOMMENTME dhall 1.25.0 doesn't support equivalence operator (≡) yet.
--- -- https://github.com/dhall-lang/dhall-lang/tree/master/standard#equivalence
---
--- let example =
---     assert : renderNamed Natural Natural/show "answer" 42 ≡ "answer=42"
+let example =
+    assert : renderNamed Natural Natural/show "answer" 42 === "answer=42"
 
 in renderNamed

--- a/cfgen/dhall/render/NamedList.dhall
+++ b/cfgen/dhall/render/NamedList.dhall
@@ -6,10 +6,8 @@ let renderNamedList
  ->
     "${name}=" ++ ./List.dhall a f xs
 
--- -- XXX-UNCOMMENTME dhall 1.25.0 doesn't support equivalence operator (≡) yet.
--- -- https://github.com/dhall-lang/dhall-lang/tree/master/standard#equivalence
--- let example =
---     assert : renderNamedList Natural Natural/show "bits" [ 0, 1 ] ≡
---         "bits=[0, 1]"
+let example =
+    assert : renderNamedList Natural Natural/show "bits" [ 0, 1 ] ===
+        "bits=[0, 1]"
 
 in renderNamedList


### PR DESCRIPTION
Solution: uncomment `assert` expressions in cfgen/dhall/ files.

Closes #226.