### PR TITLE
Problem: `bootstrap` is not tested by CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,8 @@ test-bootstrap:
       cat >hare/_test-bootstrap.sh <<'EOF'
       set -eu -o pipefail
 
-      sudo yum install -y python36 python36-devel python36-PyYAML
+      sudo yum install -y python36 python36-devel python36-PyYAML python36-pip
+      sudo pip3 install ply
 
       download=https://github.com/dhall-lang/dhall-haskell/releases/download
       for f in $download/1.26.0/dhall-1.26.0-x86_64-linux.tar.bz2 \
@@ -170,9 +171,17 @@ test-bootstrap:
       unzip -x consul_1.6.1_linux_amd64.zip
       sudo mv consul /usr/local/bin/
 
+      cd /data/mero
+      sudo ./utils/m0setup  # create loop devices
+
       cd /data/hare/
-      ./install
-      # ./bootstrap  # XXX-UNCOMMENTME
+      bash -x ./install
+
+      # XXX `systemctl start hax` command, called by `bootstrap-node` script,
+      # will fail unless `mero-kernel` systemd service is installed.
+      sudo /data/mero/scripts/install-mero-service
+
+      bash -x ./bootstrap cfgen/_misc/singlenode.yaml
       EOF
     - time $M0VG run 'bash -x /data/hare/_test-bootstrap.sh'
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
+# set -x
+export PS4='+ [${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}] '
 
 # Helper script to bootstrap the cluster.
 
@@ -36,7 +38,7 @@ get_client_nodes() {
 read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
 
 [[ $join_ip ]] || {
-    echo 'Bootstrap should be run from the server node only.'
+    echo 'Bootstrap should be run from the server node only' >&2
     exit 1
 }
 
@@ -80,3 +82,5 @@ sleep 5
 get_client_nodes | while read node _; do
     ssh $node $SRC_DIR/bootstrap-node &
 done
+
+wait

--- a/bootstrap-node
+++ b/bootstrap-node
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
+# set -x
+export PS4='+ [${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}] '
 
 # Helper script to continue bootstrap the node after
 # the Consul agent is started already.
@@ -7,10 +9,12 @@ set -eu -o pipefail
 SRC_DIR="$(dirname $(readlink -f $0))"
 prog=${0##*/}
 
-err() {
+die() {
     >&2 echo "$prog: $HOSTNAME: $*"
     exit 1
 }
+
+sudo systemctl status mero-kernel || die 'No `mero-kernel` systemd service'
 
 . $SRC_DIR/update-consul-conf
 
@@ -19,9 +23,8 @@ if [[ -n $CONFD_IDs || -n $IOS_IDs ]]; then
 fi
 
 if [[ -n $CONFD_IDs ]]; then
-    [[ -f /tmp/confd.xc ]] || {
-        err "Can not bootstrap server node without confd.xc file."
-    }
+    [[ -f /tmp/confd.xc ]] ||
+        die 'Cannot bootstrap server node without confd.xc file'
     sudo mv /tmp/confd.xc /etc/mero/
 fi
 

--- a/install
+++ b/install
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
+# set -x
+export PS4='+ [${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}] '
 
 # Install Hare software on the local node.
 


### PR DESCRIPTION
Solution: extend "test-bootstrap" job definition in `.gitlab-ci.yml` file
to run `bootstrap` script.

Closes #128.