### PR TITLE
Problem: python-consul is not installed by `make devinstall`

### DIFF
--- a/cfgen/requirements.txt
+++ b/cfgen/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 ply  # cfgen tests execute `m0confgen`, which depends on `ply`
+python-consul

--- a/ci/m0vg/init-node
+++ b/ci/m0vg/init-node
@@ -10,7 +10,6 @@ alt_epel+=/prvsnr/vendor/centos/epel/
 sudo yum-config-manager --add-repo=$alt_epel
 
 sudo yum install -y python36 python36-devel python36-PyYAML python36-pip
-sudo pip3 install ply python-consul
 
 sudo mkdir -p /var/mero
 for i in {0..9}; do


### PR DESCRIPTION
Solution: add it to the cfgen/requirements.txt list.

Closes #417.

Related issue: #410