### PR TITLE
Problem: 'cleanup' CI job downloads unneeded files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ cleanup:
     # commit. Cloning 30 latest commits seems to be good enough - it's quite
     # rare for people to push more than 30 new commits in one go.
     GIT_DEPTH: 30
+    GIT_SUBMODULE_STRATEGY: none
 
   script:
     - cd $WORKSPACE_DIR


### PR DESCRIPTION
Solution: don't let `cleanup` job download git submodules.
Downloading takes time and that data is not needed anyway.