### PR TITLE
Problem: cfgen error messages are anonymous

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Set, \
 import yaml
 
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 
 def parse_opts(argv):
@@ -137,7 +137,7 @@ def main(argv=None):
 def die(msg: str, status: int = 1):
     assert msg
     assert status != 0
-    print(msg, file=sys.stderr)
+    print(os.path.basename(sys.argv[0]) + ': ' + msg, file=sys.stderr)
     sys.exit(status)
 
 


### PR DESCRIPTION
The error message in #638 puzzles the reader.
```
$ hctl bootstrap --mkfs /tmp/CDF.yaml
2020-01-22 05:18:05: Generating cluster configuration... '-o' argument must be a path to writable directory
```
There is no "'-o' argument" in the command being executed.

Solution: prefix error messages with `cfgen: `.

Closes #639.