### PR TITLE
Problem: no script to cleanup CSM pacemaker resources

### DIFF
--- a/utils/prov-ha-csm-reset
+++ b/utils/prov-ha-csm-reset
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+# set -x
+
+resources=(
+    csm-agent
+    csm-web
+    kibana
+    kibana-vip
+)
+for r in ${resources[@]}; do
+    pcs resource delete $r || true
+done


### PR DESCRIPTION
Solution: add a script to cleanup csm resources in pacemaker

[ci skip]