### PR TITLE
Problem: bootstrap on existing Mero data is needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,7 +131,7 @@ build:
 
       cdf=$1
       cd /data/hare/
-      bash -x ./bootstrap $cdf
+      bash -x ./bootstrap --mkfs $cdf
 
       # Run an I/O test.
       cp /data/mero/clovis/m0crate/tests/test1_io.yaml .
@@ -258,7 +258,7 @@ test-boot2:
       chmod 0600 $kh
 
       cd /data/hare/
-      bash -x ./bootstrap cfgen/_misc/ci-boot2.yaml
+      bash -x ./bootstrap --mkfs cfgen/_misc/ci-boot2.yaml
       EOF
     - |
       time $M0VG run --vm ssu1 \

--- a/bootstrap
+++ b/bootstrap
@@ -5,19 +5,21 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 # Helper script to bootstrap the cluster.
 
+PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
 M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
 
 usage() {
-    echo "Usage: ${0##*/} /path/to/cluster-description-file.yaml"
-}
+    cat <<EOF
+Usage: $PROG [--mkfs] cluster-description-file.yaml
 
-(($# == 1)) || {
-    usage >&2
-    exit 1
-}
+Bootstrap cluster described by the description file.
 
-cluster_descr=$1
+Options:
+  --mkfs                    Do m0mkfs (WARNING: wipes Mero data).
+  -h, --help                Show this help and exit.
+EOF
+}
 
 say() {
     echo -n "$(date '+%F %T'): $*"
@@ -72,6 +74,29 @@ get_ready_agents() {
 get_ready_agents_nr() {
     consul members | sed 1d | wc -l
 }
+
+TEMP=$(getopt --options h \
+              --longoptions help,mkfs \
+              --name "$PROG" -- "$@" || true)
+
+(($? == 0)) || { usage >&2; exit 1; }
+
+eval set -- "$TEMP"
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        --mkfs)              opt_mkfs=--mkfs; shift ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
+
+(($# == 1)) || {
+    usage >&2
+    exit 1
+}
+
+cluster_descr=$1
 
 say 'Generating cluster configuration... '
 cfgen_out=/tmp
@@ -168,12 +193,12 @@ echo ' Ok.'
 
 # Start Mero in two phases: 1st confd-s, then ios-es.
 say 'Starting Mero (phase1)... '
-$SRC_DIR/bootstrap-node phase1 &
+$SRC_DIR/bootstrap-node ${opt_mkfs:-} --phase 1 &
 pids=($!)
 
 while read node _; do
     scp -q $cfgen_out/confd.xc $node:/tmp/
-    ssh $node $SRC_DIR/bootstrap-node phase1 &
+    ssh $node $SRC_DIR/bootstrap-node ${opt_mkfs:-} --phase 1 &
     pids+=($!)
 # Note: confd-s are running on server nodes only.
 done < <(get_server_nodes | grep -vw $HOSTNAME || true)
@@ -182,11 +207,11 @@ echo 'Ok.'
 
 # Now the 2nd phase (ios-es).
 say 'Starting Mero (phase2)... '
-$SRC_DIR/bootstrap-node phase2 &
+$SRC_DIR/bootstrap-node ${opt_mkfs:-} --phase 2 &
 pids=($!)
 
 while read node _; do
-    ssh $node $SRC_DIR/bootstrap-node phase2 &
+    ssh $node $SRC_DIR/bootstrap-node ${opt_mkfs:-} --phase 2 &
     pids+=($!)
 done < <(get_all_nodes | grep -vw $HOSTNAME || true)
 wait4 ${pids[@]}

--- a/bootstrap-node
+++ b/bootstrap-node
@@ -3,30 +3,53 @@ set -eu -o pipefail
 # set -x
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
+PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
-prog=${0##*/}
 
 usage() {
     cat <<EOF
-Usage: $prog { phase1 | phase2 }
+Usage: $PROG [--mkfs] { -p|--phase 1|2 }
 
 Bootstraps single node after consul agent is started.
 
 The required parameter is one of the following:
 
-  phase1 - start confd Mero process(es)
-  phase2 - start ios Mero process(es)
+  --phase 1 - start confd Mero process(es)
+  --phase 2 - start ios Mero process(es)
+
+Options:
+  --mkfs                    Do m0mkfs (WARNING: wipes Mero data).
+  -h, --help                Show this help and exit.
 EOF
 }
 
-case "$*" in
-    phase[12]) ;;
-    *) usage >&2; exit 1;;
-esac
-phase=$1
+do_mkfs=false
+phase=-
+
+TEMP=$(getopt --options hp: \
+              --longoptions help,mkfs,phase: \
+              --name "$PROG" -- "$@" || true)
+
+(($? == 0)) || { usage >&2; exit 1; }
+
+eval set -- "$TEMP"
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        --mkfs)              do_mkfs=true; shift ;;
+        -p|--phase)          phase=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   echo 'getopt: internal error...'; exit 1 ;;
+    esac
+done
+
+[[ $phase =~ ^[12]$ ]] || {
+    usage >&2
+    exit 1
+}
 
 die() {
-    >&2 echo "$prog: $HOSTNAME: $*"
+    >&2 echo "$PROG: $HOSTNAME: $*"
     exit 1
 }
 
@@ -54,13 +77,13 @@ if [[ -n $CONFD_IDs || -n $IOS_IDs ]]; then
     done
 fi
 
-if [[ -n $CONFD_IDs && $phase == phase1 ]]; then
+if [[ -n $CONFD_IDs && $phase == 1 ]]; then
     [[ -f /tmp/confd.xc ]] ||
         die 'Cannot bootstrap a server node without /tmp/confd.xc file'
     sudo mv /tmp/confd.xc /etc/mero/
 fi
 
-if [[ $phase == phase1 ]]; then
+if [[ $phase == 1 ]]; then
     IDs=$CONFD_IDs
 else
     IDs=$IOS_IDs
@@ -68,10 +91,12 @@ fi
 
 for id in $IDs; do
     fid=$(id2fid $id)
-    sudo systemctl start mero-mkfs@$fid
-    touch /tmp/mero-mkfs-pass-$fid
-    # Give time for service check to reset m0mkfs' HA state:
-    # (1s * 2) - time of two checks + 1s. (See check-service.)
-    sleep 3
+    if $do_mkfs; then
+        sudo systemctl start mero-mkfs@$fid
+        touch /tmp/mero-mkfs-pass-$fid
+        # Give time for service check to reset m0mkfs' HA state:
+        # (1s * 2) - time of two checks + 1s. (See check-service.)
+        sleep 3
+    fi
     sudo systemctl start m0d@$fid
 done


### PR DESCRIPTION
After the EES HA failover, we should be able to bootstrap
the cluster on existing Mero data without running m0mkfs.

Solution: add `--mkfs` option to the `bootstrap` script.
By default, no m0mkfs should be done (it wipes away all
user's data in Mero and should be considered a dangerous
operation).

Closes #330.