### PR TITLE
Problem: unclear error msg on hostnames mismatch

### DIFF
--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -49,6 +49,14 @@ id2fid() {
 }
 
 HAX_ID=$(get_service_ids 'grep -iw ha')
+[[ $HAX_ID ]] || {
+    cat >&2 <<.
+Cannot get information about Hax from Consul for this host ($HOSTNAME).
+Please verify that the hostname matches the one stored in Consul.
+.
+    usage >&2
+    exit 1
+}
 CONFD_IDs=$(get_service_ids 'grep -iw confd')
 IOS_IDs=$(get_service_ids 'grep -iw ios | grep -iwv confd')
 S3_IDs=$(get_service_ids 'grep -iw m0_client_s3')


### PR DESCRIPTION
On hostnames mismatch between nodes and Consul KV Store
the error message is very cryptic currently:

```
2020-03-11 09:50:11: Updating Consul agents configs from the KV store.../opt/seagate/eos/hare/libexec/update-consul-conf: line 31: $1: unbound variable
```

Solution: add the check and the proper error msg to the
`update-consul-conf` script.

Closes #783.