### PR TITLE
Problem: `install` script always builds hax

### DIFF
--- a/install
+++ b/install
@@ -9,16 +9,23 @@ SRC_DIR="$(dirname $(readlink -f $0))"
 M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
 
 init_hax() {
-    local env_dir=$SRC_DIR/.env
+    local rebuild_hax=$1
 
+    local env_dir=$SRC_DIR/.env
     python3 -m venv $env_dir
     . $env_dir/bin/activate
 
-    pushd $SRC_DIR/hax >/dev/null
-    pip3 install wheel flake8 mypy
-    python3 setup.py flake8 mypy bdist_wheel
-    pip3 install dist/hax-0.0.1-cp36-cp36m-linux_x86_64.whl
-    popd >/dev/null
+    cd $SRC_DIR/hax
+    local wheel_file=dist/hax-0.0.1-cp36-cp36m-linux_x86_64.whl
+    if ! [[ -f $wheel_file ]] || $rebuild_hax; then
+        pip3 install flake8 mypy
+        python3 setup.py flake8 mypy
+
+        pip3 install wheel
+        python3 setup.py bdist_wheel
+    fi
+    pip3 install $wheel_file
+    cd -
 }
 
 create_env_file() {
@@ -33,7 +40,36 @@ install_systemd() {
     sudo cp $SRC_DIR/systemd/*.service /usr/lib/systemd/system/
 }
 
-init_hax
+usage() {
+    cat <<EOF
+Usage: ${0##*/} [OPTION]
+
+Options:
+    --rebuild-hax    Build hax even if the wheel file exists
+    -h, --help       Show this help message and exit
+EOF
+}
+
+TEMP=$(getopt --options h --long rebuild-hax,help --name "${0##*/}" -- "$@")
+eval set -- "$TEMP"
+while true; do
+    case "$1" in
+        --rebuild-hax)
+            rebuild_hax=true;;
+        -h|--help)
+            usage
+            exit 0;;
+        --)
+            shift
+            break;;
+        *)
+            echo '**ERROR** getopt' >&2
+            exit 1;;
+    esac
+    shift
+done
+
+init_hax ${rebuild_hax:-false}
 create_env_file
 install_systemd
 


### PR DESCRIPTION
Solution: build hax only if wheel file is absent or `--rebuild-hax` option
is provided.

Closes #292.