### PR TITLE
Problem: parsing of build-ees-ha-args.yaml fails

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -108,6 +108,7 @@ if [[ -f $argsfile ]]; then
            right-volume) rvolume=$value ;;
            skip-mkfs)    skip_mkfs=true ;;
            net-type)     net_type=$value ;;
+           '')           ;;
            *) echo "Invalid parameter '$name' in $argsfile" >&2
               usage >&2; exit 1 ;;
        esac


### PR DESCRIPTION
Provisioner puts blank lines into `build-ees-ha-args.yaml` file:
```
[root@smc7-m11 ~]# cat /var/lib/hare/build-ees-ha-args.yaml
interface: bond0

net-type: o2ib

ip1: 172.16.0.172
ip2: 172.16.0.173
left-node: smc7-m11.mero.colo.seagate.com
right-node: smc8-m11.mero.colo.seagate.com
left-volume: /dev/disk/by-id/dm-name-mpathe2
right-volume: /dev/disk/by-id/dm-name-mpathb2
skip-mkfs: true
```

`build-ees-ha` cannot parse them:
```
Invalid parameter '' in /var/lib/hare/build-ees-ha-args.yaml
```

Solution: update `build-ees-ha` script to skip blank lines in the args file.