### PR TITLE
Problem: hctl shutdown doesn't work on semi-started cluster

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -21,7 +21,10 @@ def processfid2str(fidk: int) -> str:
 
 def get_kv(c: Consul, key: str) -> str:
     kv: Dict[str, bytes] = c.kv.get(key)[1]
-    return kv['Value'].decode() if kv is not None else ''
+    if not kv:
+        return ''
+    val = kv['Value']
+    return val.decode() if val is not None else ''
 
 
 def processes_get(c: Consul) -> List[Process]:


### PR DESCRIPTION
I faced the following issue at my singlenode configuration:
```
sudo hctl shutdown
Traceback (most recent call last):
  File "/opt/seagate/hare/libexec/hare/hare-shutdown", line 108, in <module>
    sys.exit(main())
  File "/opt/seagate/hare/libexec/hare/hare-shutdown", line 96, in main
    leader = get_kv(c, 'leader')
  File "/opt/seagate/hare/libexec/hare/hare-shutdown", line 24, in get_kv
    return kv['Value'].decode() if kv is not None else ''
AttributeError: 'NoneType' object has no attribute 'decode'
```

Solution: assume that the requested key may not exist in `get_kv`
function.