### PR TITLE
Problem: ees-ha: hctl status does not work

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -85,7 +85,7 @@ def process_status(cns: Consul, host: str, proc: Process) -> str:
 
 
 def consul_status(host: str) -> str:
-    cmd = '{}sudo systemctl is-active --quiet hare-consul-agent'.format(
+    cmd = '{}sudo systemctl is-active --quiet hare-consul-agent*'.format(
         '' if is_localhost(host) else f'ssh {host} ')
     return 'passing' if os.system(cmd) == 0 else 'offline'
 


### PR DESCRIPTION
In EES-HA we use Pacemaker to start/stop Consul systemd
service. So the service name was updated from `hare-consul-agent`
to `hare-consul-agent-c{1,2}`. As result, `hctl status`
stopped working. But it's a convenient utility for devs and
QA's to check the services status and get endpoint addresses.

Solution: update utils/hare-status:consul_status() function
which checks for the Consul systemd service to support the
new unit names also.

Closes #813.