### PR TITLE
Problem: build-ees-ha fails due to missing rsync

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -28,11 +28,12 @@ BuildRequires: python36-devel
 BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
+Requires: facter
 Requires: mero = %{h_mero_version}
 Requires: pacemaker
 Requires: pcs
 Requires: python36
-Requires: facter
+Requires: rsync
 
 Conflicts: halon
 # puppet-agent provides `facter` but doesn't install it in the default PATH,


### PR DESCRIPTION
QA tried to run `salt \* state.apply components.ha.ees_ha` command.
The [command failed][] with the following error:

> sudo: rsync: command not found

Solution: add `rsync` to Hare runtime dependencies.

[command failed]: https://jts.seagate.com/browse/EOS-5837?focusedCommentId=1803529&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1803529