### PR TITLE
Problem: hare-status and hare-shutdown scripts crashes if kv[Value] is None

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -21,10 +21,7 @@ def processfid2str(fidk: int) -> str:
 
 def get_kv(c: Consul, key: str) -> str:
     kv: Dict[str, bytes] = c.kv.get(key)[1]
-    if not kv:
-        return ''
-    val = kv['Value']
-    return val.decode() if val is not None else ''
+    return kv['Value'].decode() if kv and kv['Value'] is not None else ''
 
 
 def processes_get(c: Consul) -> List[Process]:

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -18,7 +18,7 @@ def processfid2str(fidk: int) -> str:
 
 def get_kv(cns: Consul, key: str) -> str:
     kv: Dict[str, bytes] = cns.kv.get(key)[1]
-    return kv['Value'].decode() if kv is not None else ''
+    return kv['Value'].decode() if kv and kv['Value'] is not None else ''
 
 
 def leader_tag(cns: Consul, host: str) -> str:


### PR DESCRIPTION
Solution: `kv['Value'].decode() if kv and kv['Value'] is not None else ''`
add above line

Closes issue #513