### PR TITLE
Problem: ees-ha: /var/mero is mounted by Provisioner

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -174,8 +174,11 @@ if ! [[ $skip_mkfs ]]; then
     mkfs_ext4 $rvolume
 fi
 
-mkdir -p /var/mero && sudo mount $lvolume /var/mero
-ssh $rnode "mkdir -p /var/mero && sudo mount $rvolume /var/mero"
+# Mount /var/mero (if not mounted).
+mkdir -p /var/mero &&
+  ! mountpoint -q /var/mero && sudo mount $lvolume /var/mero || true
+ssh $rnode "mkdir -p /var/mero &&
+  ! mountpoint -q /var/mero && sudo mount $rvolume /var/mero || true"
 
 # Update data_iface values in CDF: 1st data_iface will be `${iface}_c1`,
 #                                  2nd data_iface will be `${iface}_c2`.


### PR DESCRIPTION
Currently, `build-ees-ha` script expects `/var/mero/` to be
unmounted. But it needs to be mounted for `hare` component
(which runs `hctl bootstrap` as part of its sanity check).
Hare component is provisioned just before `ha.ees_ha`, so
`/var/mero` is left mounted.

Solution: improve `build-ees-ha` script to accept both -
mounted and unmounted `/var/mero`.

[skip ci]