### PR TITLE
Problem: hax failover to the left node does not work

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -320,7 +320,7 @@ sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
          -e "/ExecStart=/iExecStartPre=/bin/mount $rvolume /var/mero2" \
          -e '/ExecStart=/aExecStopPost=/bin/umount -l /var/mero2' \
          -i /usr/lib/systemd/system/hare-hax-c2.service
-echo 'HARE_HAX_NODE_NAME=$rnode' | sudo tee $hare_dir/hax-env-c2 > /dev/null
+echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
 cmd="
 sudo cp /usr/lib/systemd/system/hare-hax.service


### PR DESCRIPTION
Solution: fix the code at `build-ees-ha` script which creates
hax-env-c2 file on the "left" node - the hostname is wrong.