### PR TITLE
Problem: services status is not checked after bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -133,3 +133,15 @@ for pid in ${pids[@]}; do
     wait $pid
 done
 echo 'Ok.'
+
+say 'Checking the health of the services... '
+sleep 5 # Give Consul some time to pick up the statuses
+for svc in confd ios; do
+    curl -s http://127.0.0.1:8500/v1/health/service/$svc |
+        jq -r '.[] | "\(.Node.Node) \([.Checks[].Status]|unique)"' |
+        fgrep -v '["passing"]' && {
+            echo "Check '$svc' service on the node(s) listed above."
+            exit 1
+        } || true
+done
+echo 'Ok.'

--- a/update-consul-conf
+++ b/update-consul-conf
@@ -71,7 +71,7 @@ append_hax_svc() {
       \"checks\": [
           {
             \"args\": [ \"/opt/seagate/consul/check-service\", \"--hax\" ],
-            \"interval\": \"10s\",
+            \"interval\": \"1s\",
             \"status\": \"warning\"
           }
         ]
@@ -93,7 +93,7 @@ append_confd_svc() {
           {
             \"args\": [ \"/opt/seagate/consul/check-service\",
                         \"--fid\", \"$fid\" ],
-            \"interval\": \"10s\",
+            \"interval\": \"1s\",
             \"status\": \"warning\"
           }
         ]
@@ -121,7 +121,7 @@ append_ios_svc() {
           {
             \"args\": [ \"/opt/seagate/consul/check-service\",
                         \"--fid\", \"$fid\" ],
-            \"interval\": \"10s\",
+            \"interval\": \"1s\",
             \"status\": \"warning\"
           }
         ]


### PR DESCRIPTION
It might be quite handy to check the services statuses at the end of the bootstrap process.

Solution: add the check into the `bootstrap` script.

```
$ ./bootstrap cfgen/_misc/two-nodes.yaml 
2019-09-27 18:03:25: Generating cluster configuration... Ok.
2019-09-27 18:03:27: Starting our Consul server agent... Ok.
2019-09-27 18:03:30: Importing configuration into the KV Store... Ok.
2019-09-27 18:03:35: Starting all the rest Consul server agents... Ok.
2019-09-27 18:03:35: Waiting for the RC Leader to be elected............. Ok.
2019-09-27 18:03:45: Starting Consul client agents... Ok.
2019-09-27 18:03:46: Starting Mero (phase1)... Ok.
2019-09-27 18:03:48: Starting Mero (phase2)... Ok.
2019-09-27 18:03:53: Checking the health of Mero services... Ok.
```