### PR TITLE
Problem: the RC Leader re-election might not happen if confd dies

### DIFF
--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -46,8 +46,11 @@ get_session_id | grep -q ^- || {
 cleanup
 
 # Create session with the service:confd Health Checker:
-CHECKS=$(curl -s http://127.0.0.1:8500/v1/health/node/$HOSTNAME |
-         jq '[.[].CheckID]')
+CHECKS_A=($(consul kv get -recurse node/$HOSTNAME | egrep -w 'confd|ha' |
+            sed -r 's/.*service.([0-9]+).*/"service:\1"/'))
+# See the trick comma separated list explained here:
+# https://stackoverflow.com/questions/38625176/store-array-output-to-comma-separated-list-in-bash-scripting
+CHECKS=$(IFS=,; echo "[\"serfHealth\", ${CHECKS_A[*]}]")
 PAYLD="{\"Name\": \"leader\", \"Checks\": $CHECKS, \"LockDelay\": \"2s\"}"
 RES=$(curl -sX PUT -d "$PAYLD" http://localhost:8500/v1/session/create)
 SID=$(echo "$RES" | jq -r '.ID' 2>/dev/null || true)


### PR DESCRIPTION
Sometimes during re-election Consul may not return the full list
of health checks on the node. As result, the session will be
created unbound with the checks, which could lead to the situation
when re-election will not happen if the confd process dies later.

Solution: get the list of checks and their IDs on the node
not from the Consul's catalogue, but from the KV Store - it
seems to be more robust approach. Also, it allows to select
only the needed services (confd and hax) to bind the session with
instead of all registered on the node.

Closes #367.