### PR TITLE
Problem: yum install hare fails

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -36,12 +36,6 @@ Requires: python36
 Requires: rsync
 
 Conflicts: halon
-# puppet-agent provides `facter` but doesn't install it in the default PATH,
-# rendering it anavailable for Hare. If puppet-agent already installed in the
-# system, it will prevent installation of normal `facter` package, defacto
-# leaving Hare w/o `facter`, even though from the yum/rpm standpoint all Hare's
-# dependencies are satisfied.
-Conflicts: puppet-agent
 
 %description
 Cluster monitoring and recovery for high-availability.


### PR DESCRIPTION

An attempt to `yum install hare` on VMs deployed using SSC platform fails with
> Error: hare conflicts with puppet-agent-6.13.0-1.el7.x86_64

The Lab team is rolling out puppet to manage EES configurations.
Currently puppet is only running in the SSC but will be rolled out to
the rest of the lab soon.  There should not be any conflict as puppet
and all of its dependencies are self-contained and installed
independently in /opt/puppetlabs.

The 5 year old version of `facter` available in epel is fine to use if
we don't have a new `puppet-agent` installed but since we do in the lab,
it has been obsoleted.  Since `puppet-agent` spec file has a 'Provides:
facter', Hare install will work with this change whether or not
`puppet-agent` is installed.  Facter is in the default PATH when
installed with `puppet-agent` thanks to /etc/profile.d/puppet-agent.sh
and /etc/profile.d/puppet-agent.csh.

Solution: delete "Conflicts: puppet-agent" entry from `hare.spec`.

Jira: [EOS-5868](https://jts.seagate.com//browse/EOS-5868)