### PR TITLE
Problem: build-ees-ha script cannot be used on a real HW

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -7,7 +7,7 @@ PROG=${0##*/}
 
 usage() {
     cat <<EOF
-Usage: $PROG --ip1 <addr> --ip2 <addr> <CDF>
+Usage: $PROG [OPTS] --ip1 <addr> --ip2 <addr> <CDF>
 
 Configures EES-HA by preparing the configuration files and
 adding resources into the Pacemaker.
@@ -18,18 +18,23 @@ the local sub-network and are not used by anyone else.
 Note2: for the script to work - make sure Pacemaker is
 started and the cluster is running.
 
-Note3: the script should be run from the pod-c1 node.
+Note3: the script should be run from the "left" node.
 
-Options:
+Mandatory Parameters:
   --ip1 <addr>         1st roaming IP address
   --ip2 <addr>         2nd roaming IP address.
         <CDF>          Hare Cluster Description File
 
+Options:
+  -i, --interface <if>  Data Network interface (default: eth1)
+  --left-node  <n1>     Left Node hostname  (default: pod-c1)
+  --right-node <n2>     Right Node hostname (default: pod-c2)
+
 EOF
 }
 
-TEMP=$(getopt --options h \
-              --longoptions help,ip1:,ip2: \
+TEMP=$(getopt --options h,i: \
+              --longoptions help,ip1:,ip2:,interface:,left-node:,right-node: \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -38,12 +43,18 @@ eval set -- "$TEMP"
 
 ip1=
 ip2=
+iface=eth1
+lnode=pod-c1
+rnode=pod-c2
 
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --ip1)               ip1=$2; shift 2 ;;
         --ip2)               ip2=$2; shift 2 ;;
+        -i|--interface)      iface=$2; shift 2 ;;
+        --left-node)         lnode=$2; shift 2 ;;
+        --right-node)        rnode=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
@@ -65,8 +76,8 @@ sudo pcs resource create ip-c1 ocf:heartbeat:IPaddr2 \
 sudo pcs resource create ip-c2 ocf:heartbeat:IPaddr2 \
                                ip=$ip2 cidr_netmask=24 iflabel=c2 \
                                op monitor interval=30s
-sudo pcs constraint location ip-c1 prefers pod-c1
-sudo pcs constraint location ip-c2 prefers pod-c2
+sudo pcs constraint location ip-c1 prefers $lnode
+sudo pcs constraint location ip-c2 prefers $rnode
 
 echo 'Adding LNet...'
 sudo pcs resource create lnet systemd:lnet
@@ -79,12 +90,12 @@ sudo mkdir -p /usr/lib/ocf/resource.d/seagate &&
 sudo ln -sf /data/hare/pacemaker/lnet
            /usr/lib/ocf/resource.d/seagate/lnet
 '
-pdsh -w pod-c[1-2] $cmd
+pdsh -w $lnode,$rnode $cmd
 
 sudo pcs resource create lnet-c1 ocf:seagate:lnet \
-                                 iface=eth1:c1 op monitor interval=30s
+                                 iface=$iface:c1 op monitor interval=30s
 sudo pcs resource create lnet-c2 ocf:seagate:lnet \
-                                 iface=eth1:c2 op monitor interval=30s
+                                 iface=$iface:c2 op monitor interval=30s
 sudo pcs resource group add c1 ip-c1 lnet-c1
 sudo pcs resource group add c2 ip-c2 lnet-c2
 
@@ -99,7 +110,7 @@ mkfs_ext4 /dev/sdb
 mkfs_ext4 /dev/sdc
 
 mkdir -p /var/mero && sudo mount /dev/sdb /var/mero
-ssh pod-c2 'mkdir -p /var/mero && sudo mount /dev/sdc /var/mero'
+ssh $rnode 'mkdir -p /var/mero && sudo mount /dev/sdc /var/mero'
 
 hctl bootstrap --mkfs $cdf
 hctl shutdown
@@ -130,7 +141,7 @@ sudo ln -sf /var/mero1/m0d-0x7200000000000001\:0x?
            /var/mero/ &&
 sudo umount /var/mero1 &&
 sudo umount /var/mero'
-ssh pod-c2 $cmd
+ssh $rnode $cmd
 
 echo 'Preparing Consul agents config files...'
 cmd='
@@ -144,7 +155,7 @@ for i in c{1,2}; do
     sudo sed "/ExecStart=/aExecStartPost=/bin/sleep 5"
              -i /usr/lib/systemd/system/hare-consul-agent-$i.service;
 done'
-pdsh -w pod-c[1-2] $cmd
+pdsh -w $lnode,$rnode $cmd
 
 cmd_deregister_node() {
     local node=$1
@@ -156,22 +167,22 @@ consul_c1_cfg_dir=$hare_dir/consul-$ip1
 
 sudo sed \
  -e "/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c2_cfg_dir" \
- -e '/ExecStart=/iExecStartPre=/opt/seagate/eos/hare/bin/consul force-leave pod-c2' \
- -e "/ExecStartPost=/aExecStartPost=$(cmd_deregister_node pod-c2)" \
+ -e "/ExecStart=/iExecStartPre=/opt/seagate/eos/hare/bin/consul force-leave $rnode" \
+ -e "/ExecStartPost=/aExecStartPost=$(cmd_deregister_node $rnode)" \
  -i /usr/lib/systemd/system/hare-consul-agent-c2.service
 sudo systemctl daemon-reload
 
 cmd="
 sudo sed
  -e '/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c1_cfg_dir'
- -e '/ExecStart=/iExecStartPre=/opt/seagate/eos/hare/bin/consul force-leave pod-c1'
- -e \"/ExecStartPost=/aExecStartPost=$(cmd_deregister_node pod-c1)\"
+ -e '/ExecStart=/iExecStartPre=/opt/seagate/eos/hare/bin/consul force-leave $lnode'
+ -e \"/ExecStartPost=/aExecStartPost=$(cmd_deregister_node $lnode)\"
  -i /usr/lib/systemd/system/hare-consul-agent-c1.service &&
 sudo systemctl daemon-reload"
-ssh pod-c2 $cmd
+ssh $rnode $cmd
 
 sudo cp $hare_dir/consul-env $hare_dir/consul-env-c1
-sudo scp pod-c2:$hare_dir/consul-env $hare_dir/consul-env-c2
+sudo scp $rnode:$hare_dir/consul-env $hare_dir/consul-env-c2
 sudo sed -r \
   -e 's/server$/server-c1/' \
   -e "s/JOIN=/&-retry-join $ip2 /" \
@@ -183,7 +194,7 @@ sudo sed -r \
 
 cmd="
 sudo cp $hare_dir/consul-env $hare_dir/consul-env-c2 &&
-sudo scp pod-c1:$hare_dir/consul-env $hare_dir/consul-env-c1 &&
+sudo scp $lnode:$hare_dir/consul-env $hare_dir/consul-env-c1 &&
 sudo sed -r \
   -e 's/server$/server-c1/' \
   -e 's/127.0.0.1 //' \
@@ -193,7 +204,7 @@ sudo sed -r \
 sudo sed -r \
   -e 's/server$/server-c2/' \
   -i $hare_dir/consul-env-c2"
-ssh pod-c2 $cmd
+ssh $rnode $cmd
 
 sudo cp $hare_dir/consul-server-conf.json \
         $hare_dir/consul-server-c1-conf.json
@@ -201,10 +212,10 @@ sudo sed -e 's/"--hax"/"--svc", "hare-hax-c1"/' \
          -i $hare_dir/consul-server-c1-conf.json
 cp $hare_dir/consul-server-c1-conf.json \
    /tmp/consul-server-c1-conf.json
-sudo sed -e '/server/a\ \ "node_name": "pod-c1",' \
+sudo sed -e '/server/a\ \ "node_name": "$lnode",' \
          -e '/server/a\ \ "leave_on_terminate": true,' \
          -i /tmp/consul-server-c1-conf.json
-sudo scp /tmp/consul-server-c1-conf.json pod-c2:$hare_dir/
+sudo scp /tmp/consul-server-c1-conf.json $rnode:$hare_dir/
 
 cmd="
 sudo cp $hare_dir/consul-server-conf.json \
@@ -213,11 +224,11 @@ sudo sed -e 's/\"--hax\"/\"--svc\", \"hare-hax-c2\"/' \
          -i $hare_dir/consul-server-c2-conf.json &&
 cp $hare_dir/consul-server-c2-conf.json \
    /tmp/consul-server-c2-conf.json &&
-sudo sed -e '/server/a\ \ \"node_name\": \"pod-c2\",' \
+sudo sed -e '/server/a\ \ \"node_name\": \"$rnode\",' \
          -e '/server/a\ \ \"leave_on_terminate\": true,' \
          -i /tmp/consul-server-c2-conf.json &&
-sudo scp /tmp/consul-server-c2-conf.json pod-c1:$hare_dir/"
-ssh pod-c2 $cmd
+sudo scp /tmp/consul-server-c2-conf.json $lnode:$hare_dir/"
+ssh $rnode $cmd
 
 echo 'Adding Consul to Pacemaker...'
 sudo pcs resource create consul-c1 systemd:hare-consul-agent-c1
@@ -254,7 +265,7 @@ sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
          -e "/ExecStart=/iExecStartPre=/bin/mount $sdc /var/mero2" \
          -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero2' \
          -i /usr/lib/systemd/system/hare-hax-c2.service
-echo 'HARE_HAX_NODE_NAME=pod-c2' | sudo tee $hare_dir/hax-env-c2 > /dev/null
+echo 'HARE_HAX_NODE_NAME=$rnode' | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
 cmd="
 sudo cp /usr/lib/systemd/system/hare-hax.service
@@ -270,8 +281,8 @@ sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
          -e '/ExecStart=/iExecStartPre=/bin/mount $sdc /var/mero'
          -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero'
          -i /usr/lib/systemd/system/hare-hax-c2.service &&
-echo 'HARE_HAX_NODE_NAME=pod-c1' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
-ssh pod-c2 $cmd
+echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
+ssh $rnode $cmd
 
 sudo pcs resource create hax-c1 systemd:hare-hax-c1
 sudo pcs resource create hax-c2 systemd:hare-hax-c2
@@ -287,7 +298,7 @@ cmd='
 sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=15sec/"
          -i /usr/lib/systemd/system/m0d@.service &&
 sudo systemctl daemon-reload'
-pdsh -w pod-c[1-2] $cmd
+pdsh -w $lnode,$rnode $cmd
 
 get_fid() {
     local cfg=$1


### PR DESCRIPTION
The problem is that hostnames of the nodes and data interface
name are hard-coded.

Solution: add cmd-line options for the node names and the
interface name.

Closes #649, #653.