### PR TITLE
Problem: Hax service port (8080) conflict with haproxy monitoring port.

### DIFF
--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -66,9 +66,9 @@ class KVHandler(BaseHTTPRequestHandler):
 
 def run_server(thread_to_wait=None,
                server_class=HTTPServer,
-               port=8080,
+               port=8008,
                halink=None):
-    port = 8080
+    port = 8008
     addr = ConsulUtil().get_hax_ip_address()
     server_address: Tuple[str, int] = (addr, port)
     httpd = server_class(server_address, KVHandler)


### PR DESCRIPTION
Hare bootstrap with S3 server failed because of hax service port (8080)
conflict with haproxy monitoring port.

Solution: Change Hax service port to (8008).

Closes #623 