### PR TITLE
Problem: Hare doesn't set node UUID for mero-kernel.service

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -92,6 +92,9 @@ fi
 for id in $IDs; do
     fid=$(id2fid $id)
     if $do_mkfs; then
+        echo "MERO_NODE_UUID='$(uuidgen --time)'" |
+            sudo tee /etc/sysconfig/mero-kernel >/dev/null
+
         sudo systemctl start mero-mkfs@$fid
         touch /tmp/mero-mkfs-pass-$fid
         # Give time for service check to reset m0mkfs' HA state:


### PR DESCRIPTION
Solution: set `MERO_NODE_UUID` variable in `/etc/sysconfig/mero-kernel`
file(s), created on every node.

Closes #422.
