### PR TITLE
Problem: update-consul-conf cannot get node entries from Consul KV

### DIFF
--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -7,8 +7,9 @@ HARE_BASE_DIR=/opt/seagate/eos/hare
 PATH="$HARE_BASE_DIR/libexec:$PATH"
 PATH="$HARE_BASE_DIR/bin:$PATH"
 export PATH
+NODE=`hostname -f`
 
 # TODO: should it be `consul` and PATH=/opt/seagate/eos/hare/bin:$PATH ?
-exec consul agent -bind $BIND -client "$CLIENT" $JOIN \
+exec consul agent -node "$NODE" -bind $BIND -client "$CLIENT" $JOIN \
      -config-file=/var/lib/hare/consul-$MODE-conf.json \
      -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS

--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -39,7 +39,7 @@ cleanup() {
 # If the session is already set - the leader is elected, so
 # there is nothing to do (except cleanup after ourself).
 get_session_id | grep -q ^- || {
-    if [[ $(get_leader_node) != $HOSTNAME ]]; then
+    if [[ $(get_leader_node) != $(hostname --fqdn) ]]; then
         cleanup
     fi
     exit 0
@@ -49,7 +49,7 @@ cleanup
 
 # Create session with the service:confd Health Checker:
 create_session() {
-    local checks_a=($(consul kv get -recurse m0conf/nodes/$HOSTNAME |
+    local checks_a=($(consul kv get -recurse m0conf/nodes/$(hostname --fqdn)|
                       egrep -w 'confd|ha' |
                       sed -r 's/.*processes.([0-9]+).*/"service:\1"/'))
     # See the trick comma separated list explained here:
@@ -79,7 +79,7 @@ while true; do
     sleep $((RANDOM % 10))
     SID=$(create_session || true)
     if [[ $SID ]]; then
-        consul kv put -acquire -session=$SID leader $HOSTNAME \
+        consul kv put -acquire -session=$SID leader $(hostname --fqdn) \
                       2>/dev/null && break
         destroy_session $SID
     fi

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -90,7 +90,7 @@ abort_if_RC_leader_election_is_impossible() {
     while IFS=/ read node confd_id; do
         local ok=true
         confd_id="m0d@$(printf 0x7200000000000001:0x%x $confd_id)"
-        if [[ $node == $HOSTNAME ]]; then
+        if [[ $node == $(hostname --fqdn) ]]; then
             ssh=
         else
             ssh="ssh $node"
@@ -194,7 +194,7 @@ fi
 abort_if_RC_leader_election_is_impossible
 
 # Get my IP address (the one that the other agents will join to).
-read _ join_ip <<< $(get_server_nodes | grep -w $HOSTNAME)
+read _ join_ip <<< $(get_server_nodes | grep -w $(hostname --fqdn))
 
 if [[ -z $join_ip ]]; then
     cat <<'EOF' >&2
@@ -232,7 +232,7 @@ while read node bind_ip; do
     ssh $node "$(which mk-consul-env) --mode server --bind $bind_ip --join $join_ip &&
                sudo systemctl start hare-consul-agent" &
     pids+=($!)
-done < <(get_server_nodes | grep -vw $HOSTNAME || true)
+done < <(get_server_nodes | grep -vw $(hostname --fqdn) || true)
 
 while read node bind_ip; do
     ssh $node "$(which mk-consul-env) --mode client --bind $bind_ip --join $join_ip &&
@@ -264,14 +264,14 @@ pids=($!)
 while read node _; do
     ssh $node "PATH=$PATH $(which update-consul-conf)" &
     pids+=($!)
-done < <(get_all_nodes | grep -vw $HOSTNAME || true)
+done < <(get_all_nodes | grep -vw $(hostname --fqdn) || true)
 wait4 ${pids[@]}
 echo ' OK'
 
 say 'Installing Mero configuration files...'
 while read node _; do
     scp -q $cfgen_out/confd.xc $node:$cfgen_out
-done < <(get_server_nodes | grep -vw $HOSTNAME || true)
+done < <(get_server_nodes | grep -vw $(hostname --fqdn) || true)
 echo ' OK'
 
 say 'Waiting for the RC Leader to get elected...'
@@ -311,7 +311,7 @@ start_mero() {
     while read node _; do
         ssh $node "PATH=$PATH $(which bootstrap-node) $op --phase $phase" &
         pids+=($!)
-    done < <(get_nodes $phase | grep -vw $HOSTNAME || true)
+    done < <(get_nodes $phase | grep -vw $(hostname --fqdn) || true)
     wait4 ${pids[@]}
     echo ' OK'
 }
@@ -342,7 +342,7 @@ if [[ -n $S3_IDs ]]; then
     while read node _; do
         ssh $node "PATH=$PATH $(which bootstrap-node) --phase phase3" &
         pids+=($!)
-    done < <(get_all_nodes | grep -vw $HOSTNAME || true)
+    done < <(get_all_nodes | grep -vw $(hostname --fqdn) || true)
     wait4 ${pids[@]}
     echo ' OK'
 fi

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -36,7 +36,6 @@ def sns_pools(cns: Consul) -> List[str]:
 def hosts(cns: Consul) -> Set[str]:
     data = cns.kv.get('m0conf/nodes', recurse=True)[1]
     host_names = {(x['Key'].split('/'))[2] for x in data}
-
     return host_names
 
 

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -22,14 +22,15 @@ esac
 
 get_service_ids() {
     local filter=$1
-    local cmd="consul kv get -recurse m0conf/nodes/$HOSTNAME/processes/ |
+    local host=$(hostname --fqdn)
+    local cmd="consul kv get -recurse m0conf/nodes/$host/processes/ |
                   $filter | sed 's/.*processes.//' | cut -d/ -f1"
     eval $cmd || true
 }
 
 get_service_ep() {
     local id=$1
-    consul kv get m0conf/nodes/$HOSTNAME/processes/$id/endpoint
+    consul kv get m0conf/nodes/$(hostname --fqdn)/processes/$id/endpoint
 }
 
 get_service_addr() {
@@ -51,8 +52,8 @@ id2fid() {
 HAX_ID=$(get_service_ids 'grep -iw ha')
 [[ $HAX_ID ]] || {
     cat >&2 <<.
-Cannot get information about Hax from Consul for this host ($HOSTNAME).
-Please verify that the hostname matches the one stored in Consul.
+Cannot get information about Hax from Consul for this host ($(hostname --fqdn)).
+Please verify that the host name matches the one stored in the Consul KV.
 .
     usage >&2
     exit 1


### PR DESCRIPTION
Provisioner uses FQDN (Fully Qualified Domain Name) as host names; see
[EOS-6041][].  It puts FQDNs into cluster.sls, .ssh/config files, and
the CDF (Cluster Description File).  Hare's cfgen utility reads the
CDF and generates Consul configuration and KV data files.

`m0conf/nodes/` entries of the Consul KV will contain long host names
(FQDNs).  When `update-consul-conf` tried to retrieve those entries
using short host name (`$HOSTNAME`), it failed.

```
$ echo $HOSTNAME
eosnode-1
$ hostname
eosnode-1
$ hostname --fqdn
eosnode-1.colo.seagate.com
$ grep -A1 eosnode-1: /opt/seagate/eos-prvsnr/pillar/components/cluster.sls
    eosnode-1:
        hostname: eosnode-1.colo.seagate.com
$ grep -m1 hostname /var/lib/hare/cluster.yaml
  - hostname: eosnode-1.colo.seagate.com
$ consul kv get -recurse m0conf/nodes/$HOSTNAME | wc -l
0
$ consul kv get -recurse m0conf/nodes/$(hostname --fqdn) | wc -l
53
```

Solution: use `hostname --fqdn` when retrieving m0conf/node/ entries
from the Consul KV.

Closes #791.

[EOS-6041]: https://jts.seagate.com/browse/EOS-6041