### PR TITLE
Problem: hax exits if Consul has not started listening TCP yet

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -13,7 +13,6 @@ from typing import NamedTuple
 
 __all__ = ['main']
 
-
 HL_Fids = NamedTuple('HL_Fids', [('hax_ep', str), ('hax_fid', Fid),
                                  ('ha_fid', Fid), ('rm_fid', Fid)])
 
@@ -36,11 +35,7 @@ def _get_halink_fids(util: ConsulUtil) -> HL_Fids:
     hax_fid: Fid = util.get_hax_fid()
     ha_fid: Fid = util.get_ha_fid()
     rm_fid: Fid = util.get_rm_fid()
-    return HL_Fids(
-            hax_ep,
-            hax_fid,
-            ha_fid,
-            rm_fid)
+    return HL_Fids(hax_ep, hax_fid, ha_fid, rm_fid)
 
 
 def main():

--- a/hax/mypy.ini
+++ b/hax/mypy.ini
@@ -2,3 +2,8 @@
 python_version = 3.6
 warn_return_any = True
 
+[mypy-urllib3]
+ignore_missing_imports = True
+
+[mypy-urllib3.exceptions]
+ignore_missing_imports = True


### PR DESCRIPTION
Solution: consider the exceptions from urllib3 module (i.e.
network-related issues) as a reason to repeat the operation. Previously
ConsulException subclasses were considered as a reason for repeating.

Closes EOS-6448