### PR TITLE
Problem: ees-ha: iface update semantics regression

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -183,8 +183,8 @@ ssh $rnode "mkdir -p /var/mero &&
 # Update data_iface values in CDF: 1st data_iface will be `${iface}_c1`,
 #                                  2nd data_iface will be `${iface}_c2`.
 sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
-                0,/(data_iface: *)\b${iface}\b/s//\1${iface}_c1/ ;
-                0,/(data_iface: *)\b${iface}\b/s//\1${iface}_c2/" \
+                0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c1/ ;
+                0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/" \
             -i $cdf
 
 hctl bootstrap --mkfs $cdf


### PR DESCRIPTION
Previously, the code replaced the interface value in CDF
file completely to avoid any possible discrepancy between
the value provided to the `build-ees-ha` script and the
value in the CDF file. But commit e68dded has broken this
semantics.

Solution: fix and restore the old semantics.

[skip ci]