### PR TITLE
Problem: iface config discrepancy is possible

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -170,10 +170,10 @@ fi
 mkdir -p /var/mero && sudo mount $lvolume /var/mero
 ssh $rnode "mkdir -p /var/mero && sudo mount $rvolume /var/mero"
 
-# Update data_iface parameter with `_c1/2` suffixes in CDF (if needed):
-# 1st data_iface will be suffixed with `_c1`, second with `_c2`.
-sudo sed -E -e '0,/(data_iface: *[a-z]+[0-9])[^_][^c][^1]/s//\1_c1/' \
-            -e '0,/(data_iface: *[a-z]+[0-9])[^_][^c][^2]/s//\1_c2/' \
+# Update data_iface parameter in CDF: 1st data_iface will be `${iface}_c1`,
+#                                     2nd data_iface will be `${iface}_c2`.
+sudo sed -E -e "0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c1\2/" \
+            -e "0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c2\2/" \
             -i $cdf
 
 hctl bootstrap --mkfs $cdf


### PR DESCRIPTION
Network interface configuration discrepancy between CDF and
parameter to `build-ees-ha` script is possible.

Solution: update CDF with the same interface which is provided
to `build-ees-ha` script via `--interface` parameter.

[skip ci]