### PR TITLE
Problem: ees-ha: hax startup fails

### DIFF
--- a/systemd/hare-hax.service
+++ b/systemd/hare-hax.service
@@ -4,9 +4,8 @@ Requires=hare-consul-agent.service mero-kernel.service
 After=hare-consul-agent.service mero-kernel.service
 
 [Service]
-WorkingDirectory=/var/mero/hax
 # TODO: '/opt/seagate/eos/hare' prefix can be different, e.g. '/usr'
 Environment=PYTHONPATH=/opt/seagate/eos/hare/lib64/python3.6/site-packages:/opt/seagate/eos/hare/lib/python3.6/site-packages
-ExecStart=/opt/seagate/eos/hare/bin/hax
+ExecStart=/bin/sh -c 'cd /var/mero/hax && exec /opt/seagate/eos/hare/bin/hax'
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
In EES HA we mount `/var/mero` before starting `hax` via the
ExecStartPre directive in its systemd configuration file (see "Adding Hax to Pacemaker" section at `build-ees-ha` script).
But the WorkingDirectory specified as `/var/mero/hax` in
this file does not exist yet before the mount complete, so
the mount command fails:

```
systemd[NN]: Failed at step CHDIR spawning /bin/mount: No such file or directory
systemd[1]: hare-hax-c1.service: control process exited, code=exited status=200
```

Solution: `cd /var/mero/hax` at ExecStart instead of using
WorkingDirectory. By this time `/var/mero` is mounted already.

[skip ci]