### PR TITLE
Problem: bootstrap --mkfs option may not work

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -92,7 +92,7 @@ while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --mkfs)              opt_mkfs=--mkfs; shift ;;
-        -c|--conf-dir)       conf_dir=$2; shift ;;
+        -c|--conf-dir)       conf_dir=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
@@ -103,7 +103,7 @@ done
     exit 1
 }
 
-cluster_descr=$1
+cluster_descr=${1:-}
 cfgen_out=${conf_dir:-'/tmp'}
 
 if ! [[ $conf_dir ]]; then


### PR DESCRIPTION
If the `--mkfs` option specified last for the bootstrap
script it does not work:

$ ./bootstrap -c /tmp --mkfs

Solution: fix options parsing bug in the script.