### PR TITLE
Problem: cannot start two Consul agents on the same node

### DIFF
--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -11,4 +11,4 @@ export PATH
 # TODO: should it be `consul` and PATH=/opt/seagate/hare/bin:$PATH ?
 exec consul agent -bind $BIND -client "$CLIENT" $JOIN \
      -config-file=/var/lib/hare/consul-$MODE-conf.json \
-     -data-dir=/tmp/consul $EXTRA_OPTS
+     -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -68,7 +68,7 @@ if [[ -n $extra_opts ]]; then
 fi
 
 # Prepare for consul-agent startup:
-sudo rm -rf /tmp/consul
+sudo rm -rf /var/lib/hare/consul-$bind_addr
 # TODO: '/opt/seagate/hare' prefix can be different
 sudo cp /opt/seagate/hare/share/consul/consul-$mode-conf.json.in \
         /var/lib/hare/consul-$mode-conf.json


### PR DESCRIPTION
For EES HA we need to be able to start two Consul agents
on the same node during the failover. Currently we use
`/tmp/consul` as the Consul agent process data directory -
that's why we can't have several of them on the same node.

Solution: add the unique IP address to the directory name:
`/tmp/consul-<IP-addr>`.