### PR TITLE
Problem: RC Leader election may get stuck on bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -87,7 +87,7 @@ get_session() {
 count=1
 while [[ $(get_session) == '-' ]]; do
     if (( $count > 5 )); then
-        consul kv put leader elect > /dev/null
+        consul kv put leader elect$RANDOM > /dev/null
         count=1
     fi
     sleep 1


### PR DESCRIPTION
The RC Leader election may get stuck on bootstrap when something
is wrong. It's because when we change the value of the `leader`
key in the loop we put the same value (`elect`). But the election
watch won't be triggered of the value is not changed.

Solution: put different value into the `leader` key on each loop
iteration.