### PR TITLE
Problem: misleading 'hctl shutdown' error message

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -86,6 +86,12 @@ def consul_is_active_at(hostname: str) -> bool:
     return os.system(cmd) == 0
 
 
+def pcs_consul_is_active_at(hostname: str) -> bool:
+    cmd = ssh_prefix(hostname) + \
+        'sudo systemctl is-active --quiet hare-consul-agent*'
+    return os.system(cmd) == 0
+
+
 def exec_silent(cmd: str) -> bool:
     return os.system(cmd) == 0
 
@@ -160,7 +166,10 @@ def _stop_parallel(process_list: List[Process], thread_count: int = 8) -> None:
 def main() -> None:
     _setup_logging()
     if not consul_is_active_at('localhost'):
-        exit('Cluster is not running')
+        if pcs_consul_is_active_at('localhost'):
+            exit("Cluster is run by Pacemaker, try `pcs cluster stop --all'")
+        else:
+            exit('Cluster is not running')
 
     cns = Consul()
     processes = processes_by_consul_svc_name(cns)


### PR DESCRIPTION
In EES-HA the cluster is being run by Pacemaker, but the
`hctl shutdown` command shows the following:
```
$ hctl shutdown
Cluster is not running
```

This is very confusing.

Solution: update `utils/hare-shutdown` to check for Consul
systemd service in EES-HA and show the correct error message:
```
$ hctl shutdown
Cluster is run by Pacemaker, try `pcs cluster stop --all'
```
