### PR TITLE
Problem: ees-ha: failover / failback takes too long

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -402,7 +402,7 @@ sudo pcs cluster cib-push mcfg --config
 
 echo 'Adding Mero to Pacemaker...'
 
-cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=15sec/"
+cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
               -i /usr/lib/systemd/system/m0d@.service &&
      sudo systemctl daemon-reload'
 run_on_both $cmd
@@ -493,7 +493,7 @@ s3_resource_add() {
    pcs cluster cib-push s3cfg --config
 }
 
-cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=15sec/"
+cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
               -i /usr/lib/systemd/system/s3server@.service &&
      sudo systemctl daemon-reload'
 run_on_both $cmd


### PR DESCRIPTION
Currently, the systemd stop timeout is 15 secs. For s3server,
m0d-ios, m0d-confd - it's already 15 * 3 == 45 seconds just
to stop them. It's too much and does not fit MRD requirement
(which is up to 30 secs).

Solution: decrease TimeoutStopSec to 5 secs for m0d and
s3server systemd units in `build-ees-ha` script.

Relates to EOS-6417.

[skip ci]