### PR TITLE
Problem: Hare builds in test stage instead of build stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,12 +44,6 @@ rpmbuild:
 # Test ----------------------------------------------------------------- {{{1
 #
 
-test-utils:
-  stage: test
-  tags: [ m0vg ]
-  except: [ tags ]
-  script: [ ci/test-utils ]
-
 test-boot1:
   stage: test
   tags: [ m0vg ]

--- a/ci/build
+++ b/ci/build
@@ -20,3 +20,7 @@ git clone --recursive --depth 1 --shallow-submodules \
 
 # Build Mero.
 ci_docker ci/docker/build-mero
+
+# Build Hare.
+ci_docker make test
+ci_docker make install

--- a/ci/test-utils
+++ b/ci/test-utils
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
-export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
-set -x
-
-. ci/common-defs.sh  # ci_docker
-
-ci_docker make test
-ci_docker make install


### PR DESCRIPTION
Solution:

Ideally, Hare build should be a part of a build job in the build stage.
Build hare in build job.

Closes issue #440