### PR TITLE
Problem: rpm doesn't pass validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ test-cfgen: $(PY_VENV_DIR)
 
 VERSION   := $(shell cat VERSION)
 GITREV     = git$(shell git rev-parse --short HEAD)
-DIST_FILE := hare-$(VERSION).tar.gz
+DIST_FILE := eos-hare-$(VERSION).tar.gz
 
 RPMBUILD_DIR    := $(HOME)/rpmbuild
 RPMBUILD_TOPDIR := $(abspath $(RPMBUILD_DIR))
@@ -364,9 +364,9 @@ RPMSPECS_DIR    := $(RPMBUILD_DIR)/SPECS
 dist:
 	@$(call _info,Generating dist archive)
 	@rm -f $(DIST_FILE)
-	@git archive -v --prefix=hare/ HEAD -o $(DIST_FILE:.gz=)
+	@git archive -v --prefix=eos-hare/ HEAD -o $(DIST_FILE:.gz=)
 	git submodule foreach --recursive \
-	     "git archive --prefix=hare/\$$path/ --output=\$$sha1.tar HEAD \
+	     "git archive --prefix=eos-hare/\$$path/ --output=\$$sha1.tar HEAD \
 	      && tar --concatenate --file=$$(pwd)/$(DIST_FILE:.gz=) \$$sha1.tar \
 	      && rm \$$sha1.tar"
 	@gzip $(DIST_FILE:.gz=)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ ensure that
   ```bash
   (set -eu
 
-  if ! rpm -q hare s3server; then
-      if ! sudo yum install -y hare s3server; then
+  if ! rpm -q eos-hare s3server; then
+      if ! sudo yum install -y eos-hare s3server; then
           for x in 'integration/centos-7.7.1908/last_successful' 's3server_uploads'
           do
               repo="ci-storage.mero.colo.seagate.com/releases/eos/$x"
@@ -50,7 +50,7 @@ ensure that
 	  done
 	  unset repo x
 
-          sudo yum install -y hare s3server
+          sudo yum install -y eos-hare s3server
       fi
   fi
   )

--- a/ci/docker/test-utils
+++ b/ci/docker/test-utils
@@ -10,7 +10,7 @@ if [[ -z ${MERO_COMMIT_REF:-} ]]; then
     yum-config-manager --add-repo="http://$repo"
     tee -a /etc/yum.repos.d/${repo//\//_}.repo <<< 'gpgcheck=0'
 
-    yum install -y hare mero-devel
+    yum install -y eos-hare mero-devel
 fi
 
 make test

--- a/ci/m0vg/init-node
+++ b/ci/m0vg/init-node
@@ -26,7 +26,7 @@ else
         # error message.  This happens when the CI job is retried manually.
         sudo tee -a /etc/yum.repos.d/${repo//\//_}.repo <<< 'gpgcheck=0'
     fi
-    sudo yum install -y hare s3server s3cmd
+    sudo yum install -y eos-hare s3server s3cmd
 fi
 
 # Current user should be able to write to /var/lib/hare/ directory,

--- a/ci/rpmbuild
+++ b/ci/rpmbuild
@@ -21,7 +21,7 @@ time make rpm
 # CI jobs.
 mkdir -vp $RPMSYNC_DIR
 cp -v \
-   /root/rpmbuild/RPMS/x86_64/hare*.rpm \
+   /root/rpmbuild/RPMS/x86_64/eos-hare*.rpm \
    $latest_release_dir/mero{,-devel}-[0-9]*.rpm \
    $latest_release_dir/s3server-[0-9]*.rpm \
    /releases/eos/s3server_uploads/log4cxx_eos{,-devel}-[0-9]*.rpm \

--- a/hare.spec
+++ b/hare.spec
@@ -12,10 +12,10 @@
 %define h_build_jobs_opt  %(test -n "$build_jobs" && echo "-j$build_jobs" || echo '')
 
 Summary: Hare (Halon replacement)
-Name: hare
+Name: eos-hare
 Version: %{h_version}
 Release: %{h_build_num}_%{h_gitrev}_m0%{h_mero_gitrev}%{?dist}
-License: All rights reserved
+License: Seagate
 Group: System Environment/Daemons
 Source: %{name}-%{h_version}.tar.gz
 


### PR DESCRIPTION
Solution: change the name of rpm package so it follows EOS naming
convention.

Closes: EOS-5878, #762 