### PR TITLE
Problem: provisioned Hare is not cocky enough

### DIFF
--- a/utils/prov-init
+++ b/utils/prov-init
@@ -15,4 +15,5 @@ fi
 # Generate configuration files and validate them by bootstrapping the cluster.
 hctl bootstrap --mkfs "$1"
 
+hctl status
 hctl shutdown


### PR DESCRIPTION
Solution: update `prov-init` script to show `hctl status` output
after the cluster is started (by Provisioner).

[ci skip]