### PR TITLE
Problem: README.md contains redundant information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ The scripts in this repository constitute a middleware layer between [Consul](ht
 
 ## Installation
 
-* Copy `consul` executable to a `$PATH` directory (e.g., `/usr/local/bin/`) on each node of the cluster.
-* Install Python dependencies:
-  ```sh
-  pip3 install -r hax/requirements.txt
-  ```
+* Copy `consul` executable to a `$PATH` directory (e.g.,
+  `/usr/local/bin/`) on each node of the cluster.
+
 * Ensure that Mero sources are built.
   ```sh
   $M0_SRC_DIR/scripts/m0 make


### PR DESCRIPTION
There is no need to install dependencies from `hax/requirements.txt`
explicitly, `install` script will take care of this.

Solution: remove redundant paragraph from README.md.