### PR TITLE
Problem: non-optimal auxiliary resources configuration

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -439,57 +439,27 @@ sudo rsync -u /etc/sysconfig/m0d-* $rnode:/etc/sysconfig/
 sudo rsync -u "$rnode:/etc/sysconfig/m0d-*" /etc/sysconfig/
 
 echo 'Adding ldap to Pacemaker...'
-pcs resource create ldap-c1 systemd:slapd op monitor interval=30s
-pcs resource create ldap-c2 systemd:slapd op monitor interval=30s
-pcs constraint location ldap-c1 prefers $lnode=INFINITY
-pcs constraint location ldap-c1 avoids  $rnode=INFINITY
-pcs constraint location ldap-c2 prefers $rnode=INFINITY
-pcs constraint location ldap-c2 avoids  $lnode=INFINITY
+pcs resource create ldap systemd:slapd clone op monitor interval=30s
 
 echo 'Adding s3authserver to Pacemaker...'
-pcs resource create s3auth-c1 systemd:s3authserver op monitor interval=30
-pcs resource create s3auth-c2 systemd:s3authserver op monitor interval=30
-pcs constraint colocation add s3auth-c1 with ldap-c1 score=INFINITY
-pcs constraint colocation add s3auth-c2 with ldap-c2 score=INFINITY
+pcs cluster cib s3authcfg
+pcs -f s3authcfg resource create s3auth systemd:s3authserver clone op monitor interval=30
+pcs -f s3authcfg constraint order ldap-clone then s3auth-clone
+pcs -f s3authcfg constraint order mero-ios-c1 then s3auth-clone
+pcs -f s3authcfg constraint order mero-ios-c2 then s3auth-clone
+pcs cluster cib-push s3authcfg --config
 
 echo 'Adding elastic search to Pacemaker..'
-pcs resource create els-search-c1 systemd:elasticsearch op monitor interval=30s
-pcs resource create els-search-c2 systemd:elasticsearch op monitor interval=30s
-pcs constraint location els-search-c1 prefers $lnode=INFINITY
-pcs constraint location els-search-c1 avoids  $rnode=INFINITY
-pcs constraint location els-search-c2 prefers $rnode=INFINITY
-pcs constraint location els-search-c2 avoids  $lnode=INFINITY
+pcs resource create els-search systemd:elasticsearch clone op monitor interval=30s
 
 echo 'Adding statsd to Pacemaker...'
-pcs resource create statsd-c1 systemd:statsd op monitor interval=30s
-pcs resource create statsd-c2 systemd:statsd op monitor interval=30s
-pcs constraint colocation add statsd-c1 with els-search-c1 score=INFINITY
-pcs constraint colocation add statsd-c2 with els-search-c2 score=INFINITY
+pcs resource create statsd systemd:statsd clone op monitor interval=30s
+pcs constraint order els-search-clone then statsd-clone
 
 echo 'Adding haproxy to pacemaker...'
-pcs resource create haproxy-c1 systemd:haproxy
-pcs constraint location haproxy-c1 prefers $lnode=INFINITY
-pcs constraint location haproxy-c1 avoids  $rnode=INFINITY
-
-pcs resource create haproxy-c2 systemd:haproxy
-pcs constraint location haproxy-c2 prefers $rnode=INFINITY
-pcs constraint location haproxy-c2 avoids  $lnode=INFINITY
-
-pcs resource create s3backcons-c1 systemd:s3backgroundconsumer
-pcs constraint location s3backcons-c1 prefers $lnode=INFINITY
-pcs constraint location s3backcons-c1 avoids  $rnode=INFINITY
-pcs resource create s3backprod-c1 systemd:s3backgroundproducer
-pcs constraint location s3backprod-c1 prefers $lnode=INFINITY
-pcs constraint location s3backprod-c1 avoids  $rnode=INFINITY
-pcs resource create s3backcons-c2 systemd:s3backgroundconsumer
-pcs constraint location s3backcons-c2 prefers $rnode=INFINITY
-pcs constraint location s3backcons-c2 avoids  $lnode=INFINITY
-pcs resource create s3backprod-c2 systemd:s3backgroundproducer
-pcs constraint location s3backprod-c2 prefers $rnode=INFINITY
-pcs constraint location s3backprod-c2 avoids  $lnode=INFINITY
+pcs resource create haproxy systemd:haproxy clone op monitor interval=30s
 
 echo 'Adding S3server to Pacemaker...'
-
 get_s3_svc() {
     local cfg=$1
     local svc=$2
@@ -501,22 +471,36 @@ get_s3_svc() {
 s3_resource_add() {
    local conf_file=$1
    local suffix=$2
-   local node=$3
+   local node_local=$3
+   local node_remote=$4
    local count=1
    local s3server_fids=$(get_s3_svc $hare_dir/$conf_file s3service)
 
-   pcs cluster cib mcfg
+   pcs cluster cib s3cfg
    for i in ${s3server_fids[@]}
    do
-      pcs -f mcfg resource create s3server-$suffix-$count systemd:$i op stop timeout=600
-      pcs -f mcfg constraint location s3server-$suffix-$count prefers $node=INFINITY
-      pcs -f mcfg constraint colocation add s3server-$suffix-$count with s3auth-$suffix score=INFINITY
-      pcs -f mcfg constraint order mero-ios-c1 then s3server-$suffix-$count
-      pcs -f mcfg constraint order mero-ios-c2 then s3server-$suffix-$count
+      pcs -f s3cfg resource create s3server-$suffix-$count systemd:$i op stop timeout=600
+      pcs -f s3cfg constraint location s3server-$suffix-$count prefers $node_local=INFINITY
+      pcs -f s3cfg constraint location s3server-$suffix-$count avoids $node_remote=INFINITY
+      # Order constraint adds the startup dependency of s3server on s3authserver
+      pcs -f s3cfg constraint order s3auth-clone then s3server-$suffix-$count
+      # Colocation constraint will add a s3server's liveness dependency on the local s3authserver 
+      pcs -f s3cfg constraint colocation add s3server-$suffix-$count with s3auth-clone score=INFINITY
       (( count++ ))
    done
-   pcs cluster cib-push mcfg --config
+   pcs cluster cib-push s3cfg --config
 }
 
-s3_resource_add consul-server-c1-conf.json c1 $lnode
-s3_resource_add consul-server-c2-conf.json c2 $rnode
+s3_resource_add consul-server-c1-conf.json c1 $lnode $rnode
+s3_resource_add consul-server-c2-conf.json c2 $rnode $lnode
+
+echo 'Adding rabbit-mq resources and constraints...'
+pcs resource create rabbitmq systemd:rabbitmq-server clone op monitor interval=30s
+
+echo 'Adding s3background services...'
+pcs cluster cib s3bcfg
+pcs -f s3bcfg resource create s3backcons systemd:s3backgroundconsumer clone
+pcs -f s3bcfg constraint order rabbitmq-clone then s3backcons-clone
+pcs -f s3bcfg resource create s3backprod systemd:s3backgroundproducer clone
+pcs -f s3bcfg constraint order s3backcons-clone then s3backprod-clone
+pcs cluster cib-push s3bcfg --config


### PR DESCRIPTION
Solution:
Clone slapd, statsd, s3authserver, elasticsearch, s3backgroundconsumer and
s3backgroundproducer resources instead of creating their one instance per node.
These services are started in active/active mode and does not differ in
configuraton with respect to their location.

Although having separate resource per node helps slightly in testing and might be
useful for maintenance reasons, if only subset of resources need to be stopped, but
proves to be complicated to define dependency constraints across the nodes.

Closes #756