### PR TITLE
Problem: ees-ha: md-volumes are not checked

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -120,6 +120,16 @@ fi
     exit 1
 }
 
+[[ -b $lvolume ]] || {
+    echo "ERROR: meta-data volume $lvolume is not available" >&2
+    exit 1
+}
+
+[[ -b $rvolume ]] || {
+    echo "ERROR: meta-data volume $rvolume is not available" >&2
+    exit 1
+}
+
 echo 'Adding the roaming IP addresses into Pacemaker...'
 sudo pcs cluster cib icfg
 sudo pcs -f icfg resource create ip-c1 ocf:heartbeat:IPaddr2 \


### PR DESCRIPTION
The `build-ees-ha` script does not check for the meta-data
volumes beforehand. If the volume is not present, the problem
will be detected only at the later stage when the volume is
tried to be mount-ed - which, of course, will fail - and the
reason of this failure might not be very obvious for a user.

Solution: check for the volumes beforehand, in the very
beginning of the `build-ees-ha` script, and report error if it
is not present.

[skip ci]