### PR TITLE
Problem: ees-ha: failed-over Consul agent may not start

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -280,7 +280,7 @@ consul_c1_cfg_dir=$hare_dir/consul-$ip1
 
 sudo sed \
  -e "/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c2_cfg_dir" \
- -e "/ExecStart=/iExecStartPre=/opt/seagate/eos/hare/bin/consul force-leave $rnode" \
+ -e "/ExecStart=/iExecStartPre=-/opt/seagate/eos/hare/bin/consul force-leave $rnode" \
  -e "/ExecStartPost=/aExecStartPost=$(cmd_deregister_node $rnode)" \
  -i /usr/lib/systemd/system/hare-consul-agent-c2.service
 sudo systemctl daemon-reload
@@ -288,7 +288,7 @@ sudo systemctl daemon-reload
 cmd="
 sudo sed
  -e '/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c1_cfg_dir'
- -e '/ExecStart=/iExecStartPre=/opt/seagate/eos/hare/bin/consul force-leave $lnode'
+ -e '/ExecStart=/iExecStartPre=-/opt/seagate/eos/hare/bin/consul force-leave $lnode'
  -e \"/ExecStartPost=/aExecStartPost=$(cmd_deregister_node $lnode)\"
  -i /usr/lib/systemd/system/hare-consul-agent-c1.service &&
 sudo systemctl daemon-reload"


### PR DESCRIPTION
For example, when both nodes are rebooted but only one
is started - failed-over Consul agent systemd unit may fail
on the `ExecStartPre=consul force-leave <node>` command:

```
Error force leaving: Unexpected response code: 500 (agent: No node found with name '<node-name>')
```

Solution: instruct systemd to ignore the exit status of
`consul force-leave` command and start Consul agent anyway.