### PR TITLE
Problem: ees-ha: s3server stop may be too long

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -406,10 +406,10 @@ sudo pcs -f mcfg constraint order consul-c1 then hax-c2
 sudo pcs cluster cib-push mcfg --config
 
 echo 'Adding Mero to Pacemaker...'
-cmd='
-sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=15sec/"
-         -i /usr/lib/systemd/system/m0d@.service &&
-sudo systemctl daemon-reload'
+
+cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=15sec/"
+              -i /usr/lib/systemd/system/m0d@.service &&
+     sudo systemctl daemon-reload'
 run_on_both $cmd
 
 get_fid() {
@@ -497,6 +497,11 @@ s3_resource_add() {
    done
    pcs cluster cib-push s3cfg --config
 }
+
+cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=15sec/"
+              -i /usr/lib/systemd/system/s3server@.service &&
+     sudo systemctl daemon-reload'
+run_on_both $cmd
 
 s3_resource_add consul-server-c1-conf.json c1 $lnode $rnode
 s3_resource_add consul-server-c2-conf.json c2 $rnode $lnode


### PR DESCRIPTION
Currently, the systemd TimeoutStopSec parameter for s3server
is set to 5 minutes and sometimes (due to some bug in Mero)
the stopping of s3server may take up to all these 5 minutes,
which is too long. (It affects cluster stop, failover, failback, etc.)

Note: we already have decreased this timeout for m0d processes
to 15 seconds for similar reasons.

Solution: decrease the systemd TimeoutStopSec to 15 seconds
for s3server.

[skip ci]