### PR TITLE
Problem: logging for @repeat_if_fails is not informative

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -38,7 +38,7 @@ class ConsumerThread(Thread):
                             raise StopIteration()
                         item = pull_msg()
 
-                    logging.debug('Got something from the queue')
+                    logging.debug('Got %s message from queue', item)
                     if isinstance(item, EntrypointRequest):
                         ha_link = item.ha_link_instance
                         # While replying any Exception is catched. In such a

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -36,6 +36,7 @@ class KVHandler(BaseHTTPRequestHandler):
         ha_states = self.to_ha_states(KVHandler.parse_json(post_data))
         logging.info('HA states: %s', ha_states)
         self.server.halink.broadcast_ha_states(ha_states)
+        logging.debug('POST request processed')
 
     @staticmethod
     def parse_json(raw_data: bytes) -> Any:

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -50,9 +50,12 @@ def repeat_if_fails(wait_seconds=5):
         def wrapper(*args, **kwds):
             while (True):
                 try:
-                    logging.debug('Attempting to invoke the repeatable call')
+                    logging.debug(
+                        'Attempting to invoke the repeatable call: %s',
+                        f.__name__)
                     result = f(*args, **kwds)
-                    logging.debug('The repeatable call succeeded')
+                    logging.debug('The repeatable call succeeded: %s',
+                                  f.__name__)
                     return result
                 except HAConsistencyException as e:
                     logging.warn(
@@ -222,10 +225,12 @@ class ConsulUtil:
 
         try:
             # TODO [KN] improve type stubs!
+            data = json.dumps({'state': ha_process_events[event.chp_event]})
+            key = f'processes/{event.fid}'
+            logging.debug('Setting process status in KV: %s:%s', key, data)
             self.cns.kv.put(  # type: ignore
                 # This `type:` directive prevents mypy error:
                 #     "KV" has no attribute "put"
-                f'processes/{event.fid}',
-                json.dumps({'state': ha_process_events[event.chp_event]}))
+                key, data)
         except ConsulException as e:
             raise HAConsistencyException('Failed to put value to KV') from e


### PR DESCRIPTION
In the logs there are dozens of pairs like "Attempting to invoke the repeatable call" and "The repeatable call succeeded" but they give not that much of context.

Solution:
1. While logging, mention the names of the wrapped functions (given that it is pretty easy in Python).
2. Make logging around taking the messages from the blocking queue more
informative (get rid of opaque strings like "Got something from the
queue").