### PR TITLE
Problem: prov-ha-reset may leave /var/mero{1,2} mounted

### DIFF
--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -37,3 +37,6 @@ resources=(
 for r in ${resources[@]}; do
     pcs resource delete $r || true
 done
+
+umount -l /var/mero2 || true
+umount -l /var/mero1 || true


### PR DESCRIPTION
This will cause ees_ha provisioning to fail next time.

Solution: umount `/var/mero{1,2}` from the `prov-ha-reset`
script.