### PR TITLE
Problem: wrong HTTP address in Consul agent configuration

### DIFF
--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -36,6 +36,10 @@ get_service_addr() {
     echo ${1%:*}
 }
 
+get_service_ip_addr() {
+    echo ${1%@*}
+}
+
 get_service_port() {
     echo ${1##*:}
 }
@@ -154,7 +158,7 @@ trap "rm -f $tmpfile" EXIT # delete automatically on exit
 jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
 sudo cp $tmpfile $CONF_FILE
 
-sudo sed -r "s;(http://)localhost;\1$(get_service_addr $HAX_EP);" \
+sudo sed -r "s;(http://)localhost;\1$(get_service_ip_addr $HAX_EP);" \
          -i $CONF_FILE
 
 consul reload > /dev/null


### PR DESCRIPTION
The address contains `@tcp:12345...` part from the endpoint, so
Consul complains like this in the system log:

```
Nov 07 18:38:01 pod-c1 hare-consul[7774]: 2019/11/07 18:38:01 [ERR] agent: Failed to invoke http watch handler 'http://172.28.128.102@tcp:12345:1:8080': Post http://172.28.128.102@tcp:12345:1:8080: invalid URL port "12345:1:8080"
```

The bug was introduced at the recent commit 6f12b5cf.

Solution: fix the code to take only the IP address part of the
endpoint address.