### PR TITLE
Problem: update-consul-env to update optional params

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -40,7 +40,9 @@ read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
     exit 1
 }
 
-$SRC_DIR/update-consul-env server $join_ip '' # join_ip is our bind_ip
+# $join_ip is our bind_ip address
+$SRC_DIR/update-consul-env --mode server --bind $join_ip \
+                           --extra-options '-ui -bootstrap-expect 1'
 sudo systemctl start consul-agent
 
 # Give Consul some time for its internal bootstrap and leader
@@ -52,13 +54,15 @@ jq '[.[] | {key, value: (.value | @base64)}]' < /tmp/consul-kv.json |
 
 # Our agent is ready, start all the reset server agents.
 get_server_nodes | { grep -vw $HOSTNAME || true; } | while read node bind_ip; do
-    ssh $node "$SRC_DIR/update-consul-env server $bind_ip $join_ip &&
-                   sudo systemctl start consul-agent"
+    ssh $node "$SRC_DIR/update-consul-env --mode server --bind $bind_ip \
+                                          --join $join_ip &&
+               sudo systemctl start consul-agent"
 done
 
 # Start client agents.
 get_client_nodes | while read node bind_ip; do
-    ssh $node "$SRC_DIR/update-consul-env client $bind_ip $join_ip &&
+    ssh $node "$SRC_DIR/update-consul-env --mode client --bind $bind_ip \
+                                          --join $join_ip &&
                    sudo systemctl start consul-agent"
 done
 

--- a/consul-server-conf.json
+++ b/consul-server-conf.json
@@ -1,6 +1,5 @@
 {
   "server": true,
-  "bootstrap_expect": 1,
   "watches": [
     {
       "type": "key",

--- a/systemd/consul
+++ b/systemd/consul
@@ -3,4 +3,4 @@ set -eu -o pipefail
 
 exec consul agent -bind $BIND -client "$CLIENT" $JOIN \
      -config-file=/opt/seagate/consul/consul-$MODE-conf.json \
-     -data-dir=/tmp/consul $OPTS
+     -data-dir=/tmp/consul $EXTRA_OPTS

--- a/systemd/consul-env
+++ b/systemd/consul-env
@@ -4,4 +4,4 @@ BIND={{GetPrivateIP}}
 CLIENT=127.0.0.1 {{GetPrivateIP}}
 # optional:
 JOIN=
-OPTS=-ui
+EXTRA_OPTS=

--- a/update-consul-env
+++ b/update-consul-env
@@ -1,25 +1,58 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+PROG_NAME=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
 ENV_FILE=$SRC_DIR/systemd/consul-env
 
 usage() {
-    echo "Usage: ${0##*/} <client|server> <bind_address> <join_address>"
-    echo
-    echo "Updates Consul agent startup parameters at $ENV_FILE."
+    >&2 cat <<EOF
+Usage: ${0##*/} -m|--mode <client|server> -b|--bind <IP>
+                [-j|--join <IP>] [-e|--extra-options <string>]"
+
+Updates Consul agent startup parameters at $ENV_FILE.
+EOF
     exit 1
 }
 
-(( $# < 3 )) && usage
+mode=
+bind_addr=
+join_addr=
+extra_opts=
+
+TEMP=$(getopt --options hm:b:j:e: \
+              --longoptions help,mode:,bind:,join:,extra-options: \
+              --name "$PROG_NAME" -- "$@" || true)
+
+[[ $? -ne 0 ]] && usage
+
+eval set -- "$TEMP"
+
+while true ; do
+    case "$1" in
+        -h|--help)           usage ;;
+        -m|--mode)           mode=$2; shift 2 ;;
+        -b|--bind)           bind_addr=$2; shift 2 ;;
+        -j|--join)           join_addr=$2; shift 2 ;;
+        -e|--extra-options)  extra_opts=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   echo 'getopt: internal error...'; exit 1 ;;
+    esac
+done
+
+[[ -n $mode && -n $bind_addr ]] || usage
 
 sudo rm -rf /tmp/consul
 
-mode=$1
-bind_addr=$2
-join_addr=$3
-
 sed -r -e "s/^(MODE).*/\1=$mode/" \
        -e "s/^(BIND).*/\1=$bind_addr/" \
-       -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" \
-       -e "s/^(JOIN).*/\1=${join_addr:+-retry-join $join_addr}/" -i $ENV_FILE
+       -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" -i $ENV_FILE
+
+if [[ -n $join_addr ]]; then
+    sed -r -e "s/^(JOIN).*/\1=${join_addr:+-retry-join $join_addr}/" \
+        -i $ENV_FILE
+fi
+
+if [[ -n $extra_opts ]]; then
+    sed -r "s/^(EXTRA_OPTS).*/\1=$extra_opts/" -i $ENV_FILE
+fi


### PR DESCRIPTION
update-consul-env script should be able to update optional
consul agent startup parameters (like `-bootstrap-expect 1`
which should be used on one of the cluster nodes only).

Solution: add such support.