### PR TITLE
Problem: hctl requires sudo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,12 +205,12 @@ test-boot1:
       test_cluster() {
           local cdf=$1
 
-          time sudo hctl bootstrap --mkfs $cdf
+          time hctl bootstrap --mkfs $cdf
           do_io
-          sudo hctl shutdown
-          time sudo hctl bootstrap --conf-dir /tmp  # bootstrap on existing conf
+          hctl shutdown
+          time hctl bootstrap --conf-dir /tmp  # bootstrap on existing conf
           do_io
-          sudo hctl shutdown
+          hctl shutdown
       }
 
       cd /data/hare/
@@ -282,12 +282,12 @@ test-boot2:
 
       cd /data/hare/
       # Server-server Consul agents configuration.
-      time sudo hctl bootstrap --mkfs cfgen/examples/ci-boot2.yaml
+      time hctl bootstrap --mkfs cfgen/examples/ci-boot2.yaml
 
-      sudo hctl shutdown
+      hctl shutdown
 
       # Server-client Consul agents configuration.
-      time sudo hctl bootstrap --mkfs cfgen/examples/ci-boot2-1confd.yaml
+      time hctl bootstrap --mkfs cfgen/examples/ci-boot2-1confd.yaml
       EOF
     - time $M0VG run --vm ssu1
            "OTHER_HOST=${JOB_NAME}-ssu2 bash -x /data/hare/_test-boot2.sh"

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -55,18 +55,20 @@ done
 
 sed -r -e "s/^(MODE).*/\1=$mode/" \
        -e "s/^(BIND).*/\1=$bind_addr/" \
-       -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" $ENV_TEMPLATE >$ENV_FILE
+       -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" $ENV_TEMPLATE |
+    sudo tee $ENV_FILE >/dev/null
 
 if [[ -n $join_addr ]]; then
-    sed -r -e "s/^(JOIN).*/\1=${join_addr:+-retry-join $join_addr}/" \
-        -i $ENV_FILE
+    sudo sed -r -e "s/^(JOIN).*/\1=${join_addr:+-retry-join $join_addr}/" \
+             -i $ENV_FILE
 fi
 
 if [[ -n $extra_opts ]]; then
-    sed -r "s/^(EXTRA_OPTS).*/\1=$extra_opts/" -i $ENV_FILE
+    sudo sed -r "s/^(EXTRA_OPTS).*/\1=$extra_opts/" -i $ENV_FILE
 fi
 
 # Prepare for consul-agent startup:
 sudo rm -rf /tmp/consul
 # TODO: '/opt/seagate/hare' prefix can be different
-cp /opt/seagate/hare/share/consul/consul-$mode-conf.json.in /var/lib/hare/consul-$mode-conf.json
+sudo cp /opt/seagate/hare/share/consul/consul-$mode-conf.json.in \
+        /var/lib/hare/consul-$mode-conf.json

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -153,6 +153,6 @@ done
 tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)
 trap "rm -f $tmpfile" EXIT # delete automatically on exit
 jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
-cat $tmpfile >$CONF_FILE
+sudo cp $tmpfile $CONF_FILE
 
 consul reload > /dev/null


### PR DESCRIPTION
hctl should not require sudo.

Solution: fix the creation of files at /var/lib/hare
with sudo at `mk-consul-env` script.