### PR TITLE
Problem: build-ees-ha: awkward error msg about params.yaml

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -97,7 +97,7 @@ if [[ -f $argsfile ]]; then
            right-node)   rnode=$value   ;;
            left-volume)  lvolume=$value ;;
            right-volume) rvolume=$value ;;
-           *) echo "Invalid parameter in $argsfile"
+           *) echo "Invalid parameter '$name' in $argsfile" >&2
               usage >&2; exit 1 ;;
        esac
     done < $argsfile


### PR DESCRIPTION
No erroneous parameter name is given in the error msg which will
make it hard to debug.

Solution: improve the error msg.

[skip ci]