### PR TITLE
Problem: setup.yaml does not support arguments with variables

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -32,6 +32,7 @@ Requires: mero = %{h_mero_version}
 Requires: pacemaker
 Requires: pcs
 Requires: python36
+Requires: shyaml
 
 Conflicts: halon
 

--- a/provisioning/setup-ha.yaml
+++ b/provisioning/setup-ha.yaml
@@ -4,14 +4,7 @@ hare:
     args: null
   init:
     script: /opt/seagate/eos/hare/libexec/build-ees-ha
-    args:
-      ip1: null
-      ip2: null
-      interface: null
-      left-node: null
-      right-node: null
-      left-volume: null
-      right-volume: null 
+    args: /var/lib/hare/build-ees-ha-args.yaml
   config:
     script: null
     args: null

--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -7,7 +7,7 @@ PROG=${0##*/}
 
 usage() {
     cat <<EOF
-Usage: $PROG [OPTS] --ip1 <addr> --ip2 <addr> <CDF>
+Usage: $PROG [OPTS] <CDF> [<params.yaml>]
 
 Configures EES-HA by preparing the configuration files and
 adding resources into the Pacemaker.
@@ -35,6 +35,17 @@ Optional parameters:
   --right-node    <n2>  Right Node hostname (default: pod-c2)
   --left-volume   <lv>  Left  Node /var/mero volume (default: /dev/sdb)
   --right-volume  <rv>  Right Node /var/mero volume (default: /dev/sdc)
+
+Note: parameters can be specified either directly via cmd-line options
+or via a yaml file, e.g.:
+
+  ip1: <ip>
+  ip2: <ip2>
+  interface: <iface>
+  left-node: <lnode>
+  right-node: <rnode>
+  left-volume: <lvolume>
+  right-volume: <rvolume>
 
 EOF
 }
@@ -72,13 +83,34 @@ while true; do
 done
 
 cdf=${1:-}
+argsfile=${2:-}
 
-[[ $ip1 ]] && [[ $ip2 ]] && [[ $cdf ]] || {
+hare_dir=/var/lib/hare
+
+get_arg_value() {
+   local arg_name=$1
+   local arg_value=$(shyaml get-value $arg_name < $argsfile)
+
+   if [[ $arg_value == None || $arg_value == null ]]; then
+       arg_value=
+   fi
+   echo "$arg_value"
+}
+
+if [[ -n $argsfile ]] && [[ -f $argsfile ]]; then
+    ip1=$(get_arg_value ip1)
+    ip2=$(get_arg_value ip2)
+    iface=$(get_arg_value interface)
+    lnode=$(get_arg_value left-node)
+    rnode=$(get_arg_value right-node)
+    lvolume=$(get_arg_value left-volume)
+    rvolume=$(get_arg_value right-volume)
+fi
+
+[[ $ip1 ]] && [[ $ip2 ]] && [[ $cdf ]]  || {
     usage >&2
     exit 1
 }
-
-hare_dir=/var/lib/hare
 
 echo 'Adding the roaming IP addresses into Pacemaker...'
 sudo pcs resource create ip-c1 ocf:heartbeat:IPaddr2 \


### PR DESCRIPTION
Solution:
- Accept build-ees-ha-args.yaml file as an optional argument to build-ees-ha-script.
- Fetch arguments from yaml file and use accordingly in build-ees-ha script.
- Add hare dependency on shyaml used by build-ees-ha script.
- Update setup-ha.yaml with build-ees-ha-args.yaml as an arguments file to build-ees-ha.

closes #695, #696