### PR TITLE
Problem: Profile fid and process fid are not easily obtainable

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1108,6 +1108,15 @@ def generate_consul_agents(cluster: Cluster) -> str:
         indent=2) + '\n'
 
 
+def fid2str(id: Oid) -> str:
+    types = {ObjT.root: 't', ObjT.fdmi_flt_grp: 'g', ObjT.fdmi_filter: 'l',
+             ObjT.node: 'n', ObjT.process: 'r', ObjT.service: 's',
+             ObjT.sdev: 'd', ObjT.pool: 'o', ObjT.pver: 'v', ObjT.objv: 'j',
+             ObjT.site: 'S', ObjT.rack: 'a', ObjT.enclosure: 'e',
+             ObjT.controller: 'c', ObjT.drive: 'k', ObjT.profile: 'p'}
+    return f'{hex((ord(types[id.type]) << 56)+1)}:{hex(id.fidk)}'
+
+
 def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
     assert os.path.isabs(dhall_dir)
 
@@ -1118,6 +1127,20 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
 
     ConsulService = NamedTuple('ConsulService', [
         ('node_name', str), ('proc_id', Oid), ('svc_types', str), ('ep', str)])
+
+    def profile() -> str:
+        for profile_id, profile in m0conf.items():
+            if profile_id.type is ObjT.profile:
+                return fid2str(profile_id)
+        return ''
+
+    def sns_pools() -> List[Oid]:
+        for root_id, root in m0conf.items():
+            if root_id.type is ObjT.root:
+                return [x for x in root.pools
+                        if x is not root.mdpool and
+                        root.imeta_pver not in m0conf[x].pvers]
+        return []
 
     def services() -> Iterator[ConsulService]:
         for node_id, node in m0conf.items():
@@ -1137,6 +1160,8 @@ def generate_consul_kv(m0conf: Dict[Oid, Any], dhall_dir: str) -> str:
         ('leader', ''),
         ('epoch', 1),
         ('last_fidk', _fidk_gen),
+        ('profile', profile()),
+        *[(f'profile/pool/{x.fidk}', f'{fid2str(x)}') for x in sns_pools()],
         *[(f'node/{x.node_name}/service/{x.proc_id.fidk}/types',
            f'{x.svc_types}') for x in services()],
         *[(f'node/{x.node_name}/service/{x.proc_id.fidk}/ep', f'{x.ep}')

--- a/cluster-status
+++ b/cluster-status
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import consul
+from typing import List, NamedTuple
+from socket import gethostname
+import os
+
+
+__all__ = ['main']
+
+Process = NamedTuple('Process', [('name', str), ('fid', str),
+                                 ('ep', str)])
+
+
+def processfid2str(fidk: int) -> str:
+    process_type = 'r'
+    return f'{hex((ord(process_type) << 56)+1)}:{hex(fidk)}'
+
+
+def get_kv(c: consul, key: str) -> str:
+    kv = c.kv.get(key)[1]
+    return kv['Value'].decode()
+
+
+def leader_tag(c: consul, host: str) -> str:
+    return ' (RC)' if get_kv(c, 'leader') == host else ''
+
+
+def profile(c: consul) -> str:
+    return get_kv(c, 'profile')
+
+
+def sns_pools(c: consul) -> [str]:
+    def fid_get(t: tuple) -> str:
+        keys = t['Key'].split("/")
+        return get_kv(c, f'profile/pool/{keys[2]}')
+
+    return map(fid_get, c.kv.get('profile/pool', recurse=True)[1])
+
+
+def hosts(c: consul) -> List:
+    data = c.kv.get('node', recurse=True)[1]
+    host_names = set([(x['Key'].split("/"))[1] for x in data])
+
+    return host_names
+
+
+def svc2name(types: str) -> str:
+    if 'ios' in types.split(" "):
+        return 'ioservice'
+    elif 'ha' in types.split(" "):
+        return 'hax'
+    elif 'confd' in types.split(" "):
+        return 'confd'
+    else:
+        return 'c0_client'
+
+
+def processes(c: consul, host: str) -> List:
+    data = c.kv.get(f'node/{host}/service', recurse=True)[1]
+    fidk_list = list(set([(x['Key'].split("/"))[3] for x in data]))
+    fidk_list.sort(key=int, reverse=False)
+
+    return [Process(name=svc2name(get_kv(c, f'node/{host}/service/{x}/types')),
+                    fid=processfid2str(int(x)),
+                    ep=get_kv(c, f'node/{host}/service/{x}/ep'))
+            for x in fidk_list]
+
+
+def is_localhost(hostname: str) -> bool:
+    name = gethostname()
+    return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
+
+
+def process_status(host: str, ps: Process) -> str:
+    cmd = f'sudo systemctl is-active --quiet'
+    cmd = f'{cmd} {ps.name}' if ps.name == 'hax' else f'{cmd} m0d@{ps.fid}'
+
+    if not is_localhost(host):
+        cmd = f'ssh {host} {cmd}'
+
+    return 'online' if os.system(cmd) == 0 else 'offline'
+
+
+def main():
+    c = consul.Consul()
+    cluster_status = '[FIXME]'
+    print(f'Cluster Status: {cluster_status}')
+    print(f'Data Pools:')
+    for x in sns_pools(c):
+        print(f'    {x}')
+    print(f'Profile : {profile(c)}')
+    print(f'Services:')
+    host_list = hosts(c)
+    for h in host_list:
+        print(f'    {h} {leader_tag(c, h)}')
+        process_list = processes(c, h)
+        for p in process_list:
+            print(f'    [{process_status(h, p):<10}] {p.name:<20}\
+ {p.fid:<30} {p.ep:<30}')
+
+
+if __name__ == '__main__':
+    main()

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -18,6 +18,8 @@ Key | Value | Description
 `eq/<epoch>` | event | `eq/*` items are collectively referred to as the EQ (Event Queue).  Events are consumed and dequeued by the RC script.
 `leader` | node name | This key is used for RC leader election.  Created with [`consul lock`](https://www.consul.io/docs/commands/lock.html) command.
 `last_fidk` | last genarated FID key | Atomically incremented counter that is used to generate fids.  Natural number.
+`profile` | profile FID of cluster.
+`profile/pool/<pool_fidk> | data pool FID
 `node/<node_name>/service/<process_fidk>/types` | Mero service types | Space-separated list of Mero service types running on the Mero process (Consul service) with fid key `<process_fidk>`.  Example: `rms confd`.
 `node/<node_name>/service/<process_fidk>/ep` | endpoint address | Endpoint address of the Mero process (Consul service) with fid key `<process_fidk>`.  Example: `192.168.180.162@tcp:12345:44:101`.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.


### PR DESCRIPTION
Closes #271 

Solution: Add `cluster-status` utility to display required information


Open questions:
1. How to check cluster status (consul status on all node ?)
2. Is it good if we can populate latest status of all process/services in kv
   and show with `cluster-status` ?