### PR TITLE
Problem: misleading msg about Consul leader on shutdown

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -96,7 +96,7 @@ def main() -> None:
     for svc in shutdown_sequence:
         for proc in processes[svc]:
             process_stop(proc)
-    print(f'Killing Consul leader at {leader_node}... ', end='', flush=True)
+    print(f'Killing RC Leader at {leader_node}... ', end='', flush=True)
     exec(ssh_prefix(leader_node) + 'sudo pkill --exact -KILL consul')
 
 


### PR DESCRIPTION
At the last step of the shutdown we kill not the Consul leader,
but our RC Leader watch handler.

Solution: fix the msg printout.