### PR TITLE
Problem: false positive service status check on startup

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -281,7 +281,7 @@ count=1
 for svc in confd ios s3service; do
     svc_not_ready=$(check_service $svc)
     while [[ $svc_not_ready ]]; do
-        if (( $count > 5 )); then
+        if (( $count > 30 )); then
             echo $svc_not_ready >&2
             echo "Check '$svc' service on the node(s) listed above." >&2
             exit 1


### PR DESCRIPTION
s3server startup, for example, may take longer that 5 secons
(our maximum check time currently), especially on CI VMs.

Solution: increase the check time to 30 seconds.