### PR TITLE
Problem: CI tests run on outdated m0vg box

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   GIT_DEPTH: 1  # clone only the current commit
   GIT_STRATEGY: clone  # make a fresh `git clone` of the repo for every new CI job
   GIT_SUBMODULE_STRATEGY: normal  # init and check out submodules
-  CENTOS_RELEASE: eos
+  CENTOS_RELEASE: '7.6'
   DOCKER_REGISTRY: registry.gitlab.mero.colo.seagate.com
   M0_VG_NO_SYMLINKS: "true"
   RPMSYNC_DIR:    "/releases/dev/$CI_PROJECT_PATH/$CI_COMMIT_REF_SLUG/B$CI_PIPELINE_ID"

--- a/ci/common-defs.sh
+++ b/ci/common-defs.sh
@@ -35,8 +35,8 @@ ci_m0vg_init() (
     fi
 
     $M0VG env add <<EOF
-M0_VM_BOX=centos75/dev-halon
-M0_VM_BOX_URL='http://ci-storage.mero.colo.seagate.com/vagrant/centos75/dev'
+M0_VM_BOX=centos76/dev
+M0_VM_BOX_URL='http://ci-storage.mero.colo.seagate.com/vagrant/centos76/dev'
 M0_VM_CMU_MEM_MB=4096
 M0_VM_NAME_PREFIX=$JOB_NAME
 M0_VM_HOSTNAME_PREFIX=$JOB_NAME

--- a/ci/m0vg/init-node
+++ b/ci/m0vg/init-node
@@ -3,14 +3,6 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-# XXX python36 is not available in `epel` repository; see issue #109.
-# It might reappear eventually.  If it does, remove this workaround.
-alt_epel=http://ci-storage.mero.colo.seagate.com
-alt_epel+=/prvsnr/vendor/centos/epel/
-sudo yum-config-manager --add-repo=$alt_epel
-
-sudo yum install -y python36 python36-devel python36-PyYAML python36-pip
-
 sudo mkdir -p /var/mero
 for i in {0..9}; do
     sudo dd if=/dev/zero of=/var/mero/disk$i.img bs=1M seek=9999 count=1

--- a/ci/rpmbuild
+++ b/ci/rpmbuild
@@ -3,9 +3,10 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-latest_release_dir=$(readlink -f /releases/master/BCURRENT)
+latest_release_dir=$(readlink -f /releases/eos/BLATEST)
 mkdir -vp $RPMSYNC_DIR
 cp -v $latest_release_dir/mero{,-devel}-[0-9]*.rpm $RPMSYNC_DIR/
+cp -v $latest_release_dir/s3*-[0-9]*.rpm $RPMSYNC_DIR/
 
 time yum install -y $latest_release_dir/mero{,-devel}-[0-9]*.rpm
 


### PR DESCRIPTION
Solution: update base m0vg box to CentOS 7.6, with all the latest Hare
dependencies pre-installed.

Also, update the docker image used by *rpmbuild* job to match CenOS
version of the new `m0vg` box. With this change, it's now possible to
install release rpms of *Mero* and *S3server* in Hare CI VMs and containers.

Also, it should be possible to avoid doing Mero build for every CI
pipeline and install Mero from an rpm package.