### PR TITLE
Problem: support_bundle section of setup.yaml is not used

### DIFF
--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -14,3 +14,6 @@ hare:
   reset:
     script: null
     args: null
+
+support_bundle:
+    - /opt/seagate/eos/hare/bin/hctl reportbug


### PR DESCRIPTION
Solution: rely on hctl reportbug feature and add command invocation
support_bundle section of setup.yaml file.

Currently hare script is used, but m0reportbug may be considered as an
option depending on amount of required modifications.