### PR TITLE
Problem: ees-ha: regression - no I/O after failover

### DIFF
--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -7,9 +7,8 @@ HARE_BASE_DIR=/opt/seagate/eos/hare
 PATH="$HARE_BASE_DIR/libexec:$PATH"
 PATH="$HARE_BASE_DIR/bin:$PATH"
 export PATH
-NODE=`hostname -f`
 
 # TODO: should it be `consul` and PATH=/opt/seagate/eos/hare/bin:$PATH ?
-exec consul agent -node "$NODE" -bind $BIND -client "$CLIENT" $JOIN \
+exec consul agent -bind $BIND -client "$CLIENT" $JOIN \
      -config-file=/var/lib/hare/consul-$MODE-conf.json \
      -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS

--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -322,11 +322,11 @@ ssh $rnode $cmd
 sudo cp $hare_dir/consul-server-conf.json \
         $hare_dir/consul-server-c1-conf.json
 sudo sed -e 's/"--hax"/"--svc", "hare-hax-c1"/' \
+         -e "/\"server\"/a\ \ \"node_name\": \"$lnode\"," \
          -i $hare_dir/consul-server-c1-conf.json
 cp $hare_dir/consul-server-c1-conf.json \
    /tmp/consul-server-c1-conf.json
-sudo sed -e "/\"server\"/a\ \ \"node_name\": \"$lnode\"," \
-         -e '/\"server\"/a\ \ "leave_on_terminate": true,' \
+sudo sed -e '/\"server\"/a\ \ "leave_on_terminate": true,' \
          -i /tmp/consul-server-c1-conf.json
 scp /tmp/consul-server-c1-conf.json $rnode:$hare_dir/
 
@@ -334,11 +334,11 @@ cmd="
 sudo cp $hare_dir/consul-server-conf.json \
         $hare_dir/consul-server-c2-conf.json &&
 sudo sed -e 's/\"--hax\"/\"--svc\", \"hare-hax-c2\"/' \
+         -e '/\"server\"/a\ \ \"node_name\": \"$rnode\",' \
          -i $hare_dir/consul-server-c2-conf.json &&
 cp $hare_dir/consul-server-c2-conf.json \
    /tmp/consul-server-c2-conf.json &&
-sudo sed -e '/\"server\"/a\ \ \"node_name\": \"$rnode\",' \
-         -e '/\"server\"/a\ \ \"leave_on_terminate\": true,' \
+sudo sed -e '/\"server\"/a\ \ \"leave_on_terminate\": true,' \
          -i /tmp/consul-server-c2-conf.json"
 ssh $rnode $cmd
 scp $rnode:/tmp/consul-server-c2-conf.json $hare_dir/


### PR DESCRIPTION
After commit 703e1124 the the I/O after failover stopped
working (EOS-6416). The problem is that in 703e1124 we
started to specify the node name explicitly via the
`systemd/hare-consul` startup script. So during the failover
we tried to start two Consul agents on the same node with
the same node name! As result, Could could not find
its old neighbour and could not restore its state.

Solution: stop specifying the node name via the
`systemd/hare-consul` startup script, but set it in the
Consul agents config files `consul-server-conf-c{1,2}.json`.
These two config files are present on both nodes for both
agents, so even during the failover each agent will know
its node name.

Closes EOS-6416.