### PR TITLE
Problem: build-ees-ha falsely updates ifaces in CDF

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -183,8 +183,8 @@ ssh $rnode "mkdir -p /var/mero &&
 # Update data_iface values in CDF: 1st data_iface will be `${iface}_c1`,
 #                                  2nd data_iface will be `${iface}_c2`.
 sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
-                0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c1/ ;
-                0,/(data_iface: *)[a-z]+[0-9]([^_]|$)/s//\1${iface}_c2/" \
+                0,/(data_iface: *)\b${iface}\b/s//\1${iface}_c1/ ;
+                0,/(data_iface: *)\b${iface}\b/s//\1${iface}_c2/" \
             -i $cdf
 
 hctl bootstrap --mkfs $cdf


### PR DESCRIPTION
Some interface names, like enp175s0f1 are erroneously
updated by the `build-ees-ha` script in the CDF file.
The problem is with the RE pattern which is used to
match the interface name.

Solution: use the exact iface name from variable for
the matching.