### PR TITLE
Problem: `hctl bootstrap` hangs after non-clean shutdown

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -144,6 +144,19 @@ read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
 
 [[ $join_ip ]] || die 'Bootstrap should be run from a server node only'
 
+m0d_services=$(systemctl list-units 'm0d@*' | awk '/^m0d@/ { print $1 }')
+for svc in $m0d_services hare-{hax,consul-agent}.service; do
+    if sudo systemctl is-failed --quiet --state=failed $svc; then
+        cat <<EOF >&2
+*WARNING* $svc is in failed state.
+To see details, type
+    systemctl status $svc
+To reset the "failed" state, type
+    sudo systemctl reset-failed $svc
+EOF
+    fi
+done
+
 say 'Starting Consul server agent on this node...'
 # $join_ip is our bind_ip address
 mk-consul-env --mode server --bind $join_ip \


### PR DESCRIPTION
Solution:
        Check m0d, hare-hax, hare-consul-agent service status
        before bootstrapping cluster, if any of the services are
        in the failed state then warn the user about it.

Closes #631