### PR TITLE
Problem: RC Leader session is not bound with Mero checks on bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -23,6 +23,48 @@ say() {
     echo -n "$(date '+%F %T'): $*"
 }
 
+get_server_nodes() {
+    jq -r '.servers[] | "\(.hostname) \(.ipaddr)"' $cfgen_out/consul-agents.json
+}
+
+get_client_nodes() {
+    jq -r '.clients[] | "\(.hostname) \(.ipaddr)"' $cfgen_out/consul-agents.json
+}
+
+get_all_nodes() {
+    jq -r '(.servers + .clients)[] | "\(.hostname) \(.ipaddr)"' \
+        $cfgen_out/consul-agents.json
+}
+
+get_session() {
+    consul kv get -detailed leader | awk '/Session/ {print $2}'
+}
+
+get_session_checks_nr() {
+    local sid=$1
+    curl -sX GET http://localhost:8500/v1/session/info/$sid |
+        jq -r '.[].Checks|length'
+}
+
+wait_rc_leader() {
+    local count=1
+    while [[ $(get_session) == '-' ]]; do
+        if (($count > 5)); then
+            consul kv put leader elect$RANDOM > /dev/null
+            count=1
+        fi
+        sleep 1
+        echo -n '.'
+        ((count++))
+    done
+}
+
+wait4() {
+    for pid in $*; do
+        wait $pid
+    done
+}
+
 say 'Generating cluster configuration... '
 cfgen_out=/tmp
 
@@ -33,14 +75,6 @@ sudo mkdir -p /etc/mero
 dhall text < $cfgen_out/confd.dhall |
     $M0_SRC_DIR/utils/m0confgen > $cfgen_out/confd.xc
 
-get_server_nodes() {
-    jq -r '.servers[] | "\(.hostname) \(.ipaddr)"' $cfgen_out/consul-agents.json
-}
-
-get_client_nodes() {
-    jq -r '.clients[] | "\(.hostname) \(.ipaddr)"' $cfgen_out/consul-agents.json
-}
-
 # Get my IP address (the one that the other agents will join to).
 read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
 
@@ -50,7 +84,7 @@ read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
 }
 echo 'Ok.'
 
-say 'Starting our Consul server agent... '
+say 'Starting Consul server agent on this node... '
 # $join_ip is our bind_ip address
 $SRC_DIR/mk-consul-env --mode server --bind $join_ip \
                        --extra-options '-ui -bootstrap-expect 1'
@@ -67,35 +101,45 @@ jq '[.[] | {key, value: (.value | @base64)}]' < $cfgen_out/consul-kv.json |
     consul kv import - > /dev/null
 echo 'Ok.'
 
-say 'Starting other Consul server agents... '
+say 'Starting Consul agents on remaining cluster nodes... '
+pids=()
 while read node bind_ip; do
     ssh $node "$SRC_DIR/mk-consul-env --mode server --bind $bind_ip \
                                       --join $join_ip &&
-               sudo systemctl start consul-agent"
+               sudo systemctl start consul-agent" &
+    pids+=($!)
 done < <(get_server_nodes | grep -vw $HOSTNAME || true)
-echo 'Ok.'
 
-say 'Starting Consul client agents... '
 while read node bind_ip; do
     ssh $node "$SRC_DIR/mk-consul-env --mode client --bind $bind_ip \
                                       --join $join_ip &&
-                   sudo systemctl start consul-agent"
+                   sudo systemctl start consul-agent" &
+    pids+=($!)
 done < <(get_client_nodes)
+wait4 ${pids[@]-}
+echo 'Ok.'
+
+say 'Update Consul agents configs from the KV Store... '
+$SRC_DIR/update-consul-conf &
+pids=($!)
+while read node _; do
+    ssh $node "$SRC_DIR/update-consul-conf" &
+    pids+=($!)
+done < <(get_all_nodes | grep -vw $HOSTNAME || true)
+wait4 ${pids[@]}
 echo 'Ok.'
 
 say 'Waiting for the RC Leader to be elected...'
-get_session() {
-    consul kv get -detailed leader | awk '/Session/ {print $2}'
-}
-count=1
-while [[ $(get_session) == '-' ]]; do
-    if (($count > 5)); then
-        consul kv put leader elect$RANDOM > /dev/null
-        count=1
-    fi
-    sleep 1
-    echo -n '.'
-    ((count++))
+wait_rc_leader
+sid=$(get_session)
+# There is always the serfHealth check in the session. But
+# if it is the only one - we should destroy the current session
+# (and wait for re-election to happen) to make sure that the new
+# session will be bound to the Mero services checks also.
+while (( $(get_session_checks_nr $sid) == 1 )); do
+    curl -sX PUT http://localhost:8500/v1/session/destroy/$sid &>/dev/null
+    wait_rc_leader
+    sid=$(get_session)
 done
 echo ' Ok.'
 
@@ -108,12 +152,9 @@ while read node _; do
     scp -q $cfgen_out/confd.xc $node:/tmp/
     ssh $node $SRC_DIR/bootstrap-node phase1 &
     pids+=($!)
+# Note: confd-s are running on server nodes only.
 done < <(get_server_nodes | grep -vw $HOSTNAME || true)
-
-# Check the status explicitly from each node.
-for pid in ${pids[@]}; do
-    wait $pid
-done
+wait4 ${pids[@]}
 echo 'Ok.'
 
 # Now the 2nd phase (ios-es).
@@ -124,17 +165,8 @@ pids=($!)
 while read node _; do
     ssh $node $SRC_DIR/bootstrap-node phase2 &
     pids+=($!)
-done < <(get_server_nodes | grep -vw $HOSTNAME || true)
-
-while read node _; do
-    ssh $node $SRC_DIR/bootstrap-node phase2 &
-    pids+=($!)
-done < <(get_client_nodes)
-
-# Check the status explicitly from each node.
-for pid in ${pids[@]}; do
-    wait $pid
-done
+done < <(get_all_nodes | grep -vw $HOSTNAME || true)
+wait4 ${pids[@]}
 echo 'Ok.'
 
 say 'Checking the health of the services... '

--- a/bootstrap-node
+++ b/bootstrap-node
@@ -41,21 +41,7 @@ die() {
 systemctl list-unit-files | grep -qE '^mero-kernel\.service\>' ||
     die "'mero-kernel' systemd service is not installed"
 
-# If it is a server node, we don't need to update Consul configuration
-# two times (once for each phase).  If it is a client node, we should
-# update the configuration file on phase2. (There is no phase1 on client
-# nodes --- they don't run confd.)
-if [[ $phase == phase1 ]]; then
-    # XXX We need to pass an empty string (actually, any argument) explicitly,
-    # otherwise the sourced file will inherit the value of `$*` from current
-    # script and its CLI arguments validation will fail.
-    . $SRC_DIR/update-consul-conf ''
-else
-    . $SRC_DIR/update-consul-conf -n  # do not update, only import variables
-    if [[ -z $CONFD_IDs ]]; then
-        . $SRC_DIR/update-consul-conf ''  # client node, update
-    fi
-fi
+. $SRC_DIR/update-consul-conf --dry-run  # import CONFD_IDs, IOS_IDs, id2fid()
 
 if [[ -n $CONFD_IDs || -n $IOS_IDs ]]; then
     sudo mkdir -p /var/mero/hax
@@ -84,7 +70,7 @@ for id in $IDs; do
     fid=$(id2fid $id)
     sudo systemctl start mero-mkfs@$fid
     touch /tmp/mero-mkfs-pass-$fid
-    # Give time for service checker to reset m0mkfs' HA state:
+    # Give time for service check to reset m0mkfs' HA state:
     # (1s * 2) - time of two checks + 1s. (See check-service.)
     sleep 3
     sudo systemctl start m0d@$fid

--- a/elect-rc-leader
+++ b/elect-rc-leader
@@ -4,7 +4,7 @@ set -eu -o pipefail
 #
 # This is the handler for RC Leader election.
 #
-# It creates the session with confd health checker and
+# It creates the session with confd health check and
 # tries to acquire the leader lock with this session.
 #
 # Use it like this:
@@ -33,7 +33,7 @@ pkill -f 'sh.*proto-rc' || true
 
 # Create session with the service:confd Health Checker:
 CHECKS=$(curl -s http://127.0.0.1:8500/v1/health/node/`hostname` | jq '[.[].CheckID]')
-PAYLD="{\"Name\": \"leader\", \"Checks\": $CHECKS}"
+PAYLD="{\"Name\": \"leader\", \"Checks\": $CHECKS, \"LockDelay\": \"2s\"}"
 RES=$(curl -sX PUT -d "$PAYLD" http://localhost:8500/v1/session/create)
 SID=$(echo "$RES" | jq -r '.ID' 2>/dev/null || true)
 

--- a/rfc/5/README.md
+++ b/rfc/5/README.md
@@ -198,7 +198,7 @@ end
 **Notes:**
 
 1. `fid` in the proposed Consul KV key `processes/<fid>` corresponds to the process fid (this guarantees that the key is unique within `processes/` prefix).
-   - This means that the checker script (health-check.sh) must know the fid of the processes it monitors.
+   - This means that the check script (health-check.sh) must know the fid of the processes it monitors.
    - This is OK that the keys in the KV are not reader-friendly and don't expose the logical name of the mero process. The end user will need to look into [Consul services](https://www.consul.io/api/agent/service.html) to learn the state of the particular mero process.
 2. Checker script must check both value in Consul KV and `pgrep` the process. This is required to make sure that the value in KV is not obsolete.
 3. "online" status shown at the diagram is chosen for the sake of simplicity. The exhaustive list of the values to store can be seen in [4/KV](../4/README.md).


### PR DESCRIPTION
The RC Leader session is not bound with the Mero checks
on bootstrap (as it should). It is because at the stage of the
leader election there are no Mero services registered yet and,
as a result, their checks are not registered yet also.

From another side, we can not start Mero services without the
RC Leader (because it is our hint for the principal RM service
in the entrypoint replies).

If later the main confd Mero process crashes (the one which
hosts the principal RM service) - the leader's session won't be
destroyed and the new RC Leader won't be elected, i.e.
the cluster will just get stuck.

Solution: elect the RC Leader already after the Consul agents
are reconfigured with the Mero services from the KV Store and
make sure that the created session is bound to the Mero services
checks.

Closes #314.

```sh
$ time ./bootstrap cfgen/_misc/andriys-two-nodes.yaml 
2019-10-09 20:12:35: Generating cluster configuration... Ok.
2019-10-09 20:12:38: Starting Consul server agent on this node... Ok.
2019-10-09 20:12:41: Importing configuration into the KV Store... Ok.
2019-10-09 20:12:47: Starting Consul agents on all cluster nodes... Ok.
2019-10-09 20:12:47: Update Consul agents configs from the KV Store... Ok.
2019-10-09 20:12:48: Waiting for the RC Leader to be elected............... Ok.
2019-10-09 20:13:01: Starting Mero (phase1)... Ok.
2019-10-09 20:13:07: Starting Mero (phase2)... Ok.
2019-10-09 20:13:16: Checking the health of the services... Ok.

real	0m41.332s
user	0m5.053s
sys	0m1.668s
$ curl -sX GET http://localhost:8500/v1/session/info/$(consul kv get -detailed leader | awk '/Session/ {print $2}') | jq '.[].Checks'
[
  "serfHealth",
  "service:12",
  "service:6",
  "service:9"
]
```