### PR TITLE
Problem: 7/FAIL doesn't cover S3 server failures

### DIFF
--- a/rfc/7/README.md
+++ b/rfc/7/README.md
@@ -72,6 +72,13 @@ REACTION:
 - systemd restarts hax service, hax notifies Mero processes and re-establishes
   connections without restarting Mero services.
 
+### EVENT: S3 server crashes
+
+DETECTED BY: Consul health check
+
+REACTION: Consul [watch handler](https://www.consul.io/docs/agent/watches.html#handlers)
+restarts the S3 server.
+
 ### EVENT: Mero client crashes
 
 XXX


### PR DESCRIPTION
Solution: add the corresponding section.

---

Problem: "EES" labels look noisy in 7/FAIL

Solution: leave only [post-EES] labels.  EES is to be assumed by default.