### PR TITLE
Problem: prov-ha-reset does not remove newly added resource clones

### DIFF
--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -22,13 +22,14 @@ for node_id in 2 1; do
 done
 
 resources=(
-    s3back{prod,cons}-c2
-    s3back{prod,cons}-c1
-    haproxy-c{2,1}
-    statsd-c{2,1}
-    els-search-c{2,1}
-    s3auth-c{2,1}
-    ldap-c{2,1}
+    s3back{prod,cons}
+    s3back{prod,cons}
+    haproxy
+    statsd
+    els-search
+    s3auth
+    ldap
+    rabbitmq
     c{2,1}
     mero-kernel
     lnet


### PR DESCRIPTION
Per node resource instances were replaced by resource clones for
ldap, s3auth, elasticsearch, statsd, haproxy, s3backgroundconsumer,
s3backgroundproducers and rabbitmq.

Solution: remove c1, c2 from resource names.

Closes #798 

[ci skip]