### PR TITLE
Problem: early m0d startup timeout

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -154,7 +154,7 @@ for id in $IDs; do
     if [[ $do_mkfs != 'mkfs-only' ]]; then
         sudo systemctl start $proc$fid
         if [[ $proc == 'm0d@' ]]; then
-            wait_m0d_started $fid 30
+            wait_m0d_started $fid 120
         fi
     fi
 done


### PR DESCRIPTION
m0d startup may take much longer than 30 secs timeout
we wait currently (especially on slow CI VMs).

Solution: increase the waiting timeout to 2 minutes.