### PR TITLE
Problem: M0_NC_FAILED is sent too early on systemctl stop

### DIFF
--- a/utils/check-service
+++ b/utils/check-service
@@ -66,6 +66,7 @@ fi
 
 case $(systemctl is-active $service) in
     'active') exit 0;;
+    'deactivating') exit 0;;
     'failed') exit 2;;
     *) exit 1;;
 esac


### PR DESCRIPTION
We send M0_NC_FAILED ha notification right from the beginning
of the Mero process stop. This causes Mero process to panic
in case it needs to use m0_ha_link for some negotiations
during its graceful shutdown.

Solution: don't notify the change of Mero process status
until the shutdown is finished.

Closes #458.