### PR TITLE
Problem: rabbitmq resource creation is redundant in build-ees-ha-csm script

### DIFF
--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -106,22 +106,28 @@ systemctl is-active --quiet elasticsearch ||
 ssh $rnode "systemctl is-active --quiet elasticsearch" ||
     die 'No active elasticsearch instance found'
 
+systemctl is-active --quiet rabbitmq-server ||
+    die 'No active rabbitmq instance found'
+ssh $rnode "systemctl is-active --quiet rabbitmq-server" ||
+    die 'No active rabbitmq instance found'
+
 echo 'Adding kibana resources...'
 pcs resource create kibana-vip ocf:heartbeat:IPaddr2 \
-    ip=$vip cidr_netmask=24 nic=eth0 iflabel=v1 \
+    ip=$vip cidr_netmask=24 nic=$iface iflabel=v1 \
     op start   interval=0s timeout=60s \
     op monitor interval=5s timeout=20s \
     op stop    interval=0s timeout=60s
 pcs resource create kibana systemd:kibana op monitor interval=30s
 
 echo 'Adding csm resources and constraints...'
-pcs resource create csm-agent systemd:csm_agent op monitor interval=30s
-pcs resource create csm-web systemd:csm_web op monitor interval=30s
 
-pcs resource group add csm-kib kibana-vip kibana csm-web csm-agent
-pcs constraint colocation add csm-kib with els-search-clone score=INFINITY
-pcs constraint colocation add csm-kib with consul-c1 score=INFINITY
+pcs cluster cib csmcfg
+pcs -f csmcfg resource create csm-agent systemd:csm_agent op monitor interval=30s
+pcs -f csmcfg resource create csm-web systemd:csm_web op monitor interval=30s
 
-echo 'Adding rabbit-mq resources and constraints...'
-pcs resource create rabbitmq systemd:rabbitmq-server clone op monitor interval=30s
-pcs constraint colocation add csm-kib with rabbitmq-clone score=INFINITY
+pcs -f csmcfg resource group add csm-kibana kibana-vip kibana csm-web csm-agent
+pcs -f csmcfg constraint colocation add csm-kibana with els-search-clone score=INFINITY
+pcs -f csmcfg constraint colocation add csm-kibana with consul-c1 score=INFINITY
+
+pcs -f csmcfg constraint colocation add csm-kibana with rabbitmq-clone score=INFINITY
+pcs cluster cib-push csmcfg --config


### PR DESCRIPTION
Solution:
- Remove creation of rabbitmq resource.
- Persist csm-ha resources configuration.

Closes #796

[ci skip]