### PR TITLE
Problem: HAConsistencyException has no message attribute

### DIFF
--- a/hax/hax/exception.py
+++ b/hax/hax/exception.py
@@ -1,5 +1,7 @@
 class HaxAPIException(RuntimeError):
-    pass
+    def __init__(self, message: str):
+        super().__init__()
+        self.message = message
 
 
 class HAConsistencyException(HaxAPIException):


### PR DESCRIPTION
This prevents the fix #456 to work.

Solution: add message attribute explicitly to the exception class.


Closes #504 