### PR TITLE
Problem: yum repository URL in README.md is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fi
   if ! rpm -q hare s3server; then
       if ! sudo yum install -y hare s3server; then
           repo='ci-storage.mero.colo.seagate.com'
-          repo+='/releases/eos/'integration/last_successful'
+          repo+='/releases/eos/integration/centos-7.7.1908/last_successful'
           yum-config-manager --add-repo="http://$repo"
           sudo tee -a /etc/yum.repos.d/${repo//\//_}.repo <<< 'gpgcheck=0'
           unset repo


### PR DESCRIPTION
My was unable to fix yum repository URL from the first try: left
unneded quote in it and referred to the CentOS 7.5 directory instead
of CentOS 7.7.

Solution: fix the URL.

[ci skip]