### PR TITLE
Problem: noise from scp during bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -104,7 +104,7 @@ $SRC_DIR/bootstrap-node phase1 &
 pids=($!)
 
 while read node _; do
-    scp $cfgen_out/confd.xc $node:/tmp/
+    scp -q $cfgen_out/confd.xc $node:/tmp/
     ssh $node $SRC_DIR/bootstrap-node phase1 &
     pids+=($!)
 done < <(get_server_nodes | grep -vw $HOSTNAME || true)


### PR DESCRIPTION
During the bootstrap on several server nodes there is odd
noise from scp when it copies confd.xc.

Solution: use scp -q (quiet) option.