### PR TITLE
Problem: bad placement of CLI argument in the doc

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -28,6 +28,7 @@ The scripts in this repository constitute a middleware layer between [Consul](ht
    ```sh
    git clone --recursive ssh://git@gitlab.mero.colo.seagate.com:6022/mero/hare.git
    cd hare
+   make
    sudo make devinstall
    ```
 


### PR DESCRIPTION
The user, copying git-clone command from README_developers.md, may
accidentally omit `--recursive` argument, as it is located too far
by the right edge of the screen.

Also, POSIX-compatible CLI would put optional arguments before non-options;
see https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html

Solution: swap `--recursive` and URL arguments in the git clone command
in README_developers.md.

---

Problem: README tells to build as root

Solution: update `README_developers.md`; build Hare as normal user,
install as the super-user.
