### PR TITLE
Problem: CI wastes time collecting unneeded artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,9 +63,16 @@ rpmbuild:
   tags: [ m0vg ]
   except: [ tags ]
   script:
+    - errno_file=$WORKSPACE_DIR/hare/ci/_$CI_JOB_NAME.errno
+    - rm -f $errno_file
     # `ci/expect-timeout` is only needed for GitLab < 12.3;
     # see https://docs.gitlab.com/ee/ci/yaml/#timeout
-    - time ci/expect-timeout $((TEST_BOOT_TIMEOUT * 60)) ci/$CI_JOB_NAME
+    - |
+      rc=0
+      time ci/expect-timeout $((TEST_BOOT_TIMEOUT * 60)) ci/$CI_JOB_NAME ||
+          rc=$?
+      ((rc == 0)) || echo $rc >$errno_file
+      exit $rc
   after_script:
     - date -u -Isec
     - cd $WORKSPACE_DIR
@@ -77,7 +84,7 @@ rpmbuild:
 
   artifacts:
     name: "${CI_PROJECT_NAME}_job${CI_JOB_ID}_${CI_JOB_NAME}"
-    when: always  # whenever the job has failed or succeeded
+    when: always
     paths:
       - ${CI_JOB_NAME}*consul*.log
       - ${CI_JOB_NAME}*m0reportbug-data.tar.xz

--- a/ci/collect-artifacts
+++ b/ci/collect-artifacts
@@ -21,14 +21,17 @@ for vm in $($M0VG status | awk '$2 == "running" {print $1}'); do
     $M0VG run --vm $vm sudo systemctl --all --full --no-pager status \
           {hare,m0,mero,s3}\\* >$outdir/systemctl-status.txt || true
 
-    say 'Consul logs'
-    $M0VG scp $vm:/var/log/hare/consul\*.log $outdir/ &>/dev/null
+    if [[ -e hare/ci/_$CI_JOB_NAME.errno ]]; then
+        say 'Consul logs'
+        $M0VG scp $vm:/var/log/hare/consul\*.log $outdir/ &>/dev/null
 
-    say 'm0reportbug'
-    $M0VG run --vm $vm sudo ${MERO_COMMIT_REF:+/data/mero/utils/}m0reportbug
-    $M0VG scp $vm:m0reportbug-\*.tar.xz $outdir/
-
+        say 'm0reportbug'
+        $M0VG run --vm $vm \
+              sudo ${MERO_COMMIT_REF:+/data/mero/utils/}m0reportbug
+        $M0VG scp $vm:m0reportbug-\*.tar.xz $outdir/
+    fi
     say
+
     cd $outdir
     for f in {syslog,systemctl,consul,m0reportbug}*; do
         [[ -e $f ]] && mv {,${CI_JOB_NAME}_${vm}_}$f


### PR DESCRIPTION
Collection of CI artifacts takes up to 8 minutes; most of the time is
spent generating m0reportbug archives.  Those archives are only needed
for failed CI jobs.

Solution:
* collect Consul logs and m0reportbug archives
  iff CI job has failed
  or (CI_PROJECT_PATH == 'mero/hare' and CI_COMMIT_REF_NAME == 'master');
* collect syslogs unconditionally.
