### PR TITLE
Problem: race in HA notification between m0d and m0mkfs is still possible

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -142,9 +142,10 @@ for id in $IDs; do
         sudo systemctl start mero-mkfs@$fid
         touch /tmp/mero-mkfs-pass-$fid
         # Give time for service check to reset m0mkfs' HA state
-        # (see utils/check-service).
+        # (see utils/check-service also).
         while [[ -f /tmp/mero-mkfs-pass-$fid ||
-                 -f /tmp/mero-mkfs-fail-$fid ]]; do
+                 -f /tmp/mero-mkfs-fail-$fid ]] ||
+              ! consul kv get processes/$fid | grep -q 'STOPPED'; do
             sleep 1
         done
         sleep 1


### PR DESCRIPTION
The race described at commit 8691651d3 is still possible due to
delays in sending HA notifications by Consul even after the
check handler was invoked.

Solution: add additional check for the process status by
analysing its status in the KV Store at `processes/$fid` also
before staring m0d. The value there is updated by `hax`
when Consul broadcasts the new HA states already.

Closes #565.