### PR TITLE
Problem: CI shows environment variables unsorted

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ stages:
 before_script:
   - date -u -Isec
   - git log -1 --pretty=fuller
-  - printenv
+  - export
 
 after_script:
   - date -u -Isec


### PR DESCRIPTION
Solution: substitute `printenv` with GitLab's `export` command.

See https://docs.gitlab.com/ee/ci/variables/README.html#syntax-of-environment-variables-in-job-scripts