### PR TITLE
Problem: `cfgen` is using old version of Dhall

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,8 +108,8 @@ test-cfgen:
       pip3 install flake8 mypy
 
       download=https://github.com/dhall-lang/dhall-haskell/releases/download
-      for f in $download/1.26.0/dhall-1.26.0-x86_64-linux.tar.bz2 \
-               $download/1.26.0/dhall-json-1.4.1-x86_64-linux.tar.bz2; do
+      for f in $download/1.26.1/dhall-1.26.1-x86_64-linux.tar.bz2 \
+               $download/1.26.1/dhall-json-1.4.1-x86_64-linux.tar.bz2; do
           curl -LO $f
           tar -C /usr/local/ -xf ${f##*/}
       done
@@ -167,8 +167,8 @@ test-bootstrap:
       sudo pip3 install ply
 
       download=https://github.com/dhall-lang/dhall-haskell/releases/download
-      for f in $download/1.26.0/dhall-1.26.0-x86_64-linux.tar.bz2 \
-               $download/1.26.0/dhall-json-1.4.1-x86_64-linux.tar.bz2; do
+      for f in $download/1.26.1/dhall-1.26.1-x86_64-linux.tar.bz2 \
+               $download/1.26.1/dhall-json-1.4.1-x86_64-linux.tar.bz2; do
           curl -LO $f
           sudo tar -C /usr/local/ -xf ${f##*/}
       done

--- a/cfgen/dhall/Prelude.dhall
+++ b/cfgen/dhall/Prelude.dhall
@@ -21,5 +21,5 @@
 -}
 
   env:DHALL_PRELUDE
-? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v9.0.0/Prelude/package.dhall sha256:2acd9f8eae045eae46d8288d76b01678c4ac4883a58eadb6be0da00b3ba590cf
-? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v9.0.0/Prelude/package.dhall
+? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v10.0.0/Prelude/package.dhall sha256:771c7131fc87e13eb18f770a27c59f9418879f7e230ba2a50e46f4461f43ec69
+? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v10.0.0/Prelude/package.dhall


### PR DESCRIPTION
Solution: upgrade Dhall executables and standard library (the Prelude).