### PR TITLE
Problem: bootstrap with ready configuration is needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ build:
       sudo yum-config-manager --add-repo=$alt_epel
 
       sudo yum install -y python36 python36-devel python36-PyYAML python36-pip
-      sudo pip3 install ply
+      sudo pip3 install ply python-consul
 
       cd /tmp
       download=https://github.com/dhall-lang/dhall-haskell/releases/download
@@ -131,13 +131,17 @@ build:
 
       cdf=$1
       cd /data/hare/
-      bash -x ./bootstrap --mkfs $cdf
+      time ./bootstrap --mkfs $cdf
 
       # Run an I/O test.
       cp /data/mero/clovis/m0crate/tests/test1_io.yaml .
       ./update-m0crate-io-test-conf test1_io.yaml
       dd if=/dev/urandom of=/tmp/128M bs=1M count=100
       sudo /data/mero/clovis/m0crate/m0crate -S test1_io.yaml
+
+      # Make sure we can bootstrap on the ready configuration.
+      ./cluster-shutdown
+      time ./bootstrap --conf-dir /tmp
       EOF
 
 # Test ----------------------------------------------------------------- {{{1
@@ -258,7 +262,7 @@ test-boot2:
       chmod 0600 $kh
 
       cd /data/hare/
-      bash -x ./bootstrap --mkfs cfgen/_misc/ci-boot2.yaml
+      time ./bootstrap --mkfs cfgen/_misc/ci-boot2.yaml
       EOF
     - |
       time $M0VG run --vm ssu1 \

--- a/bootstrap
+++ b/bootstrap
@@ -11,13 +11,16 @@ M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
 
 usage() {
     cat <<EOF
-Usage: $PROG [--mkfs] cluster-description-file.yaml
+Usage: $PROG [OPTIONS...] --conf-dir DIR|cluster-description-file.yaml
 
-Bootstrap cluster described by the description file.
+Bootstrap cluster described by the description file or
+using the ready configuration at the specified directory.
 
 Options:
-  --mkfs                    Do m0mkfs (WARNING: wipes Mero data).
-  -h, --help                Show this help and exit.
+  --mkfs               Do m0mkfs (WARNING: wipes all Mero data).
+  -c, --conf-dir DIR   Don't generate configuration files, use
+                       existing ones at the specified DIR(ectory).
+  -h, --help           Show this help and exit.
 EOF
 }
 
@@ -75,38 +78,45 @@ get_ready_agents_nr() {
     consul members | sed 1d | wc -l
 }
 
-TEMP=$(getopt --options h \
-              --longoptions help,mkfs \
+TEMP=$(getopt --options hc: \
+              --longoptions help,mkfs,conf-dir: \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
 
 eval set -- "$TEMP"
+
+conf_dir=
+
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --mkfs)              opt_mkfs=--mkfs; shift ;;
+        -c|--conf-dir)       conf_dir=$2; shift ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
 done
 
-(($# == 1)) || {
+[[ $conf_dir ]] || (($# == 1)) || {
     usage >&2
     exit 1
 }
 
 cluster_descr=$1
+cfgen_out=${conf_dir:-'/tmp'}
 
-say 'Generating cluster configuration... '
-cfgen_out=/tmp
+if ! [[ $conf_dir ]]; then
+    say 'Generating cluster configuration... '
 
-cd $SRC_DIR
-cfgen/cfgen -D cfgen/dhall/ -o $cfgen_out < $cluster_descr
+    cd $SRC_DIR
+    cfgen/cfgen -D cfgen/dhall/ -o $cfgen_out < $cluster_descr
 
-sudo mkdir -p /etc/mero
-dhall text < $cfgen_out/confd.dhall |
-    $M0_SRC_DIR/utils/m0confgen > $cfgen_out/confd.xc
+    sudo mkdir -p /etc/mero
+    dhall text < $cfgen_out/confd.dhall |
+        $M0_SRC_DIR/utils/m0confgen > $cfgen_out/confd.xc
+    echo 'Ok.'
+fi
 
 # Get my IP address (the one that the other agents will join to).
 read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
@@ -115,7 +125,6 @@ read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
     echo 'Bootstrap should be run from the server node only' >&2
     exit 1
 }
-echo 'Ok.'
 
 say 'Starting Consul server agent on this node... '
 # $join_ip is our bind_ip address

--- a/bootstrap-node
+++ b/bootstrap-node
@@ -80,7 +80,7 @@ fi
 if [[ -n $CONFD_IDs && $phase == 1 ]]; then
     [[ -f /tmp/confd.xc ]] ||
         die 'Cannot bootstrap a server node without /tmp/confd.xc file'
-    sudo mv /tmp/confd.xc /etc/mero/
+    sudo cp /tmp/confd.xc /etc/mero/
 fi
 
 if [[ $phase == 1 ]]; then


### PR DESCRIPTION
The bootstrap script should be able to use existing configuration
files instead of generating them every time anew from the cluster
description file. This is needed for the EES HA failover.

Solution: extend `bootstrap` script with `--conf_dir DIR` option,
allowing it to reuse existing cluster configuration at the
specified DIRectory.

Closes #331.