### PR TITLE
Problem: cfgen throws unhelpful assertion error

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Set, \
 import yaml
 
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 
 def parse_opts(argv):
@@ -250,7 +250,11 @@ def validate_cluster_desc(desc: Dict[str, Any]) -> None:
                 f'hostname ({node_id}) != IP of {iface} ({iface_ip})'
 
         assert node['hostname']
-        assert node['data_iface']
+        iface = node['data_iface']
+        assert iface
+        assert node['facts'][ipaddr_key(iface)], \
+            f"""{node_id}: {iface!r} interface has no IP address
+Make sure the value of data_iface in the CDF is correct."""
 
         nr_confds = sum(1 for m0d in node['m0_servers'] if m0d['runs_confd'])
         assert nr_confds < 2, f'{node_id}: Too many confd services'


### PR DESCRIPTION
If nonexistent network interface is mentioned in CDF, the bootstrap fails
with unhelpful error message:
```
2020-02-08 11:37:56: Generating cluster configuration... Traceback (most recent call last):
  File "/opt/seagate/eos/hare/bin/cfgen", line 1358, in <module>
    main()
  File "/opt/seagate/eos/hare/bin/cfgen", line 126, in main
    cluster = build_cluster(cluster_desc)
  File "/opt/seagate/eos/hare/bin/cfgen", line 1272, in build_cluster
    ConfProcess.build(conf, node_id, facts, iface, ProcT.hax)
  File "/opt/seagate/eos/hare/bin/cfgen", line 546, in build
    ep = Endpoint(ipaddr=facts[ipaddr_key(iface)], portal=proc_t.value)
  File "/opt/seagate/eos/hare/bin/cfgen", line 374, in __init__
    assert ipaddr
AssertionError
```

Solution: improve the error message.

New error message:
```
Traceback (most recent call last):
  File "cfgen/cfgen", line 1391, in <module>
    main()
  File "cfgen/cfgen", line 122, in main
    validate_cluster_desc(cluster_desc)
  File "cfgen/cfgen", line 246, in validate_cluster_desc
    err(f'{iface!r} interface has no IP address\n'
AssertionError: localhost: 'eth1_XXX' interface has no IP address
Make sure the value of data_iface in the CDF is correct.
```

Note: if we conclude that exposing stack traces to end users is a problem,
we can solve it in another patch.

Closes #680.