### PR TITLE
Problem: user's python3 is not necessarily ≥ 3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ SHELL := bash
 
 TOP_SRC_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 PY_VENV_DIR := $(TOP_SRC_DIR).py3venv
-PYTHON      := python3
+PYTHON      := python3.6
 PY_VENV     := source $(PY_VENV_DIR)/bin/activate
 PIP         := $(PY_VENV); pip3
 SETUP_PY    := $(PY_VENV); $(PYTHON) setup.py

--- a/README_developers.md
+++ b/README_developers.md
@@ -11,9 +11,9 @@ The scripts in this repository constitute a middleware layer between [Consul](ht
 
 ## Installation
 
-* Ensure that `python3` is an alias to Python 3.6 or newer:
+* Ensure that `python3.6` command is available and refers to Python 3.6:
   ```sh
-  $ python3 --version
+  $ python3.6 --version
   Python 3.6.3
   ```
 * Ensure that Mero sources are built.


### PR DESCRIPTION
Solution:
* Use `python3.6` in the Makefile.
* Update README_developers.md.

**Note**: when applying this patch make sure that the old virtualenv is removed (`rm -rf ./.py3env`)

Closes #462.