### PR TITLE
Problem: Wrong yaml in setup-ha.yaml

### DIFF
--- a/provisioning/setup-ha.yaml
+++ b/provisioning/setup-ha.yaml
@@ -4,6 +4,7 @@ hare:
     args: null
   init:
     script: /opt/seagate/eos/hare/libexec/build-ees-ha
+    args:
       - /var/lib/hare/cluster.yaml
       - /var/lib/hare/build-ees-ha-args.yaml
   config:


### PR DESCRIPTION
Solution: add `args` as parent key for CDF and build-ees-ha-args file.

Closes #741.