### PR TITLE
Problem: wait_m0d_started() may return false positive

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -98,7 +98,7 @@ wait_m0d_started() {
     local timeout=$2  # seconds
     local count=0
 
-    while ! sudo systemctl status "m0d@$fid" | grep -q 'Started'; do
+    while ! sudo systemctl status "m0d@$fid" | grep -q ': Started$'; do
         (($count < $timeout)) || die "Unable to start m0d@$fid service"
         sleep 1
         ((++count))


### PR DESCRIPTION
wait_m0d_started() function at bootstrap-node script may return
false positive result sometimes. It is because we check for the
'Started' word fingerprint from the m0d process which may be
mixed with the 'Started m0d helper' from systemd.

Solution: improve regular expression for the check.