### PR TITLE
Problem: hax does not fetch real process and service status from Consul

### DIFF
--- a/hax/hax/ffi.py
+++ b/hax/hax/ffi.py
@@ -62,6 +62,13 @@ class HaxFFI:
         ]
         self.ha_broadcast = lib.m0_ha_notify
 
+        lib.m0_ha_nvec_reply_send.argtypes = [
+            c.c_void_p,  # unsigned long long  hax_msg
+            c.POINTER(HaNoteStruct),  # struct m0_ha_note *notes
+            c.c_uint32  # uint32_t nr_notes
+        ]
+        self.ha_nvec_reply = lib.m0_ha_nvec_reply_send
+
         lib.adopt_mero_thread.argtypes = []
         lib.adopt_mero_thread.restype = c.c_int
         self.adopt_mero_thread = lib.adopt_mero_thread

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -4,7 +4,7 @@ from queue import Empty, Queue
 from threading import Thread
 
 from hax.ffi import HaxFFI
-from hax.message import EntrypointRequest, ProcessEvent
+from hax.message import EntrypointRequest, HaNvecGetEvent, ProcessEvent
 from hax.util import ConsulUtil
 
 
@@ -44,6 +44,8 @@ class ConsumerThread(Thread):
                         ha_link.send_entrypoint_request_reply(item)
                     elif isinstance(item, ProcessEvent):
                         self.consul.update_process_status(item.evt)
+                    elif isinstance(item, HaNvecGetEvent):
+                        item.ha_link_instance.ha_nvec_get_reply(item)
                     else:
                         logging.warning('Unsupported event type received: %s',
                                         item)

--- a/hax/hax/hax.h
+++ b/hax/hax/hax.h
@@ -47,9 +47,9 @@ struct hax_entrypoint_request {
 };
 
 struct hax_msg {
-	struct hax_context       *hm_hc;
-	struct m0_ha_link        *hm_hl;
-	const struct m0_ha_msg   *hm_msg;
+	struct hax_context *hm_hc;
+	struct m0_ha_link  *hm_hl;
+	struct m0_ha_msg    hm_msg;
 };
 
 struct hax_context *init_halink(PyObject *obj, const char *node_uuid);
@@ -73,7 +73,7 @@ void m0_ha_entrypoint_reply_send(unsigned long long epr,
 				 const char                 *rm_eps);
 void m0_ha_failvec_reply_send(unsigned long long hm, struct m0_fid *pool_fid,
 			      uint32_t nr_notes);
-void m0_ha_nvec_reply_send(unsigned long long hm, struct m0_ha_nvec *nvec);
+void m0_ha_nvec_reply_send(unsigned long long hm, struct m0_ha_note *notes, uint32_t nr_notes);
 void m0_ha_notify(unsigned long long ctx, struct m0_ha_note *notes, uint32_t nr_notes);
 void m0_ha_broadcast_test(unsigned long long ctx);
 void hax_lock(struct hax_context *hc);

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -33,5 +33,15 @@ class ProcessEvent(BaseMessage):
         self.evt = evt
 
 
+class HaNvecGetEvent(BaseMessage):
+    def __init__(self,
+                 hax_msg=None,
+                 nvec=None,
+                 ha_link_instance=None):
+        self.hax_msg = hax_msg
+        self.nvec = nvec
+        self.ha_link_instance = ha_link_instance
+
+
 class Die(BaseMessage):
     pass

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -1,4 +1,6 @@
 import ctypes as c
+from enum import Enum
+from typing import NamedTuple
 
 
 class FidStruct(c.Structure):
@@ -7,6 +9,14 @@ class FidStruct(c.Structure):
 
 class Uint128Struct(c.Structure):
     _fields_ = [("hi", c.c_uint64), ("lo", c.c_uint64)]
+
+
+ObjT = Enum('ObjT', [
+    # There are the only conf object types we care about.
+    ('PROCESS', 0x7200000000000001),
+    ('SERVICE', 0x7300000000000001)
+])
+ObjT.__doc__ = 'Mero conf object types and their m0_fid.f_container values'
 
 
 class HaNoteStruct(c.Structure):
@@ -94,3 +104,6 @@ class Uint128:
 
     def to_c(self):
         return Uint128Struct(self.hi, self.lo)
+
+
+HaNote = NamedTuple('HaNote', [('obj_t', str), ('note', HaNoteStruct)])


### PR DESCRIPTION
`hax` used to fabricate statuses of Mero conf objects (including process and services) for ha_nvec reply. This patch removes that fabrication and instead fetches the status from consul, mainly for processes and services respectively.

Solution: fetch actual status of process and service objects from the Consul KV.