### PR TITLE
Problem: README_developers doesn't mention python3-devel

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -7,10 +7,11 @@ The scripts in this repository constitute a middleware layer between [Consul](ht
 
 ## Prerequisites
 
-* Ensure that `python3.6` command is available and refers to Python &geq; 3.6:
+* Python &geq; 3.6 and the corresponding header files.
+
+  To install them on CentOS 7.6, run
   ```sh
-  $ python3.6 --version
-  Python 3.6.3
+  sudo yum install python3 python3-devel
   ```
 
 * Ensure that Mero is built and its systemd services are installed.


### PR DESCRIPTION
If `python3-devel` package is not installed, `sudo make devinstall` fails:

```
running build_ext
building 'libhax' extension
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/hax
gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DM0_INTERNAL= -DM0_EXTERN=extern -I/work/mero -I/work/hare/.py3venv/include -I/usr/include/python3.6m -c hax/hax.c -o build/temp.linux-x86_64-3.6/hax/hax.o -g -Werror -Wall -Wextra -Wno-attributes -Wno-unused-parameter -fPIC
hax/hax.c:22:20: fatal error: Python.h: No such file or directory
 #include <Python.h>
                    ^
compilation terminated.
error: command 'gcc' failed with exit status 1
make: *** [hax/dist/hax-0.1.0-cp36-cp36m-linux_x86_64.whl] Error 1
```

Solution: update README_developers.md, mention the yum install command.