### PR TITLE
Problem: python36 packages are unavailable; CI fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,12 @@ build:
       cat >hare/_init-node.sh <<'EOF'
       set -eu -o pipefail
 
+      # XXX python36 is not available in `epel` repository; see issue #109.
+      # It might reappear eventually.  If it does, remove this workaround.
+      alt_epel=http://ci-storage.mero.colo.seagate.com
+      alt_epel+=/prvsnr/vendor/centos/epel/
+      sudo yum-config-manager --add-repo=$alt_epel
+
       sudo yum install -y python36 python36-devel python36-PyYAML python36-pip
       sudo pip3 install ply
 


### PR DESCRIPTION
Solution: use alternative rpm repository.

Kudos to Dima Chumak for this workaround!

Resolves #321.