### PR TITLE
Problem: cfgen: IP addresses are not unique error

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -193,8 +193,7 @@ def validate_cdf_schema(cdf: str, cdf_path: str, schema_path: str) -> None:
 
 
 def ipaddr_key(iface: str) -> str:
-    # `facter` converts "eth1:c1" to "eth1_c1".
-    return 'ipaddress_' + iface.replace(':', '_')
+    return 'ipaddress_' + iface
 
 
 def looks_like_ipaddr(s: str) -> bool:

--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -184,7 +184,8 @@ ssh $rnode "mkdir -p /var/mero &&
 #                                  2nd data_iface will be `${iface}_c2`.
 sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
                 0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c1/ ;
-                0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/" \
+                0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/ ;
+                s/(${iface})_(c[12])/\1:\2/" \
             -i $cdf
 
 # Make sure mero-kernel is not loaded.


### PR DESCRIPTION
With the new version of facter-3.x.x from the puppet-agent rpm
cfgen fails with the `AssertionError: IP addresses are not unique`.
It's because the new version of facter does not understand the
`_` underscore symbol in the format of the `ipaddress_<iface>`
parameter. It requires `:` symbol instead:

```
[root@smc21-m10 ~]# facter ipaddress_bond0_c1

[root@smc21-m10 ~]# facter ipaddress_bond0:c1
172.16.0.119
```

Solution: don't convert `:` symbol into `_` in the interface
name from the CDF file.

Closes #780.