### PR TITLE
Problem: test-boot* CI jobs refuse to terminate

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ variables:
   RPMSYNC_DIR:    "/releases/dev/$CI_PROJECT_PATH/$CI_COMMIT_REF_SLUG/B$CI_PIPELINE_ID"
   WORKSPACE_NAME: "${CI_PROJECT_NAME}${CI_PIPELINE_ID}"
   WORKSPACE_DIR:  "/home/gitlab-runner/workspaces/${CI_PROJECT_NAME}${CI_PIPELINE_ID}"
+  TEST_BOOT_TIMEOUT: 30  # max allowed duration of test-boot* job, in minutes
 
 stages:
   - build
@@ -51,42 +52,40 @@ test-utils:
   script: [ ci/test-utils ]
 
 # See https://docs.gitlab.com/ce/ci/yaml/README.html#anchors
-.after_script_template: &after_script_definition
-  - date -u -Isec
-  - cd $WORKSPACE_DIR
-  - /usr/bin/time hare/ci/collect-artifacts
+.test_boot_template: &test_boot_definition
+  stage: test
+  tags: [ m0vg ]
+  except: [ tags ]
+  script:
+    # `ci/expect-timeout` is only needed for GitLab < 12.3;
+    # see https://docs.gitlab.com/ee/ci/yaml/#timeout
+    - time ci/expect-timeout $((TEST_BOOT_TIMEOUT * 60)) ci/$CI_JOB_NAME
+  after_script:
+    - date -u -Isec
+    - cd $WORKSPACE_DIR
+    - /usr/bin/time hare/ci/collect-artifacts
 
-  # Clean up.  This ensures that VMs are destroyed in case of a manual
-  # job restart, when global 'cleanup' stage is not performed.
-  - $M0VG destroy -f || true
+    # Clean up.  This ensures that VMs are destroyed in case of a manual
+    # job restart, when global 'cleanup' stage is not performed.
+    - $M0VG destroy -f || true
 
-.artifacts_template: &artifacts_definition
-  name: "$CI_PROJECT_NAME job $CI_JOB_ID ($CI_JOB_NAME) logs"
-  when: always  # whenever the job has failed or succeeded
-  paths:
-    - ${CI_JOB_NAME}*consul*.log
-    - ${CI_JOB_NAME}*m0reportbug-data.tar.xz
-    # - ${CI_JOB_NAME}*m0reportbug-cores.tar.xz  # XXX too big
-    - ${CI_JOB_NAME}*m0reportbug-traces.tar.xz
-    - ${CI_JOB_NAME}*syslog.log
+  artifacts:
+    name: "${CI_PROJECT_NAME}_job${CI_JOB_ID}_${CI_JOB_NAME}"
+    when: always  # whenever the job has failed or succeeded
+    paths:
+      - ${CI_JOB_NAME}*consul*.log
+      - ${CI_JOB_NAME}*m0reportbug-data.tar.xz
+      # - ${CI_JOB_NAME}*m0reportbug-cores.tar.xz  # XXX too big
+      - ${CI_JOB_NAME}*m0reportbug-traces.tar.xz
+      - ${CI_JOB_NAME}*syslog.log
 
 test-boot1:
-  stage: test
-  tags: [ m0vg ]
-  except: [ tags ]
   variables: { M0VG: m0vg-1node/scripts/m0vg }
-  script: [ ci/test-boot1 ]
-  after_script: *after_script_definition
-  artifacts: *artifacts_definition
+  <<: *test_boot_definition
 
 test-boot2:
-  stage: test
-  tags: [ m0vg ]
-  except: [ tags ]
   variables: { M0VG: m0vg-2nodes/scripts/m0vg }
-  script: [ ci/test-boot2 ]
-  after_script: *after_script_definition
-  artifacts: *artifacts_definition
+  <<: *test_boot_definition
 
 # Cleanup ----------------------------------------------------------------- {{{1
 #
@@ -142,6 +141,5 @@ docker:rebuild-images:eos:
   extends: docker:rebuild-images
   variables:
     DOCKER_IMAGE_TAG: eos
-
 
 # vim: foldmethod=marker shiftwidth=2 tabstop=2 expandtab

--- a/ci/collect-artifacts
+++ b/ci/collect-artifacts
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
-set -x
+# set -x
 
 outdir=$CI_PROJECT_DIR
-rm -rf $outdir
-mkdir -p $outdir
 
 _m0vg="/usr/bin/time $M0VG"
 

--- a/ci/expect-timeout
+++ b/ci/expect-timeout
@@ -1,0 +1,32 @@
+#!/usr/bin/env expect
+
+set usage "Usage: $argv0 <timeout (seconds)> <program> \[<arguments>\]"
+
+proc die {msg {rc 1}} {
+    send_error "**ERROR** $msg\n"
+    exit $rc
+}
+
+switch -- [lindex $argv 0] {
+    {-h} -
+    {--help} {
+        puts $usage
+        exit
+    }
+}
+if {[llength $argv] < 2} {
+    puts stderr "Invalid command\n$usage"
+    exit 1
+}
+
+set timeout [lindex $argv 0]
+
+spawn sh -c [lrange $argv 1 end]
+expect {
+    {: test status: SUCCESS} {}
+    eof {}
+    timeout {die {Timed out!} 124}
+}
+
+set rc [lindex [wait] end]
+if {$rc != 0} {die "FAIL $rc" $rc}

--- a/ci/test-boot1
+++ b/ci/test-boot1
@@ -3,10 +3,12 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-. ci/common-defs.sh  # ci_m0vg_init
+. ci/common-defs.sh  # ci_m0vg_init, ci_success
 
 cd $WORKSPACE_DIR
 
 ci_m0vg_init cmu
-time $M0VG run /data/hare/ci/m0vg/init-node
-time $M0VG run /data/hare/ci/m0vg/test-boot1
+_time $M0VG run /data/hare/ci/m0vg/init-node
+_time $M0VG run /data/hare/ci/m0vg/test-boot1
+
+ci_success

--- a/ci/test-boot2
+++ b/ci/test-boot2
@@ -3,16 +3,18 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-. ci/common-defs.sh  # ci_m0vg_init, JOB_NAME
+. ci/common-defs.sh  # JOB_LABEL, ci_m0vg_init, ci_success
 
 cd $WORKSPACE_DIR
 
 ci_m0vg_init ssu1 ssu2
-time $M0VG run --vm ssu1 /data/hare/ci/m0vg/init-node
-time $M0VG run --vm ssu2 /data/hare/ci/m0vg/init-node
+_time $M0VG run --vm ssu1 /data/hare/ci/m0vg/init-node
+_time $M0VG run --vm ssu2 /data/hare/ci/m0vg/init-node
 
-sed -ri "s/(name:\s*)(ssu[12])/\\1${JOB_NAME}-\\2/" \
+sed -ri "s/(name:\s*)(ssu[12])/\\1${JOB_LABEL}-\\2/" \
     hare/cfgen/examples/ci-boot2{,-1confd}.yaml
 
-time $M0VG run --vm ssu1 \
-    "OTHER_HOST=${JOB_NAME}-ssu2 /data/hare/ci/m0vg/test-boot2"
+_time $M0VG run --vm ssu1 \
+    "OTHER_HOST=${JOB_LABEL}-ssu2 /data/hare/ci/m0vg/test-boot2"
+
+ci_success


### PR DESCRIPTION
Solution: use an Expect script to fail a test-boot* job if it runs
longer than $TEST_BOOT_TIMEOUT minutes.

Closes #359.
