### PR TITLE
Problem: `hare bootstrap` hungs if cluster is running

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -22,6 +22,11 @@ Options:
 EOF
 }
 
+die() {
+    echo "$PROG: $*" >&2
+    exit 1
+}
+
 say() {
     echo -n "$(date '+%F %T'): $*"
 }
@@ -104,6 +109,10 @@ done
 
 cluster_descr=${1:-}
 cfgen_out=${conf_dir:-'/var/lib/hare'}
+
+if sudo systemctl --quiet is-active hare-consul-agent; then
+    die 'Consul agent is active ==> cluster is already running'
+fi
 
 if ! [[ $conf_dir ]]; then
     say 'Generating cluster configuration... '


### PR DESCRIPTION
Solution:
if the cluster is already running then `hctl bootstrap` command
should exit with the message.

Closes #588