### PR TITLE
Problem: non-optimal wating for the RC Leader on bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -72,6 +72,14 @@ while read node bind_ip; do
 done < <(get_server_nodes | grep -vw $HOSTNAME || true)
 echo 'Ok.'
 
+say 'Starting Consul client agents... '
+while read node bind_ip; do
+    ssh $node "$SRC_DIR/update-consul-env --mode client --bind $bind_ip \
+                                          --join $join_ip &&
+                   sudo systemctl start consul-agent"
+done < <(get_client_nodes)
+echo 'Ok.'
+
 say 'Waiting for the RC Leader to be elected...'
 get_session() {
     consul kv get -detailed leader | awk '/Session/ {print $2}'
@@ -87,14 +95,6 @@ while [[ $(get_session) == '-' ]]; do
     ((count++))
 done
 echo ' Ok.'
-
-say 'Starting Consul client agents... '
-while read node bind_ip; do
-    ssh $node "$SRC_DIR/update-consul-env --mode client --bind $bind_ip \
-                                          --join $join_ip &&
-                   sudo systemctl start consul-agent"
-done < <(get_client_nodes)
-echo 'Ok.'
 
 # Start Mero in two phases: 1st confd-s, then ios-es.
 say 'Starting Mero (phase1)... '


### PR DESCRIPTION
We are waiting for the RC Leader before starting Consul client
agents. But the leader is not needed for them, it needed only
before we start Mero services (with `bootstrap-node` script).

Solution: wait for the leader later, after Consul client agents
already, but before starting Mero.

```
$ ./bootstrap cfgen/_misc/singlenode.yaml 
2019-09-27 22:53:15: Generating cluster configuration... Ok.
2019-09-27 22:53:20: Starting our Consul server agent... Ok.
2019-09-27 22:53:23: Importing configuration into the KV Store... Ok.
2019-09-27 22:53:26: Starting all the rest Consul server agents... Ok.
2019-09-27 22:53:26: Starting Consul client agents... Ok.
2019-09-27 22:53:26: Waiting for the RC Leader to be elected..... Ok.
2019-09-27 22:53:29: Starting Mero (phase1)... Ok.
2019-09-27 22:53:39: Starting Mero (phase2)... Ok.
2019-09-27 22:53:45: Checking the health of the services... Ok.
```