### PR TITLE
Problem: there are no provisioner hooks for Hare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,7 @@ install: install-dirs install-cfgen install-hax install-systemd install-vendor
 install-dirs: install-hax-dirs
 	@$(call _info,Installing directories)
 	@install --verbose --directory --mode=777 $(DESTDIR)/var/lib/hare
-	@install --verbose --directory $(DESTDIR)/var/log/hare
-	@for d in $(HARE_LIBEXEC) ; \
+	@for d in $(HARE_LIBEXEC) $(DESTDIR)/var/log/hare ; \
 	 do \
 	     install --verbose --directory $$d; \
 	 done
@@ -268,11 +267,8 @@ HAX_MODULE    = $(wildcard $(DESTDIR)/$(PREFIX)/lib64/python3.$(PY3_VERSION_MINO
 EASY_INST_PTH = $(DESTDIR)/$(PREFIX)/lib/python3.$(PY3_VERSION_MINOR)/site-packages/easy-install.pth
 
 .PHONY: uninstall
-uninstall: uninstall-hax
-
-.PHONY: uninstall-hax
-uninstall-hax:
-	@$(call _info,Un-installing hax)
+uninstall:
+	@$(call _info,Un-installing)
 	@for d in $(CFGEN_EXE) $(CFGEN_SHARE) \
 	          $(HAX_EXE) $(HAX_EGG_LINK) $(HAX_EGG) $(HAX_MODULE) \
 	          $(EASY_INST_PTH) \

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,5 @@
+# Hare utilities
+
+`prov-*` scripts are hooks for Provisioner.
+
+The rest are... misc.

--- a/utils/prov-config
+++ b/utils/prov-config
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+if (($# != 1)); then
+    cat >&2 <<EOF
+Usage: ${0##*/} CDF
+
+Required argument:
+  CDF  Path to the cluster description file.
+       Type 'cfgen --help-schema' for format description.
+EOF
+    exit 1
+fi
+
+# Generate configuration files and validate them by bootstrapping the cluster.
+hctl bootstrap --mkfs "$1"
+
+hctl shutdown

--- a/utils/prov-start
+++ b/utils/prov-start
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+exec hctl bootstrap --conf-dir /var/lib/hare

--- a/utils/prov-stop
+++ b/utils/prov-stop
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+exec hctl shutdown


### PR DESCRIPTION
Problem: there are no provisioner hooks for Hare

Provisioner is a software package that will be assembling various
software "components" (CSM, Hare, Mero, RAS, S3 Server) into
a coherent whole of EES system.  In order to do this, Provisioner
expects every component to provide a set of "hook scripts", each
hook script performing one of the predefined operations on the
component (e.g., configure, start, stop).

Solution: add `utils/prov-{config,start,stop}` hooks.

Relates to #527.
