### PR TITLE
Problem: no error msg when IPs are not configured

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -190,6 +190,17 @@ sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
 # Make sure mero-kernel is not loaded.
 run_on_both 'sudo systemctl stop mero-kernel'
 
+# Check IPs
+ip a | grep -q $ip1 || {
+    echo 'ERROR: the IP address on the left node is not configured' >&2
+    usage >&2; exit 1;
+}
+
+ssh $rnode "ip a | grep -q $ip2" || {
+    echo 'ERROR: the IP address on the right node is not configured' >&2
+    usage >&2; exit 1;
+}
+
 hctl bootstrap --mkfs $cdf
 hctl shutdown
 


### PR DESCRIPTION
Currently, when the IPs are not configured we still try to run
`hctl bootstrap` in the `build-ees-ha` script which fails with
the completely unclear error msg:

```
Traceback (most recent call last):
    File "/opt/seagate/eos/hare/bin/../bin/cfgen", line 1401, in <module>
      main()
    File "/opt/seagate/eos/hare/bin/../bin/cfgen", line 122, in main
      validate_cluster_desc(cluster_desc)
    File "/opt/seagate/eos/hare/bin/../bin/cfgen", line 239, in validate_cluster_desc
      '\n'.join('    ' + name + ' ' + ip for name, ip in nodes)
    File "/opt/seagate/eos/hare/bin/../bin/cfgen", line 239, in <genexpr>
      '\n'.join('    ' + name + ' ' + ip for name, ip in nodes)
  TypeError: must be str, not NoneType
```

Solution: check for IPs before trying `hctl bootstrap`.