### PR TITLE
Problem: build-ees-ha may not update data_iface in CDF

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -170,10 +170,11 @@ fi
 mkdir -p /var/mero && sudo mount $lvolume /var/mero
 ssh $rnode "mkdir -p /var/mero && sudo mount $rvolume /var/mero"
 
-# Update data_iface parameter in CDF: 1st data_iface will be `${iface}_c1`,
-#                                     2nd data_iface will be `${iface}_c2`.
-sudo sed -E -e "0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c1\2/" \
-            -e "0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c2\2/" \
+# Update data_iface values in CDF: 1st data_iface will be `${iface}_c1`,
+#                                  2nd data_iface will be `${iface}_c2`.
+sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
+                0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c1/ ;
+                0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c2/" \
             -i $cdf
 
 hctl bootstrap --mkfs $cdf


### PR DESCRIPTION
If there are commented out data_iface lines the script will
updated them instead of the real lines.

Solution: extend sed expression in `build-ees-ha` script to skip
commented out data_iface lines in the CDF file.

[skip ci]