### PR TITLE
Problem: shyaml is not available in yum repos

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -87,24 +87,20 @@ argsfile=${2:-}
 
 hare_dir=/var/lib/hare
 
-get_arg_value() {
-   local arg_name=$1
-   local arg_value=$(shyaml get-value $arg_name < $argsfile)
-
-   if [[ $arg_value == None || $arg_value == null ]]; then
-       arg_value=
-   fi
-   echo "$arg_value"
-}
-
-if [[ -n $argsfile ]] && [[ -f $argsfile ]]; then
-    ip1=$(get_arg_value ip1)
-    ip2=$(get_arg_value ip2)
-    iface=$(get_arg_value interface)
-    lnode=$(get_arg_value left-node)
-    rnode=$(get_arg_value right-node)
-    lvolume=$(get_arg_value left-volume)
-    rvolume=$(get_arg_value right-volume)
+if [[ -f $argsfile ]]; then
+    while IFS=': ' read name value; do
+       case $name in
+           ip1)          ip1=$value     ;;
+           ip2)          ip2=$value     ;;
+           iface)        iface=$value   ;;
+           left-node)    lnode=$value   ;;
+           right-node)   rnode=$value   ;;
+           left-volume)  lvolume=$value ;;
+           right-volume) rvolume=$value ;;
+           *) echo "Invalid parameter in $argsfile"
+              usage >&2; exit 1 ;;
+       esac
+    done < $argsfile
 fi
 
 [[ $ip1 ]] && [[ $ip2 ]] && [[ $cdf ]]  || {


### PR DESCRIPTION
Actually, the yaml file we need to parse from the build-ees-ha
script is primitive, so we can easily parse it by bash means.

Solution: parse the yaml file directly from build-ees-ha script
by bash means (it simplifies the code actually) and drop the
dependency on shyaml.