### PR TITLE
Problem: facter dependcy may be missing on some systems

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -35,6 +35,12 @@ Requires: python36
 Requires: facter
 
 Conflicts: halon
+# puppet-agent provides `facter` but doesn't install it in the default PATH,
+# rendering it anavailable for Hare. If puppet-agent already installed in the
+# system, it will prevent installation of normal `facter` package, defacto
+# leaving Hare w/o `facter`, even though from the yum/rpm standpoint all Hare's
+# dependencies are satisfied.
+Conflicts: puppet-agent
 
 %description
 Cluster monitoring and recovery for high-availability.


### PR DESCRIPTION
Solution: explicitly ban "puppet-agent" package in the Hare rpm
dependency list. "puppet-agent" can disguise itself as facter, which
will prevent normal facter package installation if "puppet-agent"
already installed in the system.