### PR TITLE
Problem: hax can't access KV if Consul leader is lost

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -81,7 +81,11 @@ class ConsulUtil:
         we want to invoke Consul.kv.get()
         """
         assert key
-        return self.cns.kv.get(key, **kwargs)[1]
+        try:
+            return self.cns.kv.get(key, **kwargs)[1]
+        except ConsulException as e:
+            raise HAConsistencyException('Could not access Consul KV')\
+                from e
 
     def _catalog_service_get(self, svc_name: str) -> List[Dict[str, Any]]:
         try:


### PR DESCRIPTION
The call to `consul.kv.get()` will raise an exception which is not
handled by hax so far. The fix makes this call repeatable, so hax will
tolerate this kind of Consul outage.

Closes #591