### PR TITLE
Problem: race in HA state notifications between m0d and m0mkfs

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -141,9 +141,13 @@ for id in $IDs; do
     if [[ $do_mkfs ]]; then
         sudo systemctl start mero-mkfs@$fid
         touch /tmp/mero-mkfs-pass-$fid
-        # Give time for service check to reset m0mkfs' HA state:
-        # (1s * 2) - time of two checks + 1s. (See check-service.)
-        sleep 3
+        # Give time for service check to reset m0mkfs' HA state
+        # (see utils/check-service).
+        while [[ -f /tmp/mero-mkfs-pass-$fid ||
+                 -f /tmp/mero-mkfs-fail-$fid ]]; do
+            sleep 1
+        done
+        sleep 1
     fi
 
     if [[ $do_mkfs != 'mkfs-only' ]]; then


### PR DESCRIPTION
It is possible that m0d process is started before the 'offline'
HA state notification for its m0mkfs process is sent by Consul.
Sometimes due to a system delays or Consul leader loss the 3
seconds delay we wait now before starting m0d may be not enough.

Solution: check that the helper files we create for m0mkfs HA
state notifications (/tmp/mero-mkfs-{pass,fail}-$fid) do not
exist already before starting m0d. Thus we make sure that
Consul has called the utils/check-service checker script for
the last m0mkfs' HA notification.

Closes #565.