### PR TITLE
Problem: ees-ha: already loaded mero-kernel fails startup

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -187,6 +187,9 @@ sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
                 0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/" \
             -i $cdf
 
+# Make sure mero-kernel is not loaded.
+run_on_both 'sudo systemctl stop mero-kernel'
+
 hctl bootstrap --mkfs $cdf
 hctl shutdown
 


### PR DESCRIPTION
Already loaded mero-kernel module causes Mero TM startup failure:

```
ERROR  [/root/rpmbuild/BUILD/mero-1.4.0/net/lnet/ulnet_core.c:1171:nlx_core_tm_start]  <! rc=-2
```

See more in EOS-6023 ticket for Mero.

Solution: unload mero-kernel module before bootstrap.

Closes #776.

[skip ci]