### PR TITLE
Problem: `hctl status` crashes if consul leader not found

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -7,7 +7,7 @@ import sys
 from socket import gethostname
 from typing import Dict, List, NamedTuple, Set
 
-from consul import Consul
+from consul import Consul, ConsulException
 
 Process = NamedTuple('Process', [('name', str), ('fidk', int), ('ep', str)])
 
@@ -109,4 +109,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except ConsulException as err:
+        print("Consul Error: %s" % err)


### PR DESCRIPTION
`hare-status` script does not handle consul.base.ConsulException

Solution: catch **consul.base.ConsulException** in `hare-status` script and
print apropriate error.

Closes #594