### PR TITLE
Problem: Missing setup.yaml for ha provisioning component

### DIFF
--- a/provisioning/setup-ha.yaml
+++ b/provisioning/setup-ha.yaml
@@ -1,0 +1,23 @@
+hare:
+  post_install:
+    script: null
+    args: null
+  init:
+    script: /opt/seagate/eos/hare/libexec/build-ees-ha
+    args:
+      ip1: null
+      ip2: null
+      interface: null
+      left-node: null
+      right-node: null
+      left-volume: null
+      right-volume: null 
+  config:
+    script: null
+    args: null
+  test:
+    script: null
+    args: null
+  reset:
+    script: null
+    args: null


### PR DESCRIPTION
Solution:
- Add build-ees-ha script to setup.yaml for ha component.
- Specify build-ees-ha script argument names in setup.yaml.
  Note: values to be populated via salt explicitly.
  see: http://gitlab.mero.colo.seagate.com/eos/provisioner/ees-prvsnr/issues/39