### PR TITLE
Problem: unable to bootstrap cluster with @o2ib lnet configuration

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -379,7 +379,7 @@ def oids_to_dhall(oids: List[Oid]) -> str:
     return '[ {} ]'.format(', '.join(oid_to_dhall(x) for x in oids))
 
 
-class Endpoint:
+class BaseEndpoint:
     _tmids: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, ipaddr: str, portal: int, tmid: int = None):
@@ -388,11 +388,17 @@ class Endpoint:
         assert portal > 0
         self.portal = portal
         if tmid is None:
-            self.tmid = Endpoint._tmids.setdefault((ipaddr, portal), 1)
-            Endpoint._tmids[(ipaddr, portal)] += 1
+            self.tmid = self._tmids.setdefault((ipaddr, portal), 1)
+            self._tmids[(ipaddr, portal)] += 1
         else:
             assert tmid > 0
             self.tmid = tmid
+
+    def _protocol_name(self):
+        raise NotImplementedError()
+
+    def to_dhall(self):
+        raise NotImplementedError()
 
     def __repr__(self):
         args = ', '.join([f'ipaddr={self.ipaddr!r}',
@@ -400,11 +406,25 @@ class Endpoint:
                           f'tmid={self.tmid}'])
         return f'{self.__class__.__name__}({args})'
 
+    def __str__(self):
+        protocol = self._protocol_name()
+        return f'{self.ipaddr}@{protocol}:12345:{self.portal}:{self.tmid}'
+
+
+class TcpEndpoint(BaseEndpoint):
+    def _protocol_name(self):
+        return 'tcp'
+
     def to_dhall(self):
         return f'utils.tcpEndpoint "{self.ipaddr}" {self.portal} {self.tmid}'
 
-    def __str__(self):
-        return f'{self.ipaddr}@tcp:12345:{self.portal}:{self.tmid}'
+
+class IbEndpoint(BaseEndpoint):
+    def _protocol_name(self):
+        return 'o2ib'
+
+    def to_dhall(self):
+        return f'utils.ibEndpoint "{self.ipaddr}" {self.portal} {self.tmid}'
 
 
 class ToDhall(metaclass=abc.ABCMeta):
@@ -518,7 +538,7 @@ class ConfProcess(ToDhall):
     _objt = ObjT.process
     _downlinks = {Downlink('services', ObjT.service)}
 
-    def __init__(self, nr_cpu: int, memsize_MB: int, endpoint: Endpoint,
+    def __init__(self, nr_cpu: int, memsize_MB: int, endpoint: BaseEndpoint,
                  services: List[Oid]):
         assert nr_cpu > 0
         self.nr_cpu = nr_cpu
@@ -545,6 +565,39 @@ class ConfProcess(ToDhall):
         return '{ %s }' % args
 
     @classmethod
+    def _get_protocol_by_interface(cls, iface: str, conf_file: str) -> str:
+        with open(conf_file, 'r') as f:
+            config_content = f.read()
+
+        parser = LnetConfigParser()
+        interfaces = parser.parse(config_content)
+
+        assert iface in interfaces, \
+            f'LNet is not configured for interface {iface}'
+
+        protocol = interfaces[iface]
+        return protocol
+
+    @classmethod
+    def _create_endpoint(cls, iface: str, proc_t: ProcT,
+                         facts: Dict[str, Any]) -> BaseEndpoint:
+        ipaddr = facts[ipaddr_key(iface)]
+        assert ipaddr, 'No IP address found. Please check the network '\
+                       'settings in the CDF file'
+        conf_file = '/etc/modprobe.d/lnet.conf'
+        if not os.path.isfile(conf_file):
+            # No 'lnet.conf' file found. Assume TCP by default.
+            protocol = 'tcp'
+        else:
+            protocol = cls._get_protocol_by_interface(iface, conf_file)
+
+        endpoint_types = {'tcp': TcpEndpoint, 'o2ib': IbEndpoint}
+        assert protocol in endpoint_types, "Can't build the endpoint:" \
+            f' unsupported protocol found in LNet configuration: {protocol}'
+
+        return endpoint_types[protocol](ipaddr=ipaddr, portal=proc_t.value)
+
+    @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
               facts: Dict[str, Any],
               iface: str,
@@ -555,7 +608,7 @@ class ConfProcess(ToDhall):
         assert iface
         assert ctrl is None or ctrl.type is ObjT.controller
 
-        ep = Endpoint(ipaddr=facts[ipaddr_key(iface)], portal=proc_t.value)
+        ep = cls._create_endpoint(iface, proc_t, facts)
         proc_id = new_oid(ObjT.process)
         m0conf[proc_id] = cls(nr_cpu=facts['processorcount'],
                               memsize_MB=facts['_memsize_MB'],
@@ -626,7 +679,7 @@ class ConfService(ToDhall):
     _objt = ObjT.service
     _downlinks = {Downlink('sdevs', ObjT.sdev)}
 
-    def __init__(self, stype: SvcT, endpoint: Endpoint, sdevs: List[Oid]):
+    def __init__(self, stype: SvcT, endpoint: BaseEndpoint, sdevs: List[Oid]):
         self.type = stype
         self.endpoint = endpoint
         assert all(x.type is ObjT.sdev for x in sdevs)
@@ -648,7 +701,7 @@ class ConfService(ToDhall):
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
-              stype: SvcT, endpoint: Endpoint) -> Oid:
+              stype: SvcT, endpoint: BaseEndpoint) -> Oid:
         assert parent.type is ObjT.process
         svc_id = new_oid(ObjT.service)
         m0conf[svc_id] = cls(stype, endpoint, sdevs=[])
@@ -1170,7 +1223,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
     m0conf = cluster.m0conf
 
     ConsulService = NamedTuple('ConsulService', [
-        ('node_name', str), ('proc_id', Oid), ('ep', Endpoint),
+        ('node_name', str), ('proc_id', Oid), ('ep', BaseEndpoint),
         ('svc_id', Oid), ('stype', str)])
 
     def profile() -> str:
@@ -1364,6 +1417,54 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     assert all_unique(x.ipaddr
                       for x in cluster.consul_servers + cluster.consul_clients)
     return cluster
+
+
+class LnetConfigParser:
+    def parse(self, content: str) -> Dict[str, str]:
+        lines = self._get_lines(content)
+        result: Dict[str, str] = {}
+        for line in lines:
+            match = re.match(r'^\s*options\s+lnet\s+networks=([^\s]*)\s+.*$',
+                             line)
+            if match:
+                result.update(self._extract_ifaces(match.group(1)))
+        return result
+
+    def _extract_ifaces(self, ifaces: str) -> Dict[str, str]:
+        '''
+        Parses the string like this: 'tcp(eth1),tcp1(eth0)' into dicts of the
+        following structure: {'eth1': 'tcp', 'eth0': tcp1}
+        '''
+        iface_map: Dict[str, str] = {}
+        for iface_def in ifaces.split(','):
+            # Match strings like this: tcp(eth1)
+            match = re.match(r'^([^\(]+)\(([^\)]+)\)', iface_def)
+            assert match
+            iface_map[match.group(2)] = match.group(1)
+        return iface_map
+
+    def _get_lines(self, whole_text: str) -> List[str]:
+        '''
+        Returns the meaningful list of lines (comments excluded) with line
+        conjunctions (with backslash at the end) processed.
+        '''
+        result: List[str] = []
+        raw_lines = whole_text.splitlines()
+        i = 0
+        while i < len(raw_lines):
+            s = ''
+            if re.match(r'^[\s]*#', raw_lines[i]):
+                i += 1
+                continue
+
+            while raw_lines[i].endswith('\\'):
+                # Add the current line with the very last character cut out
+                s += raw_lines[i][:-1]
+                i += 1
+            s += raw_lines[i]
+            result.append(s)
+            i += 1
+        return result
 
 
 if __name__ == '__main__':

--- a/cfgen/dhall/utils.dhall
+++ b/cfgen/dhall/utils.dhall
@@ -1,3 +1,4 @@
 { tcpEndpoint = ./utils/tcpEndpoint.dhall
+, ibEndpoint = ./utils/ibEndpoint.dhall
 , zoid = ./utils/zoid.dhall
 }

--- a/cfgen/dhall/utils/ibEndpoint.dhall
+++ b/cfgen/dhall/utils/ibEndpoint.dhall
@@ -1,0 +1,13 @@
+let types = ../types.dhall
+
+in
+    \(ipaddr : Text)
+ -> \(portal : Natural)
+ -> \(tmid : Natural)
+ ->
+    let addr = { ipaddr = ipaddr, mdigit = None Natural }
+    in
+      { nid = types.NetId.ib { ib = addr }
+      , portal = portal
+      , tmid = tmid
+      } : types.Endpoint


### PR DESCRIPTION
Solution:
1. Add ibEndpoint type to dhall (apart from tcpEndpoint we use now)
2. Make cfgen be aware of ibEndpoint dhall type
3. Make cfgen to analyze the lnet configuration for the current machine IP address to choose proper dhall type for the endpoint. The algorithm is as follows:
   1. Parse `/etc/modprobe.d/lnet.conf` file. 
   2. If no `/etc/modprobe.d/lnet.conf` file is found, tcp protocol is assumed.
   3. Otherwise the contents of the lnet.conf file is analyzed. If the same interface is specified multiple times, the latest mentioning wins.
   4. Valid protocol names are `tcp` and `o2ib`. If cfgen meets something else, `AssertionError` will be raised.

Closes #628