### PR TITLE
Problem: 'make clean' shows warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ clean: clean-hax clean-mypy clean-dhall-prelude
 .PHONY: clean-hax
 clean-hax:
 	@$(call _info,Cleaning hax)
-	@for d in hax/build/ hax/dist/ hax/hax.egg-info/ hax/*.so ; do \
+	@for d in hax/build hax/dist hax/hax.egg-info hax/*.so \
+	          hax/hax/__pycache__; do \
 	     if [[ -e $$d ]]; then \
 	         $(call _log,removing $$d); \
 	         rm -rf $$d; \

--- a/cfgen/Makefile
+++ b/cfgen/Makefile
@@ -2,7 +2,8 @@ SHELL = bash
 
 PYTHON_SCRIPTS = cfgen
 
-M0CONFGEN := $(if $(shell which m0confgen),m0confgen,../../mero/utils/m0confgen)
+M0CONFGEN := $(if\
+ $(shell which m0confgen 2>/dev/null),m0confgen,../../mero/utils/m0confgen)
 
 dhall-lang-version := $(shell readlink ../vendor/dhall-prelude/current)
 dhall-lang-dir := dhall/dhall-lang-$(dhall-lang-version)


### PR DESCRIPTION
```
$ make clean
[...]
make --quiet -C cfgen clean-dhall-prelude
which: no m0confgen in (/opt/rh/sclo-git212/root/usr/bin:/home/vagrant/bin:/home/
vagrant/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
```

Solution: redirect stderr output of `which m0confgen` to /dev/null.