### PR TITLE
Problem: Hare CI fails due to missing shyaml

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -32,7 +32,6 @@ Requires: mero = %{h_mero_version}
 Requires: pacemaker
 Requires: pcs
 Requires: python36
-Requires: shyaml
 
 Conflicts: halon
 


### PR DESCRIPTION
[CI jobs fail](http://gitlab.mero.colo.seagate.com/mero/hare/-/jobs/94605):
```
--> Processing Dependency: shyaml for package: hare-0.1.0-1_git6018f58_m0gite0a06ddbc.el7.x86_64
--> Running transaction check
---> Package cyrus-sasl.x86_64 0:2.1.26-23.el7 will be installed
---> Package hare.x86_64 0:0.1.0-1_git6018f58_m0gite0a06ddbc.el7 will be installed
--> Processing Dependency: shyaml for package: hare-0.1.0-1_git6018f58_m0gite0a06ddbc.el7.x86_64
--> Finished Dependency Resolution
Error: Package: hare-0.1.0-1_git6018f58_m0gite0a06ddbc.el7.x86_64 (ci-storage.mero.colo.seagate.com_releases_dev_mero_hare_master_B66669)
           Requires: shyaml
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
Connection to 192.168.121.134 closed.

Command exited with non-zero status 1
```
`shyaml` dependency of hare.rpm is missing.

Solution: remove `shyaml` from hare.spec file.

Note that `build-ees-ha` script still uses `shyaml`.  We need to find a way
to parse arguments without introducing a dependency that cannot be met.
This can be done in another patch.  Right now the priority is to fix CI.