### PR TITLE
build-ees-ha: improvements & fixes from HW setup

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -381,9 +381,9 @@ echo 'Adding ldap to Pacemaker...'
 pcs resource create ldap-c1 systemd:slapd op monitor interval=30s
 pcs resource create ldap-c2 systemd:slapd op monitor interval=30s
 pcs constraint location ldap-c1 prefers $lnode=INFINITY
-pcs constraint location ldap-c1 prefers $rnode=-INFINITY
+pcs constraint location ldap-c1 avoids  $rnode=INFINITY
 pcs constraint location ldap-c2 prefers $rnode=INFINITY
-pcs constraint location ldap-c2 prefers $lnode=-INFINITY
+pcs constraint location ldap-c2 avoids  $lnode=INFINITY
 
 echo 'Adding s3authserver to Pacemaker...'
 pcs resource create s3auth-c1 systemd:s3authserver op monitor interval=30
@@ -395,9 +395,9 @@ echo 'Adding elastic search to Pacemaker..'
 pcs resource create els-search-c1 systemd:elasticsearch op monitor interval=30s
 pcs resource create els-search-c2 systemd:elasticsearch op monitor interval=30s
 pcs constraint location els-search-c1 prefers $lnode=INFINITY
-pcs constraint location els-search-c1 prefers $rnode=-INFINITY
+pcs constraint location els-search-c1 avoids  $rnode=INFINITY
 pcs constraint location els-search-c2 prefers $rnode=INFINITY
-pcs constraint location els-search-c2 prefers $lnode=-INFINITY
+pcs constraint location els-search-c2 avoids  $lnode=INFINITY
 
 echo 'Adding statsd to Pacemaker...'
 pcs resource create statsd-c1 systemd:statsd op monitor interval=30s
@@ -408,11 +408,11 @@ pcs constraint colocation add statsd-c2 with els-search-c2 score=INFINITY
 echo 'Adding haproxy to pacemaker...'
 pcs resource create haproxy-c1 systemd:haproxy
 pcs constraint location haproxy-c1 prefers $lnode=INFINITY
-pcs constraint location haproxy-c1 prefers $rnode=-INFINITY
+pcs constraint location haproxy-c1 avoids  $rnode=INFINITY
 
 pcs resource create haproxy-c2 systemd:haproxy
 pcs constraint location haproxy-c2 prefers $rnode=INFINITY
-pcs constraint location haproxy-c2 prefers $lnode=-INFINITY
+pcs constraint location haproxy-c2 avoids  $lnode=INFINITY
 
 pcs resource create s3backcons-c1 systemd:s3backgroundconsumer
 pcs resource create s3backprod-c1 systemd:s3backgroundproducer


### PR DESCRIPTION
Problem: `pcs` expressions use misleading keyword

The "negated prefers" constraint
```
pcs constraint location ldap-c1 prefers $rnode=-INFINITY
```
has "avoids" equivalent
```
pcs constraint location ldap-c1 avoids $rnode=INFINITY
```
The latter is arguably more readable.

Solution: replace negated `prefers` with `avoids`.

---

Problem: build-ees-ha creates excessive consraints

There is no need to create location constraints for every resource.
We may co-locate it with some other resource, location constraints
for which have already been created.

Solution: remove unneeded location constraints.

E.g.:
```diff
-pcs constraint location s3auth-c1 prefers c1=INFINITY
-pcs constraint location s3auth-c1 prefers c2=-INFINITY
+pcs constraint colocation add s3auth-c1 with ldap-c1 score=INFINITY
```

---

Problem: HA doesn't restart s3server after mero-kernel

If mero-kernel is restarted during failover, HA should restart s3server
as well.

Solution: add an ordering constraint to ensure that s3server is started
after mero-kernel.

---

Problem: pcs statements are not batched together

We believe that batching Pacemaker configuration changes together and
applying them with a one-off push to the CIB (Cluster Information Base)
is more predictable than applying those changes individually.

Solution: use `pcs cluster cib` ... `pcs cluster cib-push` blocks.

---

Problem: build-ees-ha may leave /var/mero unmounted

The /etc/fstab entry for /var/mero directory had been marked with
`noauto` flag recently.  `build-ees-ha` script should expect
/var/mero directory to be unmounted and mount it even if `--skip-mkfs`
option is provided.

Solution: change `build-ees-ha` to mount `/var/mero` unconditionally.
