### PR TITLE
Problem: Consul watches use wrong port

### DIFF
--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -6,7 +6,7 @@
       "service": "ios",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8080",
+        "path": "http://localhost:8008",
         "method": "POST",
         "timeout": "10s"
       }

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -13,7 +13,7 @@
       "service": "confd",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8080",
+        "path": "http://localhost:8008",
         "method": "POST",
         "timeout": "10s"
       }
@@ -30,7 +30,7 @@
       "service": "ios",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8080",
+        "path": "http://localhost:8008",
         "method": "POST",
         "timeout": "10s"
       }


### PR DESCRIPTION
Port 8080 is reserved for HAProxy.  `hax` listens at port 8008.
When Consul watches are invoked, they should send HTTP requests to the
`hax` port.

Solution: replace 8080 with 8008 in systemd/consul-{server,client}-conf.json.in.

Related issue: #624