### PR TITLE
Problem: non-optimal waiting for the RC Leader on bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -64,9 +64,20 @@ jq '[.[] | {key, value: (.value | @base64)}]' < /tmp/consul-kv.json |
     consul kv import - > /dev/null
 echo 'Ok.'
 
+say 'Starting all the rest Consul server agents... '
+while read node bind_ip; do
+    ssh $node "$SRC_DIR/update-consul-env --mode server --bind $bind_ip \
+                                          --join $join_ip &&
+               sudo systemctl start consul-agent"
+done < <(get_server_nodes | grep -vw $HOSTNAME || true)
+echo 'Ok.'
+
 say 'Waiting for the RC Leader to be elected...'
+get_session() {
+    consul kv get -detailed leader | awk '/Session/ {print $2}'
+}
 count=1
-while ! pgrep -af 'consul.*watch.*prefix eq' > /dev/null; do
+while [[ $(get_session) == '-' ]]; do
     if (( $count > 5 )); then
         consul kv put leader elect > /dev/null
         count=1
@@ -76,14 +87,6 @@ while ! pgrep -af 'consul.*watch.*prefix eq' > /dev/null; do
     ((count++))
 done
 echo ' Ok.'
-
-say 'Starting all the rest Consul server agents... '
-while read node bind_ip; do
-    ssh $node "$SRC_DIR/update-consul-env --mode server --bind $bind_ip \
-                                          --join $join_ip &&
-               sudo systemctl start consul-agent"
-done < <(get_server_nodes | grep -vw $HOSTNAME || true)
-echo 'Ok.'
 
 say 'Starting Consul client agents... '
 while read node bind_ip; do


### PR DESCRIPTION
We are waiting for the leader to be elected on the local node
and only after this we start all the rest server agents. But
the leader can be elected on any of the server nodes.

Solution: start all server nodes and then wait for the leader.

```
$ /usr/bin/time ./bootstrap cfgen/_misc/singlenode.yaml 
2019-09-26 19:55:43: Generating cluster configuration... Ok.
2019-09-26 19:55:44: Starting our Consul server agent... Ok.
2019-09-26 19:55:47: Importing configuration into the KV Store... Ok.
2019-09-26 19:55:54: Starting all the rest Consul server agents... Ok.
2019-09-26 19:55:54: Waiting for the RC Leader to be elected....... Ok.
2019-09-26 19:55:58: Starting Consul client agents... Ok.
2019-09-26 19:55:58: Starting Mero (phase1)... Ok.
2019-09-26 19:56:00: Starting Mero (phase2)... Ok.
2.46user 0.69system 0:20.12elapsed 15%CPU (0avgtext+0avgdata 115216maxresident)k
0inputs+120outputs (0major+219690minor)pagefaults 0swaps
```