### PR TITLE
Add scripts for a development docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   GIT_DEPTH: 1  # clone only the current commit
   GIT_STRATEGY: clone  # make a fresh `git clone` of the repo for every new CI job
   GIT_SUBMODULE_STRATEGY: normal  # init and check out submodules
-  CENTOS_RELEASE: '7.5'
+  CENTOS_RELEASE: eos
   DOCKER_REGISTRY: registry.gitlab.mero.colo.seagate.com
   M0_VG_NO_SYMLINKS: "true"
   WORKSPACE_NAME: "${CI_PROJECT_NAME}${CI_PIPELINE_ID}"
@@ -43,7 +43,7 @@ build:
     - cd ${WORKSPACE_DIR}
 
     # make sure that build image is up to date
-    - docker pull $DOCKER_REGISTRY/mero/mero:$CENTOS_RELEASE
+    - docker pull $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE
 
     # Get fresh Mero copy.
     - git clone --recursive --depth 1 --shallow-submodules http://gitlab.mero.colo.seagate.com/mero/mero.git
@@ -61,7 +61,7 @@ build:
       EOF
     - time docker run --rm --name ${JOB_NAME}
                       -v ~+:/data -w /data/mero
-                  $DOCKER_REGISTRY/mero/mero:$CENTOS_RELEASE
+                  $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE
                       bash -x _build-m0.sh
 
     # Build hax's C extension.
@@ -69,20 +69,13 @@ build:
       cat >hare/_build-hax.sh <<'EOF'
       set -eu -o pipefail
 
-      yum install -y python36 python36-devel python36-pip
-
-      env_dir=.env
-      python3 -m venv $env_dir
-      . $env_dir/bin/activate
-
       cd hax
-      pip3 install wheel flake8 mypy
       python3 setup.py flake8 mypy  # sanity check
       python3 setup.py bdist_wheel
       EOF
     - time docker run --rm --name ${JOB_NAME}
                       -v ~+:/data -w /data/hare
-                  $DOCKER_REGISTRY/mero/mero:$CENTOS_RELEASE
+                  $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE
                       bash -x _build-hax.sh
 
     # containers run commands as 'root' user, seize ownership back
@@ -99,28 +92,10 @@ test-cfgen:
     - export JOB_NAME="${WORKSPACE_NAME}-${CI_JOB_NAME}"
 
     - cd ${WORKSPACE_DIR}
-
-    - |
-      cat >hare/_test-cfgen.sh <<'EOF'
-      set -eu -o pipefail
-
-      yum install -y python36 python36-pip python36-PyYAML
-      pip3 install flake8 mypy
-
-      download=https://github.com/dhall-lang/dhall-haskell/releases/download
-      for f in $download/1.26.1/dhall-1.26.1-x86_64-linux.tar.bz2 \
-               $download/1.26.1/dhall-json-1.4.1-x86_64-linux.tar.bz2; do
-          curl -LO $f
-          tar -C /usr/local/ -xf ${f##*/}
-      done
-
-      make -C cfgen
-      EOF
-
     - time docker run --rm --name ${JOB_NAME}
                       -v ~+:/data -w /data/hare
-                  $DOCKER_REGISTRY/mero/mero:$CENTOS_RELEASE
-                      bash -x _test-cfgen.sh
+                  $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE
+                      make -C cfgen
 
 test-bootstrap:
   stage: test

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,64 @@
+CENTOS_RELEASE  := latest
+NAMESPACE       := registry.gitlab.mero.colo.seagate.com
+DOCKER          := docker
+
+INAME = $(@:%-image=%)
+CNAME = $(@:%-container=%)
+
+.PHONY: images
+images: docker-image-latest \
+        docker-image-7.6 \
+        docker-image-eos
+
+.PHONY: docker-image-latest
+docker-image-latest: hare-devel-image
+
+.PHONY: docker-image-7.6
+docker-image-7.6: CENTOS_RELEASE := 7.6
+docker-image-7.6: override DOCKER_OPTS += --build-arg CENTOS_RELEASE=$(CENTOS_RELEASE)
+docker-image-7.6: hare-devel-image
+
+.PHONY: docker-image-eos
+docker-image-eos: CENTOS_RELEASE := eos
+docker-image-eos: override DOCKER_OPTS += --build-arg CENTOS_RELEASE=$(CENTOS_RELEASE)
+docker-image-eos: hare-devel-image
+
+
+.PHONY: hare-devel-image
+hare-devel-image:
+	cd $(INAME) \
+	&& tar -ch . \
+	   | $(DOCKER) build \
+			-t $(NAMESPACE)/$(INAME):$(CENTOS_RELEASE) \
+			-t $(NAMESPACE)/mero/hare:$(CENTOS_RELEASE) \
+			$(DOCKER_OPTS) -
+
+.PHONY: push
+name := hare*
+tag  := *
+push:
+	@for img in $$(docker images --filter=reference='$(NAMESPACE)/$(name):$(tag)' \
+				    --format '{{.Repository}}:{{.Tag}}' | grep -v none) \
+		    $$(docker images --filter=reference='$(NAMESPACE)/mero/$(name):$(tag)' \
+				    --format '{{.Repository}}:{{.Tag}}' | grep -v none) ; \
+	do \
+		echo "---> $$img" ; \
+		$(DOCKER) push $$img ; \
+	done
+
+.PHONY: clean
+clean:
+	@for img in $$(docker images --filter=reference='$(NAMESPACE)/$(name):$(tag)' \
+				    --format '{{.Repository}}:{{.Tag}}') \
+		    $$(docker images --filter=reference='$(NAMESPACE)/mero/$(name):$(tag)' \
+				    --format '{{.Repository}}:{{.Tag}}') ; \
+	do \
+		echo "---> $$img" ; \
+		$(DOCKER) rmi $$img ; \
+	done
+
+.PHONY: help
+help:
+	@echo '  images  - create docker images for CI environment'
+	@echo "  push    - upload local $(NAMESPACE)/$(name)* images to docker registry"
+	@echo "  clean   - remove local $(NAMESPACE)/$(name)* images"

--- a/docker/hare-devel/Dockerfile
+++ b/docker/hare-devel/Dockerfile
@@ -1,0 +1,24 @@
+ARG  CENTOS_RELEASE=latest
+FROM registry.gitlab.mero.colo.seagate.com/mero/mero:${CENTOS_RELEASE}
+
+ENV HARE_VENV_DIR=$HOME/.hare-venv
+
+RUN yum install -y python36 python36-devel python36-pip python36-PyYAML
+RUN mkdir $HARE_VENV_DIR \
+    && python3 -m venv $HARE_VENV_DIR
+
+# PyYAML - for cfgen
+# flake8 - for hax
+# mypy   - for hax
+# ply    - for Mero
+# wheel  - for hax
+RUN source $HARE_VENV_DIR/bin/activate \
+    && pip3 install PyYAML flake8 mypy ply wheel
+
+ADD https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-1.26.1-x86_64-linux.tar.bz2      /var/cache
+ADD https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-json-1.4.1-x86_64-linux.tar.bz2  /var/cache
+RUN for f in /var/cache/dhall*.tar*; do tar -C /usr/local -xf $f; done
+
+COPY docker-entrypoint /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint"]

--- a/docker/hare-devel/docker-entrypoint
+++ b/docker/hare-devel/docker-entrypoint
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu -o pipefail
+
+source $HARE_VENV_DIR/bin/activate
+exec "${@:-bash}"


### PR DESCRIPTION
Hare development image for Docker can be built using scripts from
'docker/' dir:

  ```bash
  $ make -C docker/ help
  images  - create docker images for CI environment
  push    - upload local registry.gitlab.mero.colo.seagate.com/hare* images to docker registry
  clean   - remove local registry.gitlab.mero.colo.seagate.com/hare* images
  ```

The image contains all the necessary dependencies, required for Hare
development, including Mero build dependencies.