### PR TITLE
Problem: journalctl shows hare messages as `sh[...`

### DIFF
--- a/systemd/hare
+++ b/systemd/hare
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+exec "${HAX_EXE}"

--- a/systemd/hax.service
+++ b/systemd/hax.service
@@ -6,6 +6,6 @@ After=consul-agent.service mero-kernel.service
 [Service]
 EnvironmentFile=/opt/seagate/consul/systemd/hax-environment
 WorkingDirectory=/var/mero/hax
-ExecStart=/bin/sh -c "${HAX_EXE}"
+ExecStart=/opt/seagate/consul/systemd/hare
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
Solution: since journalctl by default takes the prefix from the process
name, add `hare` script and launch it from hax' system unit.

Closes #301