### PR TITLE
Problem: build-ees-ha fails to parse interface parameter

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -7,6 +7,7 @@ PROG=${0##*/}
 
 usage() {
     cat <<EOF
+
 Usage: $PROG [OPTS] <CDF> [<params.yaml>]
 
 Configures EES-HA by preparing the configuration files and
@@ -100,7 +101,7 @@ if [[ -f $argsfile ]]; then
        case $name in
            ip1)          ip1=$value     ;;
            ip2)          ip2=$value     ;;
-           iface)        iface=$value   ;;
+           interface)    iface=$value   ;;
            left-node)    lnode=$value   ;;
            right-node)   rnode=$value   ;;
            left-volume)  lvolume=$value ;;


### PR DESCRIPTION
Solution: fix the code in `build-ees-ha` script which parses
parameters from the paramsfile.

[skip ci]