### PR TITLE
Problem: cannot start two hax processes on the same node

### DIFF
--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -4,7 +4,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict, List, NamedTuple
 
 from hax.types import Fid
-from hax.util import create_process_fid
+from hax.util import create_process_fid, ConsulUtil
 
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', str)])
 
@@ -70,7 +70,8 @@ def run_server(thread_to_wait=None,
                port=8080,
                halink=None):
     port = 8080
-    server_address = ('', port)
+    util = ConsulUtil()
+    server_address = (util.get_hax_ip_address(), port)
     httpd = server_class(server_address, KVHandler)
     httpd.halink = halink
 

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -154,4 +154,7 @@ trap "rm -f $tmpfile" EXIT # delete automatically on exit
 jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
 sudo cp $tmpfile $CONF_FILE
 
+sudo sed -r "s;(http://)localhost;\1$(get_service_addr $HAX_EP);" \
+         -i $CONF_FILE
+
 consul reload > /dev/null


### PR DESCRIPTION
For EES HA we need to be able to start two hax processes on
the same node during the failover. One of the reasons why we
cannot do this currently - it is because hax's internal http
server (used to get services health updates from Consul) is
listening on localhost address.

Solution: start the http server on the same IP address which
is used to speak with Mero processes - on the failover this
address will migrate to the alive node along with the hax
process.

Closes #413.