### PR TITLE
Problem: 'hctl shutdown' prints misleading ERROR

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -66,6 +66,7 @@ def is_localhost(hostname: str) -> bool:
 
 
 def ssh_prefix(hostname: str) -> str:
+    assert hostname
     return '' if is_localhost(hostname) else f'ssh {hostname} '
 
 
@@ -104,8 +105,9 @@ def main() -> None:
         if svc in processes:
             for proc in processes[svc]:
                 process_stop(proc)
-    print(f'Killing RC Leader at {leader_node}... ', end='', flush=True)
-    exec(ssh_prefix(leader_node) + 'sudo pkill --exact -KILL consul')
+    if leader_node:
+        print(f'Killing RC Leader at {leader_node}... ', end='', flush=True)
+        exec(ssh_prefix(leader_node) + 'sudo pkill --exact -KILL consul')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Solution: if cluster leader cannot be found (it suggests that all
consul processes have already been killed) then do not run
`sudo pkill --exact -KILL consul` command.

Closes #706.
