### PR TITLE
Problem: provisioner's script is wrongly named

### DIFF
--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -3,11 +3,11 @@ hare:
     script: null
     args: null
   init:
+    script: /opt/seagate/eos/hare/libexec/prov-init
+    args: /var/lib/hare/cluster.yaml
+  config:
     script: null
     args: null
-  config:
-    script: /opt/seagate/eos/hare/libexec/config
-    args: /var/lib/hare/cluster.yaml
   test:
     script: null
     args: null

--- a/utils/prov-init
+++ b/utils/prov-init
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e -o pipefail
+set -eu -o pipefail
 
 if (($# != 1)); then
     cat >&2 <<EOF


### PR DESCRIPTION
Solution:
- move the script to "init" section of `provisioning/setup.yaml`;
- add `prov-` prefix to the script name to make it distinguishable.

[ci skip]