### PR TITLE
Problem: cfgen error regression with the old facter

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -202,10 +202,17 @@ ssh $rnode "mkdir -p /var/mero &&
 # Update data_iface values in CDF: 1st data_iface will be `${iface}_c1`,
 #                                  2nd data_iface will be `${iface}_c2`.
 sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
+                /data_iface: *[a-z0-9]+[_:]c[12]/b ; # skip already updated
                 0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c1/ ;
-                0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/ ;
-                s/(${iface})_(c[12])/\1:\2/" \
+                0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/" \
             -i $cdf
+
+if facter --version | grep -q ^3; then
+    # New facter-3 requires colons (:) for interface aliases.
+    sudo sed -E -e "/[#].*data_iface/b ; # skip commented out data_iface lines
+                    s/(data_iface: *${iface})_(c[12])/\1:\2/" \
+            -i $cdf
+fi
 
 # Make sure mero-kernel is not loaded.
 run_on_both 'sudo systemctl stop mero-kernel'


### PR DESCRIPTION
In commit 409620c we started updating the interface names
with colons (:) in the build-ees-ha script for the new facter
utility from puppet - this causes cfgen errors regression
on the setups with the old facter version.

Solution: check facter version in the build-ees-ha script
and update interfaces with colons only for the new facter.

Closes EOS-6108.

[skip ci]