### PR TITLE
Problem: cannot start two hax processes on one node

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1,3 +1,4 @@
+import os
 import json
 
 from consul import Consul
@@ -54,7 +55,8 @@ class ConsulUtil:
         return _to_service_fid(int(sfidk['Value']))
 
     def get_my_nodename(self):
-        return self.cns.agent.self()['Config']['NodeName']
+        return (os.environ.get('HARE_HAX_NODE_NAME') or
+                self.cns.agent.self()['Config']['NodeName'])
 
     def get_node_service_by_name(self, hostname, svc_name):
         for svc in self.cns.catalog.service(service=svc_name)[1]:


### PR DESCRIPTION
For EES HA we need to be able to start two hax processes on one
node during the failover. One of the reasons why we cannot do
this currently - it is because hax determines its endpoint
address based on the node name it takes from the Consul's
catalogue and configuration from the KV Store.

Solution: add the possibility for hax to determine the node
name for itself from the environment variable. We then would
use it from the hax systemd unit for the migrated process
and pass the needed node name to hax.