### PR TITLE
Problem (regression): multi-node bootstrap does not work

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -55,9 +55,6 @@ say 'Starting our Consul server agent... '
 $SRC_DIR/mk-consul-env --mode server --bind $join_ip \
                        --extra-options '-ui -bootstrap-expect 1'
 
-# `consul-agent` service won't start without this configuration file.
-cp $SRC_DIR/consul-server-conf.json.in $SRC_DIR/consul-server-conf.json
-
 sudo systemctl start consul-agent
 
 # Give Consul some time for its internal bootstrap and leader

--- a/bootstrap-node
+++ b/bootstrap-node
@@ -34,19 +34,19 @@ die() {
 sudo systemctl list-units 'mero-kernel*' > /dev/null ||
     die 'No `mero-kernel` systemd service'
 
-# If it is a server node, we don't need to create Consul configuration
+# If it is a server node, we don't need to update Consul configuration
 # two times (once for each phase).  If it is a client node, we should
-# create the configuration file on phase2. (There is no phase1 on client
+# update the configuration file on phase2. (There is no phase1 on client
 # nodes --- they don't run confd.)
 if [[ $phase == phase1 ]]; then
     # XXX We need to pass an empty string (actually, any argument) explicitly,
     # otherwise the sourced file will inherit the value of `$*` from current
     # script and its CLI arguments validation will fail.
-    . $SRC_DIR/mk-consul-conf ''
+    . $SRC_DIR/update-consul-conf ''
 else
-    . $SRC_DIR/mk-consul-conf -n  # do not update, only import variables
+    . $SRC_DIR/update-consul-conf -n  # do not update, only import variables
     if [[ -z $CONFD_IDs ]]; then
-        . $SRC_DIR/mk-consul-conf ''  # client node, update
+        . $SRC_DIR/update-consul-conf ''  # client node, update
     fi
 fi
 

--- a/mk-consul-env
+++ b/mk-consul-env
@@ -53,17 +53,19 @@ done
     exit 1
 }
 
-sudo rm -rf /tmp/consul
-
 sed -r -e "s/^(MODE).*/\1=$mode/" \
        -e "s/^(BIND).*/\1=$bind_addr/" \
        -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" $ENV_TEMPLATE >$ENV_FILE
 
 if [[ -n $join_addr ]]; then
     sed -r -e "s/^(JOIN).*/\1=${join_addr:+-retry-join $join_addr}/" \
-        $ENV_TEMPLATE >$ENV_FILE
+        -i $ENV_FILE
 fi
 
 if [[ -n $extra_opts ]]; then
-    sed -r "s/^(EXTRA_OPTS).*/\1=$extra_opts/" $ENV_TEMPLATE >$ENV_FILE
+    sed -r "s/^(EXTRA_OPTS).*/\1=$extra_opts/" -i $ENV_FILE
 fi
+
+# Prepare for consul-agent startup:
+sudo rm -rf /tmp/consul
+cp $SRC_DIR/consul-$mode-conf.json.in $SRC_DIR/consul-$mode-conf.json

--- a/update-consul-conf
+++ b/update-consul-conf
@@ -58,9 +58,9 @@ fi
 # --------------------------------------------------------------------
 
 if [[ $CONFD_IDs ]]; then
-    CONF_TEMPLATE=$SRC_DIR/consul-server-conf.json.in
+    CONF_FILE=$SRC_DIR/consul-server-conf.json
 else
-    CONF_TEMPLATE=$SRC_DIR/consul-client-conf.json.in
+    CONF_FILE=$SRC_DIR/consul-client-conf.json
 fi
 
 SVCS_CONF=''
@@ -152,6 +152,9 @@ for id in $IOS_IDs; do
     append_ios_svc $id
 done
 
-jq ".services = [$SVCS_CONF]" <$CONF_TEMPLATE >${CONF_TEMPLATE%.in}
+tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)
+trap "rm -f $tmpfile" EXIT # delete automatically on exit
+jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
+cat $tmpfile >$CONF_FILE
 
 consul reload > /dev/null


### PR DESCRIPTION
Multi-node bootstrap does not work anymore after commit 64350757.
There were few problems introduced:
 - consul configuration files are not created on the nodes;
 - bug in `mk-consul-env` script so that it does not set
   all the agent's startup parameters (because the `consul-env`
   file is getting overwritten several times).

Solution: fix the mentioned above issues by:
 - creating consul configuration file at `mk-consul-env`;
 - fixing the bug at `mk-consul-env` with parameters setting.