### PR TITLE
Problem: unneeded argument in build-ees-ha-csm CLI

### DIFF
--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -70,8 +70,7 @@ while true; do
     esac
 done
 
-cdf=${1:-}
-argsfile=${2:-}
+argsfile=${1:-}
 
 if [[ -f $argsfile ]]; then
     while IFS=': ' read name value; do


### PR DESCRIPTION
`build-ees-ha-csm` doesn't use its CDF argument.

Solution: delete the unneeded argument.
