### PR TITLE
Problem: CI is unable to git-clone Mero

### DIFF
--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -56,7 +56,7 @@ ci_init_m0vg() (
         # Get `m0vg` script.
         # Note that we download the latest Mero, disregarding
         # `MERO_COMMIT_REF`.
-        git clone --recursive --depth 1 --shallow-submodules \
+        git clone --recursive --depth 1 \
             http://gitlab.mero.colo.seagate.com/mero/mero.git \
             ${M0VG%/scripts/m0vg}
     fi


### PR DESCRIPTION
`--depth 1 --shallow-submodules` causes git-clone to fetch only the last
commit of `gf-complete` repository.  That repo had been updated recently,
but not the corresponding submodule of mero.  The submodule still refers
to the penultimate commit, which is not available.  git-clone fails:
```
error: Server does not allow request for unadvertised object 3593fde56804b3450c41b52e6099a75abe85d284
Fetched in submodule path 'extra-libs/gf-complete', but it did not contain 3593fde56804b3450c41b52e6099a75abe85d284. Direct fetching of that commit failed.
```

The submodule of mero won't be updated for some while; see
http://gitlab.mero.colo.seagate.com/mero/hare/issues/276#note_29297 .

Solution: don't use `--shallow-submodules`.