### PR TITLE
Problem: ios-m0mkfs gets stuck sometimes

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -14,7 +14,7 @@ usage() {
     exit 1
 }
 
-(( $# != 1 )) && usage
+(( $# == 1 )) || usage
 
 cluster_descr=$1
 
@@ -68,19 +68,25 @@ get_client_nodes | while read node bind_ip; do
                    sudo systemctl start consul-agent"
 done
 
-# Start Mero.
-$SRC_DIR/bootstrap-node &
+# Start Mero in two phases: 1st confd-s, then ios-es.
+$SRC_DIR/bootstrap-node phase1 &
 
 get_server_nodes | { grep -vw $HOSTNAME || true; } | while read node _; do
     scp $cfgen_out/confd.xc $node:/tmp/
-    ssh $node $SRC_DIR/bootstrap-node &
+    ssh $node $SRC_DIR/bootstrap-node phase1 &
 done
 
-# Give some time for confd processes to start up.
-sleep 5
+wait
+
+# Now the 2nd phase (ios-es).
+$SRC_DIR/bootstrap-node phase2 &
+
+get_server_nodes | { grep -vw $HOSTNAME || true; } | while read node _; do
+    ssh $node $SRC_DIR/bootstrap-node phase2 &
+done
 
 get_client_nodes | while read node _; do
-    ssh $node $SRC_DIR/bootstrap-node &
+    ssh $node $SRC_DIR/bootstrap-node phase2 &
 done
 
 wait

--- a/bootstrap-node
+++ b/bootstrap-node
@@ -3,11 +3,26 @@ set -eu -o pipefail
 # set -x
 export PS4='+ [${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}] '
 
-# Helper script to continue bootstrap the node after
-# the Consul agent is started already.
-
 SRC_DIR="$(dirname $(readlink -f $0))"
 prog=${0##*/}
+
+usage() {
+    >&2 cat <<EOF
+Usage: $prog <phase1|phase2)>
+
+Bootstraps single node after consul agent is started.
+
+  phase1 - starts up confd Mero process(es).
+  phase2 - starts up ios Mero process(es).
+EOF
+    exit 1
+}
+
+(($# == 1)) || usage
+
+phase=$1
+
+[[ $phase =~ phase[12] ]] || usage
 
 die() {
     >&2 echo "$prog: $HOSTNAME: $*"
@@ -16,19 +31,37 @@ die() {
 
 sudo systemctl status mero-kernel || die 'No `mero-kernel` systemd service'
 
-. $SRC_DIR/update-consul-conf
+# If it is a server node - we don't need to update the configuration
+# twice on both phases. But if it is a client node - we should update
+# the configuration on phase2. (There is no phase1 on client nodes -
+# they don't run confd).
+if [[ $phase == phase1 ]]; then
+    . $SRC_DIR/update-consul-conf
+else
+    . $SRC_DIR/update-consul-conf -n # Don't update, just set vars.
+    if [[ -z $CONFD_IDs ]]; then
+        . $SRC_DIR/update-consul-conf # Client node, update.
+    fi
+fi
 
 if [[ -n $CONFD_IDs || -n $IOS_IDs ]]; then
     sudo systemctl start hax
 fi
 
-if [[ -n $CONFD_IDs ]]; then
-    [[ -f /tmp/confd.xc ]] ||
-        die 'Cannot bootstrap server node without confd.xc file'
+if [[ -n $CONFD_IDs && $phase == phase1 ]]; then
+    [[ -f /tmp/confd.xc ]] || {
+        die "Can not bootstrap server node without confd.xc file."
+    }
     sudo mv /tmp/confd.xc /etc/mero/
 fi
 
-for id in $CONFD_IDs $IOS_IDs; do
+if [[ $phase == phase1 ]]; then
+    IDs=$CONFD_IDs
+else
+    IDs=$IOS_IDs
+fi
+
+for id in $IDs; do
     fid=$(id2fid $id)
     sudo systemctl start mero-mkfs@$fid
     sudo systemctl start m0d@$fid

--- a/cfgen/_misc/two-nodes.yaml
+++ b/cfgen/_misc/two-nodes.yaml
@@ -9,7 +9,6 @@ hosts:
   - name: sage75c1
     data_iface: ens33
     m0_servers:
-      - runs_confd: true
       - io_disks: { path_glob: "/dev/loop[0-9]*" }
     c0_clients: 2
     m0t1fs_clients: 0

--- a/update-consul-conf
+++ b/update-consul-conf
@@ -3,6 +3,17 @@ set -eu -o pipefail
 
 SRC_DIR="$(dirname $(readlink -f $0))"
 
+usage() {
+    >&2 cat <<EOF
+Usage: . ${0##*/} [-n]
+
+Updates consul agent configuration file with the services from KV Store.
+
+  -n Dry run. Do not update anything. (Useful to export some functions
+     and variables, like IOS_IDs, when run as a sourced script.)
+EOF
+}
+
 get_service_ids() {
     local filter=$1
     local cmd="consul kv get -recurse node/$HOSTNAME/service/ \
@@ -31,6 +42,12 @@ HAX_ID=$(get_service_ids 'grep -i ha')
 CONFD_IDs=$(get_service_ids 'grep -i confd')
 IOS_IDs=$(get_service_ids 'grep -i ios | grep -iv confd')
 HAX_EP=$(get_service_ep $HAX_ID)
+
+# -n option has meaning only when this script is sourced,
+# so we `return` here (not `exit`).
+if (( $# == 1 )) && [[ $1 == '-n' ]]; then
+    return 0
+fi
 
 if [[ $CONFD_IDs ]]; then
     CONF_FILE=$SRC_DIR/consul-server-conf.json


### PR DESCRIPTION
ios-m0mkfs may get stuck sometimes. The problem is that
it tries to connect to confd which is not started yet.
So it connects to confd's m0mkfs and then uses the same
connection when confd process is started already. And,
of course, the latter has no idea about such a connection
and just silently drops the packets...

Solution: implement bootstrap in two phases: 1st phase
starts up confd processes, 2nd phase - ios-es.

Closes issue #246.