### PR TITLE
Fix docker:rebuild-images job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,7 +187,7 @@ docker:rebuild-images:
 
   script:
     - cd docker/
-    - make $DOCKER_IMAGE_TAG
+    - make docker-image-${DOCKER_IMAGE_TAG}
     - make push tag="${DOCKER_IMAGE_TAG}*"
 
 


### PR DESCRIPTION
Problem: docker:rebuild-images job fails

Solution: use correct Makefile target to rebuild Hare docker images.