### PR TITLE
Problem: EES-HA build-up script is missing

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+# set -x
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+
+PROG=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: $PROG --ip1 <addr> --ip2 <addr> <CDF>
+
+Configures EES-HA by preparing the configuration files and
+adding resources into the Pacemaker.
+
+Note: make sure the provided roaming IP addresses belong to
+the local sub-network and are not used by anyone else.
+
+Note2: for the script to work - make sure Pacemaker is
+started and the cluster is running.
+
+Note3: the script should be run from the pod-c1 node.
+
+Options:
+  --ip1 <addr>         1st roaming IP address
+  --ip2 <addr>         2nd roaming IP address.
+        <CDF>          Hare Cluster Description File
+
+EOF
+}
+
+TEMP=$(getopt --options h \
+              --longoptions help,ip1:,ip2: \
+              --name "$PROG" -- "$@" || true)
+
+(($? == 0)) || { usage >&2; exit 1; }
+
+eval set -- "$TEMP"
+
+ip1=
+ip2=
+
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        --ip1)               ip1=$2; shift 2 ;;
+        --ip2)               ip2=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
+
+cdf=${1:-}
+
+[[ $ip1 ]] && [[ $ip2 ]] && [[ $cdf ]] || {
+    usage >&2
+    exit 1
+}
+
+hare_dir=/var/lib/hare
+
+echo 'Adding the roaming IP addresses into Pacemaker...'
+sudo pcs resource create ip-c1 ocf:heartbeat:IPaddr2 \
+                               ip=$ip1 cidr_netmask=24 iflabel=c1 \
+                               op monitor interval=30s
+sudo pcs resource create ip-c2 ocf:heartbeat:IPaddr2 \
+                               ip=$ip2 cidr_netmask=24 iflabel=c2 \
+                               op monitor interval=30s
+sudo pcs constraint location ip-c1 prefers pod-c1
+sudo pcs constraint location ip-c2 prefers pod-c2
+
+echo 'Adding LNet...'
+sudo pcs resource create lnet systemd:lnet
+sudo pcs resource clone lnet
+sudo pcs constraint order lnet-clone then ip-c1
+sudo pcs constraint order lnet-clone then ip-c2
+
+cmd='
+sudo mkdir -p /usr/lib/ocf/resource.d/seagate &&
+sudo ln -sf /data/hare/pacemaker/lnet
+           /usr/lib/ocf/resource.d/seagate/lnet
+'
+pdsh -w pod-c[1-2] $cmd
+
+sudo pcs resource create lnet-c1 ocf:seagate:lnet \
+                                 iface=eth1:c1 op monitor interval=30s
+sudo pcs resource create lnet-c2 ocf:seagate:lnet \
+                                 iface=eth1:c2 op monitor interval=30s
+sudo pcs resource group add c1 ip-c1 lnet-c1
+sudo pcs resource group add c2 ip-c2 lnet-c2
+
+
+echo 'Preparing Hare configuration files...'
+mkfs_ext4() {
+    dev=$1
+    sudo mkfs.ext4 -q $dev &>/dev/null < <(echo y)
+}
+
+mkfs_ext4 /dev/sdb
+mkfs_ext4 /dev/sdc
+
+mkdir -p /var/mero && sudo mount /dev/sdb /var/mero
+ssh pod-c2 'mkdir -p /var/mero && sudo mount /dev/sdc /var/mero'
+
+hctl bootstrap --mkfs $cdf
+hctl shutdown
+
+for f in $hare_dir/{confd.xc,consul-kv.json}; do
+    sed -r -e 's/(102.tcp:12345:1):1/\1:2/' \
+           -e 's/(102.tcp:12345:2):1/\1:3/' \
+           -e 's/(102.tcp:12345:2):2/\1:4/' \
+           -e 's/(102.tcp:12345:4):1/\1:3/' \
+           -e 's/(102.tcp:12345:4):2/\1:4/' \
+        -i $f
+done
+
+hctl bootstrap -c $hare_dir/
+hctl shutdown
+
+sudo mkdir -p /var/mero2
+sudo mount /dev/sdc /var/mero2
+sudo ln -s /var/mero2/m0d-0x7200000000000001\:0x2? \
+           /var/mero/
+sudo umount /var/mero2
+sudo umount /var/mero
+
+cmd='
+sudo mkdir -p /var/mero1 &&
+sudo mount /dev/sdb /var/mero1 &&
+sudo ln -sf /var/mero1/m0d-0x7200000000000001\:0x?
+           /var/mero/ &&
+sudo umount /var/mero1 &&
+sudo umount /var/mero'
+ssh pod-c2 $cmd
+
+echo 'Preparing Consul agents config files...'
+cmd='
+sudo cp /usr/lib/systemd/system/hare-consul-agent.service
+        /usr/lib/systemd/system/hare-consul-agent-c1.service &&
+sudo cp /usr/lib/systemd/system/hare-consul-agent.service
+        /usr/lib/systemd/system/hare-consul-agent-c2.service &&
+for i in c{1,2}; do
+    sudo sed "s/consul-env/&-$i/"
+             -i /usr/lib/systemd/system/hare-consul-agent-$i.service &&
+    sudo sed "/ExecStart=/aExecStartPost=/bin/sleep 5"
+             -i /usr/lib/systemd/system/hare-consul-agent-$i.service;
+done'
+pdsh -w pod-c[1-2] $cmd
+
+cmd_deregister_node() {
+    node=$1
+    echo "/usr/bin/curl -i -X PUT -d '{\\\"Node\\\":\\\"$node\\\"}' 'http://localhost:8500/v1/catalog/deregister'"
+}
+
+consul_c2_cfg_dir=$hare_dir/consul-$ip2
+consul_c1_cfg_dir=$hare_dir/consul-$ip1
+
+sudo sed \
+ -e "/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c2_cfg_dir" \
+ -e '/ExecStart=/iExecStartPre=/opt/seagate/hare/bin/consul force-leave pod-c2' \
+ -e "/ExecStartPost=/aExecStartPost=$(cmd_deregister_node pod-c2)" \
+ -i /usr/lib/systemd/system/hare-consul-agent-c2.service
+sudo systemctl daemon-reload
+
+cmd="
+sudo sed
+ -e '/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c1_cfg_dir'
+ -e '/ExecStart=/iExecStartPre=/opt/seagate/hare/bin/consul force-leave pod-c1'
+ -e \"/ExecStartPost=/aExecStartPost=$(cmd_deregister_node pod-c1)\"
+ -i /usr/lib/systemd/system/hare-consul-agent-c1.service &&
+sudo systemctl daemon-reload"
+ssh pod-c2 $cmd
+
+sudo cp $hare_dir/consul-env $hare_dir/consul-env-c1
+sudo scp pod-c2:$hare_dir/consul-env $hare_dir/consul-env-c2
+sudo sed -r \
+  -e 's/server$/server-c1/' \
+  -e "s/JOIN=/&-retry-join $ip2 /" \
+  -i $hare_dir/consul-env-c1
+sudo sed -r \
+  -e 's/server$/server-c2/' \
+  -e 's/127.0.0.1 //' \
+  -i $hare_dir/consul-env-c2
+
+cmd="
+sudo cp $hare_dir/consul-env $hare_dir/consul-env-c2 &&
+sudo scp pod-c1:$hare_dir/consul-env $hare_dir/consul-env-c1 &&
+sudo sed -r \
+  -e 's/server$/server-c1/' \
+  -e 's/127.0.0.1 //' \
+  -e 's/JOIN=/&-retry-join $ip2 /' \
+  -e 's/ -bootstrap-expect 1//' \
+  -i $hare_dir/consul-env-c1 &&
+sudo sed -r \
+  -e 's/server$/server-c2/' \
+  -i $hare_dir/consul-env-c2"
+ssh pod-c2 $cmd
+
+sudo cp $hare_dir/consul-server-conf.json \
+        $hare_dir/consul-server-c1-conf.json
+sudo sed -e 's/"--hax"/"--svc", "hare-hax-c1"/' \
+         -i $hare_dir/consul-server-c1-conf.json
+cp $hare_dir/consul-server-c1-conf.json \
+   /tmp/consul-server-c1-conf.json
+sudo sed -e '/server/a\ \ "node_name": "pod-c1",' \
+         -e '/server/a\ \ "leave_on_terminate": true,' \
+         -i /tmp/consul-server-c1-conf.json
+sudo scp /tmp/consul-server-c1-conf.json pod-c2:$hare_dir/
+
+cmd="
+sudo cp $hare_dir/consul-server-conf.json \
+        $hare_dir/consul-server-c2-conf.json &&
+sudo sed -e 's/\"--hax\"/\"--svc\", \"hare-hax-c2\"/' \
+         -i $hare_dir/consul-server-c2-conf.json &&
+cp $hare_dir/consul-server-c2-conf.json \
+   /tmp/consul-server-c2-conf.json &&
+sudo sed -e '/server/a\ \ \"node_name\": \"pod-c2\",' \
+         -e '/server/a\ \ \"leave_on_terminate\": true,' \
+         -i /tmp/consul-server-c2-conf.json &&
+sudo scp /tmp/consul-server-c2-conf.json pod-c1:$hare_dir/"
+ssh pod-c2 $cmd
+
+echo 'Adding Consul to Pacemaker...'
+sudo pcs resource create consul-c1 systemd:hare-consul-agent-c1
+sudo pcs resource create consul-c2 systemd:hare-consul-agent-c2
+sudo pcs resource group add c1 consul-c1
+sudo pcs resource group add c2 consul-c2
+
+echo 'Adding Mero kernel module to Pacemaker...'
+sudo pcs resource create mero-kernel systemd:mero-kernel
+sudo pcs resource clone mero-kernel
+sudo pcs constraint order lnet-c1 then mero-kernel-clone
+sudo pcs constraint order lnet-c2 then mero-kernel-clone
+
+echo 'Adding Hax to Pacemaker...'
+
+get_sd_id() {
+    sd_name=$1
+    ls -l /dev/disk/by-id/ | grep "$sd_name$" | head -1 | awk '{print $9}'
+}
+
+sdb="/dev/disk/by-id/$(get_sd_id sdb)"
+sdc="/dev/disk/by-id/$(get_sd_id sdc)"
+
+sudo cp /usr/lib/systemd/system/hare-hax.service \
+        /usr/lib/systemd/system/hare-hax-c1.service
+sudo cp /usr/lib/systemd/system/hare-hax.service \
+        /usr/lib/systemd/system/hare-hax-c2.service
+sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
+         -e "/ExecStart=/iExecStartPre=/bin/mount $sdb /var/mero" \
+         -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero' \
+         -i /usr/lib/systemd/system/hare-hax-c1.service
+sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
+         -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2' \
+         -e "/ExecStart=/iExecStartPre=/bin/mount $sdc /var/mero2" \
+         -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero2' \
+         -i /usr/lib/systemd/system/hare-hax-c2.service
+echo 'HARE_HAX_NODE_NAME=pod-c2' | sudo tee $hare_dir/hax-env-c2 > /dev/null
+
+cmd="
+sudo cp /usr/lib/systemd/system/hare-hax.service
+        /usr/lib/systemd/system/hare-hax-c1.service &&
+sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/'
+         -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
+         -e '/ExecStart=/iExecStartPre=/bin/mount $sdb /var/mero1'
+         -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero1'
+         -i /usr/lib/systemd/system/hare-hax-c1.service &&
+sudo cp /usr/lib/systemd/system/hare-hax.service
+        /usr/lib/systemd/system/hare-hax-c2.service &&
+sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
+         -e '/ExecStart=/iExecStartPre=/bin/mount $sdc /var/mero'
+         -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero'
+         -i /usr/lib/systemd/system/hare-hax-c2.service &&
+echo 'HARE_HAX_NODE_NAME=pod-c1' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
+ssh pod-c2 $cmd
+
+sudo pcs resource create hax-c1 systemd:hare-hax-c1
+sudo pcs resource create hax-c2 systemd:hare-hax-c2
+sudo pcs resource group add c1 hax-c1
+sudo pcs resource group add c2 hax-c2
+sudo pcs constraint order mero-kernel-clone then hax-c1
+sudo pcs constraint order mero-kernel-clone then hax-c2
+sudo pcs constraint order consul-c2 then hax-c1
+sudo pcs constraint order consul-c1 then hax-c2
+
+echo 'Adding Mero to Pacemaker...'
+cmd='
+sudo sed 's/TimeoutStopSec=.*/TimeoutStopSec=15sec/'
+         -i /usr/lib/systemd/system/m0d@.service &&
+sudo systemctl daemon-reload'
+pdsh -w pod-c[1-2] $cmd
+
+get_fid() {
+    cfg=$1
+    svc=$2
+    cat $cfg | jq -r '.services[] | "\(.name) \(.checks[].args[])"' |
+        grep "${svc}.0x" | awk '{print $2}'
+}
+
+confd_c1_fid=$(get_fid $hare_dir/consul-server-c1-conf.json confd)
+confd_c2_fid=$(get_fid $hare_dir/consul-server-c2-conf.json confd)
+ios_c1_fid=$(get_fid $hare_dir/consul-server-c1-conf.json ios)
+ios_c2_fid=$(get_fid $hare_dir/consul-server-c2-conf.json ios)
+
+sudo pcs cluster cib mcfg
+sudo pcs -f mcfg resource create mero-confd-c1 \
+                 systemd:m0d@$confd_c1_fid op stop timeout=600
+sudo pcs -f mcfg resource create mero-ios-c1 \
+                 systemd:m0d@$ios_c1_fid op stop timeout=600
+sudo pcs -f mcfg resource group add c1 mero-confd-c1
+sudo pcs -f mcfg resource group add c1 mero-ios-c1
+sudo pcs -f mcfg resource create mero-confd-c2 \
+                 systemd:m0d@$confd_c2_fid op stop timeout=600
+sudo pcs -f mcfg resource create mero-ios-c2 \
+                 systemd:m0d@$ios_c2_fid op stop timeout=600
+sudo pcs -f mcfg resource group add c2 mero-confd-c2
+sudo pcs -f mcfg resource group add c2 mero-ios-c2
+sudo pcs -f mcfg constraint order mero-confd-c1 then mero-ios-c2
+sudo pcs -f mcfg constraint order mero-confd-c2 then mero-ios-c1
+sudo pcs cluster cib-push mcfg --config
+


### PR DESCRIPTION
Solution: introduce the `build-ees-ha` script which builds-up
the EES-HA Pacemaker-based setup on m0vg pod-c1/2 nodes.

Here is the example output:

```
[vagrant@pod-c1 ~]$ ./build-ees-ha
Usage: build-ees-ha --ip1 <addr> --ip2 <addr> <CDF>

Configures EES-HA by preparing the configuration files and
adding resources into the Pacemaker.

Note: make sure the provided roaming IP addresses belong to
the local sub-network and are not used by anyone else.

Note2: for the script to work - make sure Pacemaker is
started and the cluster is running.

Note3: the script should be run from the pod-c1 node.

Options:
  --ip1 <addr>         1st roaming IP address
  --ip2 <addr>         2nd roaming IP address.
        <CDF>          Hare Cluster Description File

[vagrant@pod-c1 ~]$ ./build-ees-ha --ip1 192.168.151.101 --ip2 192.168.151.102 ees-cluster.yaml
Adding the roaming IP addresses into Pacemaker...
Adding LNet...
Adding lnet-clone ip-c1 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding lnet-clone ip-c2 (kind: Mandatory) (Options: first-action=start then-action=start)
Preparing Hare configuration files...
2019-12-11 19:55:03: Generating cluster configuration... Ok.
2019-12-11 19:55:05: Starting Consul server agent on this node.......... Ok.
2019-12-11 19:55:13: Importing configuration into the KV Store... Ok.
2019-12-11 19:55:13: Starting Consul agents on remaining cluster nodes.... Ok.
2019-12-11 19:55:14: Update Consul agents configs from the KV Store... Ok.
2019-12-11 19:55:15: Waiting for the RC Leader to be elected...... Ok.
2019-12-11 19:55:19: Starting Mero (phase1)... Ok.
2019-12-11 19:55:29: Starting Mero (phase2)... Ok.
2019-12-11 19:55:39: Checking the health of the services... Ok.
Stopping ios (m0d@0x7200000000000001:0x2b) on pod-c2...done
Stopping confd (m0d@0x7200000000000001:0x28) on pod-c2...done
Stopping hare-consul-agent (hare-consul-agent) on pod-c2...done
Stopping ios (m0d@0x7200000000000001:0xc) on pod-c1...done
Stopping confd (m0d@0x7200000000000001:0x9) on pod-c1...done
Stopping hare-consul-agent (hare-consul-agent) on pod-c1...done
Stopping consul watcher on pod-c1...done
2019-12-11 19:55:59: Starting Consul server agent on this node........... Ok.
2019-12-11 19:56:08: Importing configuration into the KV Store... Ok.
2019-12-11 19:56:08: Starting Consul agents on remaining cluster nodes.... Ok.
2019-12-11 19:56:10: Update Consul agents configs from the KV Store... Ok.
2019-12-11 19:56:11: Waiting for the RC Leader to be elected..... Ok.
2019-12-11 19:56:13: Starting Mero (phase1)... Ok.
2019-12-11 19:56:14: Starting Mero (phase2)... Ok.
2019-12-11 19:56:15: Checking the health of the services... Ok.
Stopping ios (m0d@0x7200000000000001:0xc) on pod-c1...done
Stopping confd (m0d@0x7200000000000001:0x9) on pod-c1...done
Stopping hare-consul-agent (hare-consul-agent) on pod-c1...done
Stopping ios (m0d@0x7200000000000001:0x2b) on pod-c2...done
Stopping confd (m0d@0x7200000000000001:0x28) on pod-c2...done
Stopping hare-consul-agent (hare-consul-agent) on pod-c2...done
Stopping consul watcher on pod-c2...done
Preparing Consul agents config files...
consul-env                                      100%  136    80.8KB/s   00:00
consul-server-c1-conf.json                      100% 2128     1.7MB/s   00:00
Adding Consul to Pacemaker...
Adding Mero kernel module to Pacemaker...
Adding lnet-c1 mero-kernel-clone (kind: Mandatory) (Options: first-action=start then-action=start)
Adding lnet-c2 mero-kernel-clone (kind: Mandatory) (Options: first-action=start then-action=start)
Adding Hax to Pacemaker...
Adding mero-kernel-clone hax-c1 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding mero-kernel-clone hax-c2 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding consul-c2 hax-c1 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding consul-c1 hax-c2 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding Mero to Pacemaker...
Adding mero-confd-c1 mero-ios-c2 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding mero-confd-c2 mero-ios-c1 (kind: Mandatory) (Options: first-action=start then-action=start)
CIB updated
[vagrant@pod-c1 ~]$ sudo pcs status
Cluster name: ees_cluster
Stack: corosync
Current DC: pod-c2 (version 1.1.19-8.el7_6.4-c3c624ea3d) - partition with quorum
Last updated: Wed Dec 11 19:57:41 2019
Last change: Wed Dec 11 19:56:56 2019 by root via cibadmin on pod-c1

2 nodes configured
16 resources configured

Online: [ pod-c1 pod-c2 ]

Full list of resources:

 Clone Set: lnet-clone [lnet]
     Started: [ pod-c1 pod-c2 ]
 Resource Group: c1
     ip-c1	(ocf::heartbeat:IPaddr2):	Started pod-c1
     lnet-c1	(ocf::seagate:lnet):	Started pod-c1
     consul-c1	(systemd:hare-consul-agent-c1):	Started pod-c1
     hax-c1	(systemd:hare-hax-c1):	Started pod-c1
     mero-confd-c1	(systemd:m0d@0x7200000000000001:0x9):	Started pod-c1
     mero-ios-c1	(systemd:m0d@0x7200000000000001:0xc):	Started pod-c1
 Resource Group: c2
     ip-c2	(ocf::heartbeat:IPaddr2):	Started pod-c2
     lnet-c2	(ocf::seagate:lnet):	Started pod-c2
     consul-c2	(systemd:hare-consul-agent-c2):	Started pod-c2
     hax-c2	(systemd:hare-hax-c2):	Started pod-c2
     mero-confd-c2	(systemd:m0d@0x7200000000000001:0x28):	Started pod-c2
     mero-ios-c2	(systemd:m0d@0x7200000000000001:0x2b):	Started pod-c2
 Clone Set: mero-kernel-clone [mero-kernel]
     Started: [ pod-c1 pod-c2 ]

Daemon Status:
  corosync: active/disabled
  pacemaker: active/disabled
  pcsd: active/enabled
```