### PR TITLE
Problem: tar --remove-files in hare-reportbug may fail

### DIFF
--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -56,6 +56,7 @@ fi
 mkdir -p "$dest_dir/hare/$HOSTNAME"
 cd "$dest_dir/hare/$HOSTNAME"
 
+exec 5>&2
 exec 2> >(tee _reportbug.stderr >&2)
 
 sudo journalctl --no-pager --full --utc --boot --output short-precise \
@@ -71,4 +72,7 @@ cp --parents /var/lib/hare/*.{yaml,json} . 2>/dev/null || true
 cp -r --parents /var/log/hare/ . 2>/dev/null || true
 
 cd ..
+
+# Close copied stderr to avoid usage of $HOSTNAME directory
+exec 2>&5
 tar --remove-files -czf "hare_${bundle_id}.tar.gz" $HOSTNAME


### PR DESCRIPTION
Solution: undo stderr redirection before creating archive.

Closes #827.