### PR TITLE
Problem: progress of m0reportbug is not shown

### DIFF
--- a/ci/collect-artifacts
+++ b/ci/collect-artifacts
@@ -9,6 +9,7 @@ say() {
 
 outdir=$CI_PROJECT_DIR
 
+# XXX-TODO Collect artifacts from different hosts in parallel.
 for vm in $($M0VG status | awk '$2 == "running" {print $1}'); do
     echo "----- $vm -----"
 
@@ -20,9 +21,8 @@ for vm in $($M0VG status | awk '$2 == "running" {print $1}'); do
     $M0VG scp $vm:/var/log/hare/consul\*.log $outdir/ &>/dev/null
 
     say 'm0reportbug'
-    $M0VG run --vm $vm sudo ${MERO_COMMIT_REF:+/data/mero/utils/}m0reportbug \
-          &>/dev/null
-    $M0VG scp $vm:m0reportbug-\*.tar.xz $outdir/ &>/dev/null
+    $M0VG run --vm $vm sudo ${MERO_COMMIT_REF:+/data/mero/utils/}m0reportbug
+    $M0VG scp $vm:m0reportbug-\*.tar.xz $outdir/
 
     say
     cd $outdir


### PR DESCRIPTION
`m0reportbug` runs for minutes without any visibility on what it does.

Solution: show output of m0reportbug, don't redirect it to /dev/null.