### PR TITLE
Problem: system update needs to stop cluster without fencing

### DIFF
--- a/pcswrap/pcswrap/client.py
+++ b/pcswrap/pcswrap/client.py
@@ -2,11 +2,25 @@ import argparse
 import json
 import os
 import sys
+import logging
 from typing import List
 
-from pcswrap.exception import CliException
+from pcswrap.exception import CliException, MaintenanceFailed, TimeoutException
 from pcswrap.internal.connector import CliConnector
-from pcswrap.types import Node, PcsConnector
+from pcswrap.types import Resource, Node, PcsConnector
+from pcswrap.internal.waiter import Waiter
+
+__all__ = ['Client', 'main']
+
+
+def all_stopped(resource_list: List[Resource]) -> bool:
+    logging.debug('The following resources are found: %s', resource_list)
+    return all([not r.active for r in resource_list])
+
+
+def non_standby_nodes(node_list: List[Node]) -> bool:
+    logging.debug('The following nodes are found: %s', node_list)
+    return all([not n.standby for n in node_list])
 
 
 class Client():
@@ -32,22 +46,64 @@ class Client():
     def get_cluster_name(self) -> str:
         return self.connector.get_cluster_name()
 
-    def standby_all(self) -> None:
+    def standby_all(self, timeout: int = 120) -> None:
         self.connector.standby_all()
+        waiter = Waiter(title='no running resources',
+                        timeout_seconds=timeout,
+                        provider_fn=self.connector.get_resources,
+                        predicate=all_stopped)
+        waiter.wait()
 
-    def unstandby_all(self) -> None:
+    def unstandby_all(self, timeout: int = 120) -> None:
         self.connector.unstandby_all()
+        waiter = Waiter(title='no standby nodes in cluster',
+                        timeout_seconds=timeout,
+                        provider_fn=self.connector.get_nodes,
+                        predicate=non_standby_nodes)
+        waiter.wait()
 
     def shutdown_node(self, node_name: str) -> None:
         self.connector.shutdown_node(node_name)
+
+    def disable_stonith(self, timeout: int = 120) -> None:
+        resources = self.connector.get_stonith_resources()
+        for r in resources:
+            self.connector.disable_resource(r)
+
+        waiter = Waiter(title='stonith resources are disabled',
+                        timeout_seconds=timeout,
+                        provider_fn=self.connector.get_stonith_resources,
+                        predicate=all_stopped)
+        waiter.wait()
+
+    def enable_stonith(self, timeout: int = 120) -> None:
+        resources = self.connector.get_stonith_resources()
+        for r in resources:
+            self.connector.enable_resource(r)
+
+        def all_started(resource_list: List[Resource]) -> bool:
+            logging.debug('The following resources are found: %s',
+                          resource_list)
+            return all([r.active for r in resource_list])
+
+        waiter = Waiter(title='stonith resources are enabled',
+                        timeout_seconds=timeout,
+                        provider_fn=self.connector.get_stonith_resources,
+                        predicate=all_started)
+        waiter.wait()
 
 
 def parse_opts(argv: List[str]):
     prog_name = os.environ.get('PCSCLI_PROG_NAME')
 
-    p = argparse.ArgumentParser(
-        prog=prog_name,
-        description='Manages the nodes in HA cluster.')
+    p = argparse.ArgumentParser(prog=prog_name,
+                                description='Manages the nodes in HA cluster.')
+    p.add_argument('--verbose',
+                   help='Be verbose while executing',
+                   action='store_true',
+                   default=False,
+                   dest='verbose')
+
     subparsers = p.add_subparsers()
     status_parser = subparsers.add_parser(
         'status',
@@ -86,6 +142,37 @@ def parse_opts(argv: List[str]):
                                  type=str,
                                  nargs=1,
                                  help='Name of the node to poweroff')
+    maintenance_parser = subparsers.add_parser(
+        'maintenance',
+        help='Switch the cluster to maintenance mode',
+    )
+    maintenance_parser.add_argument('--all',
+                                    dest='maintenance_all',
+                                    action='store_true')
+
+    maintenance_parser.add_argument(
+        '--timeout-sec',
+        type=int,
+        dest='timeout_sec',
+        default=120,
+        help='Maximum time that this command will'
+        ' wait for any operation to complete before raising an error')
+
+    unmaintenance_parser = subparsers.add_parser(
+        'unmaintenance',
+        help='Move the cluster from maintenance back to normal mode',
+    )
+    unmaintenance_parser.add_argument('--all',
+                                      dest='unmaintenance_all',
+                                      action='store_true')
+
+    unmaintenance_parser.add_argument(
+        '--timeout-sec',
+        type=int,
+        dest='timeout_sec',
+        default=120,
+        help='Maximum time that this command will'
+        ' wait for any operation to complete before raising an error')
     opts = p.parse_args(argv)
     return opts
 
@@ -94,7 +181,42 @@ def _get_client() -> Client:
     return Client()
 
 
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level,
+                        stream=sys.stderr,
+                        format='%(asctime)s [%(levelname)s] %(message)s')
+
+
+def _cluster_maintenance(timeout: int = 120):
+    client = Client()
+    logging.info('Disabling stonith resources first')
+
+    try:
+        client.disable_stonith(timeout)
+    except TimeoutException:
+        raise MaintenanceFailed()
+    logging.debug('Switching to standby mode')
+    try:
+        client.standby_all(timeout)
+    except Exception:
+        raise MaintenanceFailed()
+
+    logging.info('All nodes are in standby mode now')
+
+
+def _cluster_unmaintenance(timeout: int = 120):
+    client = Client()
+    client.unstandby_all(timeout=timeout)
+    logging.info('All nodes are back to normal mode.')
+    client.enable_stonith(timeout=timeout)
+    logging.info('Stonith resources are enabled. Cluster is functional now.')
+
+
 def _run(args) -> None:
+    is_verbose = args.verbose
+    _setup_logging(is_verbose)
+
     if hasattr(args, 'standby_node'):
         if hasattr(args, 'standby_node_all'):
             _get_client().standby_all()
@@ -112,15 +234,32 @@ def _run(args) -> None:
     elif hasattr(args, 'shutdown_node'):
         node = args.shutdown_node[0]
         _get_client().shutdown_node(node)
+    elif hasattr(args, 'maintenance_all'):
+        _cluster_maintenance(timeout=args.timeout_sec)
+    elif hasattr(args, 'unmaintenance_all'):
+        _cluster_unmaintenance(timeout=args.timeout_sec)
 
 
 def main() -> None:
     args = parse_opts(sys.argv[1:])
     try:
         _run(args)
+    except MaintenanceFailed:
+        logging.error('Failed to switch to maintenance mode.')
+        logging.error(
+            'The cluster is now unstable. Maintenance mode '
+            'was not rolled back to prevent STONITH actions to happen '
+            'unexpectedly.')
+        prog_name = os.environ.get('PCSCLI_PROG_NAME') or 'pcswrap'
+        logging.error(
+            'Consider running `%s unmaintenance --all` to switch'
+            ' the cluster to normal mode manually.', prog_name)
+        sys.exit(1)
+
     except CliException as e:
-        print(e.err, file=sys.stderr)
+        logging.error('Exiting with FAILURE: %s', e)
+        logging.debug('Detailed info', exc_info=True)
         sys.exit(1)
     except Exception:
-        print('Unexpected error:', sys.exc_info()[0], file=sys.stderr)
+        logging.exception('Unexpected error happened')
         sys.exit(1)

--- a/pcswrap/pcswrap/exception.py
+++ b/pcswrap/pcswrap/exception.py
@@ -5,9 +5,18 @@ class PcsException(RuntimeError):
     pass
 
 
+class TimeoutException(PcsException):
+    pass
+
+
 @dataclass(eq=False)
 class PcsNoStatusException(PcsException):
     message: str
+
+
+@dataclass(eq=False)
+class MaintenanceFailed(PcsException):
+    pass
 
 
 @dataclass(eq=False)

--- a/pcswrap/pcswrap/internal/waiter.py
+++ b/pcswrap/pcswrap/internal/waiter.py
@@ -1,0 +1,38 @@
+import logging
+from pcswrap.exception import TimeoutException
+from time import sleep
+
+
+class Waiter:
+    def __init__(self,
+                 title: str = '',
+                 provider_fn=None,
+                 predicate=None,
+                 pause_seconds=2,
+                 timeout_seconds=120):
+        assert provider_fn
+        assert predicate
+        self.provider_fn = provider_fn
+        self.predicate = predicate
+        self.pause_seconds = pause_seconds
+        self.timeout_seconds = timeout_seconds
+        self.title = title
+
+    def wait(self):
+        time_left = self.timeout_seconds
+        msg = self.title
+        logging.debug(
+            f'Waiting for condition "{msg}", timeout = {time_left} sec')
+        while True:
+            data = self.provider_fn()
+            ok = self.predicate(data)
+            logging.debug(f'{msg}? - {ok}')
+            if ok:
+                logging.debug(f'Condition "{msg}" is met, exiting')
+                return
+            time_left = time_left - self.pause_seconds
+            if time_left <= 0:
+                logging.debug(f'Condition "{msg}" is not met,'
+                              ' exiting by timeout')
+                raise TimeoutException()
+            sleep(self.pause_seconds)

--- a/pcswrap/pcswrap/types.py
+++ b/pcswrap/pcswrap/types.py
@@ -2,7 +2,14 @@ from typing import List, NamedTuple
 from abc import ABC, abstractmethod
 
 Node = NamedTuple('Node', [('name', str), ('online', bool), ('shutdown', bool),
-                           ('standby', bool)])
+                           ('standby', bool), ('unclean', bool)])
+
+Resource = NamedTuple('Resource', [('id', str), ('resource_agent', str),
+                                   ('role', str), ('target_role', str),
+                                   ('active', bool), ('orphaned', bool),
+                                   ('blocked', bool), ('managed', bool),
+                                   ('failed', bool), ('failure_ignored', bool),
+                                   ('nodes_running_on', int)])
 
 
 class PcsConnector(ABC):
@@ -32,4 +39,20 @@ class PcsConnector(ABC):
 
     @abstractmethod
     def shutdown_node(self, node_name: str) -> None:
+        pass
+
+    @abstractmethod
+    def get_resources(self) -> List[Resource]:
+        pass
+
+    @abstractmethod
+    def get_stonith_resources(self) -> List[Resource]:
+        pass
+
+    @abstractmethod
+    def disable_resource(self, resource: Resource) -> None:
+        pass
+
+    @abstractmethod
+    def enable_resource(self, resource: Resource) -> None:
         pass

--- a/pcswrap/tests/status-xml-plain-resources.xml
+++ b/pcswrap/tests/status-xml-plain-resources.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<crm_mon version="1.1.20">
+    <summary>
+        <stack type="corosync" />
+        <current_dc present="true" version="1.1.20-5.el7_7.2-3c4c782f70" name="ssc-vm-c-259.colo.seagate.com" id="1" with_quorum="true" />
+        <last_update time="Thu Mar 26 06:05:30 2020" />
+        <last_change time="Thu Mar 26 05:58:43 2020" user="root" client="cibadmin" origin="ssc-vm-c-260.colo.seagate.com" />
+        <nodes_configured number="2" expected_votes="unknown" />
+        <resources_configured number="3" disabled="2" blocked="0" />
+        <cluster_options stonith-enabled="true" symmetric-cluster="true" no-quorum-policy="ignore" maintenance-mode="false" />
+    </summary>
+    <nodes>
+        <node name="ssc-vm-c-259.colo.seagate.com" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="true" resources_running="0" type="member" />
+        <node name="ssc-vm-c-260.colo.seagate.com" id="2" online="true" standby="true" standby_onfail="false" maintenance="false" pending="false" unclean="true" shutdown="false" expected_up="true" is_dc="false" resources_running="1" type="member" />
+    </nodes>
+    <resources>
+        <resource id="c-259.stonith" resource_agent="stonith:fence_dummy" role="Stopped" target_role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0" />
+        <resource id="c-260.stonith" resource_agent="stonith:fence_dummy" role="Stopped" target_role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0" />
+        <resource id="MyResource" resource_agent="ocf::heartbeat:anything" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="true" failure_ignored="false" nodes_running_on="1" >
+            <node name="ssc-vm-c-260.colo.seagate.com" id="2" cached="false"/>
+        </resource>
+    </resources>
+    <node_attributes>
+        <node name="ssc-vm-c-259.colo.seagate.com">
+        </node>
+        <node name="ssc-vm-c-260.colo.seagate.com">
+        </node>
+    </node_attributes>
+    <node_history>
+        <node name="ssc-vm-c-260.colo.seagate.com">
+            <resource_history id="c-259.stonith" orphan="false" migration-threshold="1000000">
+                <operation_history call="15" task="monitor" interval="10000ms" last-rc-change="Wed Mar 25 09:07:05 2020" exec-time="56ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="120" task="stop" last-rc-change="Thu Mar 26 05:51:41 2020" last-run="Thu Mar 26 05:51:41 2020" exec-time="0ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+            <resource_history id="MyResource" orphan="false" migration-threshold="1000000" fail-count="1000000" last-failure="Thu Mar 26 05:59:03 2020">
+                <operation_history call="118" task="monitor" interval="10000ms" last-rc-change="Thu Mar 26 05:10:51 2020" exec-time="13ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="122" task="stop" last-rc-change="Thu Mar 26 05:58:43 2020" last-run="Thu Mar 26 05:58:43 2020" exec-time="20004ms" queue-time="0ms" rc="1" rc_text="unknown error" />
+                <operation_history call="122" task="stop" last-rc-change="Thu Mar 26 05:58:43 2020" last-run="Thu Mar 26 05:58:43 2020" exec-time="20004ms" queue-time="0ms" rc="1" rc_text="unknown error" />
+            </resource_history>
+        </node>
+        <node name="ssc-vm-c-259.colo.seagate.com">
+            <resource_history id="c-260.stonith" orphan="false" migration-threshold="1000000">
+                <operation_history call="15" task="monitor" interval="10000ms" last-rc-change="Wed Mar 25 09:06:36 2020" exec-time="53ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="22" task="stop" last-rc-change="Thu Mar 26 05:51:47 2020" last-run="Thu Mar 26 05:51:47 2020" exec-time="1ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+            <resource_history id="MyResource" orphan="false" migration-threshold="1000000">
+                <operation_history call="13" task="probe" last-rc-change="Wed Mar 25 09:06:36 2020" last-run="Wed Mar 25 09:06:36 2020" exec-time="17ms" queue-time="0ms" rc="1" rc_text="unknown error" />
+                <operation_history call="18" task="monitor" interval="10000ms" last-rc-change="Wed Mar 25 09:06:36 2020" exec-time="13ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="20" task="stop" last-rc-change="Wed Mar 25 09:07:05 2020" last-run="Wed Mar 25 09:07:05 2020" exec-time="19ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+        </node>
+    </node_history>
+    <failures>
+        <failure op_key="MyResource_stop_0" node="ssc-vm-c-260.colo.seagate.com" exitstatus="unknown error" exitreason="" exitcode="1" call="122" status="Timed Out" last-rc-change="Thu Mar 26 05:58:43 2020" queued="0" exec="20004" interval="0" task="stop" />
+        <failure op_key="MyResource_monitor_0" node="ssc-vm-c-259.colo.seagate.com" exitstatus="unknown error" exitreason="" exitcode="1" call="13" status="complete" last-rc-change="Wed Mar 25 09:06:36 2020" queued="0" exec="17" interval="0" task="monitor" />
+    </failures>
+    <fence_history>
+        <fence_event target="ssc-vm-c-260.colo.seagate.com" action="reboot" state="failed" origin="ssc-vm-c-259.colo.seagate.com" client="crmd.16818" completed="Thu Mar 26 05:59:04 2020" />
+        <fence_event target="ssc-vm-c-260.colo.seagate.com" action="reboot" state="success" origin="ssc-vm-c-260.colo.seagate.com" client="crmd.18402" delegate="ssc-vm-c-259.colo.seagate.com" completed="Wed Mar 25 09:06:35 2020" />
+    </fence_history>
+    <tickets>
+    </tickets>
+    <bans>
+        <ban id="location-c-259.stonith-ssc-vm-c-259.colo.seagate.com--INFINITY" resource="c-259.stonith" node="ssc-vm-c-259.colo.seagate.com" weight="-1000000" master_only="false" />
+        <ban id="location-c-260.stonith-ssc-vm-c-260.colo.seagate.com--INFINITY" resource="c-260.stonith" node="ssc-vm-c-260.colo.seagate.com" weight="-1000000" master_only="false" />
+    </bans>
+</crm_mon>

--- a/pcswrap/tests/status-xml-w-clones.xml
+++ b/pcswrap/tests/status-xml-w-clones.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<crm_mon version="1.1.20">
+    <summary>
+        <stack type="corosync" />
+        <current_dc present="true" version="1.1.20-5.el7_7.1-3c4c782f70" name="smc8-m11" id="2" with_quorum="true" />
+        <last_update time="Wed Feb 26 14:07:26 2020" />
+        <last_change time="Tue Feb 25 20:08:36 2020" user="root" client="cibadmin" origin="smc7-m11" />
+        <nodes_configured number="2" expected_votes="unknown" />
+        <resources_configured number="6" disabled="0" blocked="0" />
+        <cluster_options stonith-enabled="false" symmetric-cluster="true" no-quorum-policy="ignore" maintenance-mode="false" />
+    </summary>
+    <nodes>
+        <node name="smc7-m11" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="3" type="member" />
+        <node name="smc8-m11" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="true" resources_running="3" type="member" />
+    </nodes>
+    <resources>
+        <clone id="lnet-clone" multi_state="false" unique="false" managed="true" failed="false" failure_ignored="false" >
+            <resource id="lnet" resource_agent="systemd:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                <node name="smc8-m11" id="2" cached="false"/>
+            </resource>
+            <resource id="lnet" resource_agent="systemd:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                <node name="smc7-m11" id="1" cached="false"/>
+            </resource>
+        </clone>
+        <group id="c1" number_resources="2" >
+             <resource id="ip-c1" resource_agent="ocf::heartbeat:IPaddr2" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                 <node name="smc7-m11" id="1" cached="false"/>
+             </resource>
+             <resource id="lnet-c1" resource_agent="ocf::seagate:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                 <node name="smc7-m11" id="1" cached="false"/>
+             </resource>
+        </group>
+        <group id="c2" number_resources="2" >
+             <resource id="ip-c2" resource_agent="ocf::heartbeat:IPaddr2" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                 <node name="smc8-m11" id="2" cached="false"/>
+             </resource>
+             <resource id="lnet-c2" resource_agent="ocf::seagate:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                 <node name="smc8-m11" id="2" cached="false"/>
+             </resource>
+        </group>
+    </resources>
+    <node_attributes>
+        <node name="smc7-m11">
+        </node>
+        <node name="smc8-m11">
+        </node>
+    </node_attributes>
+    <node_history>
+        <node name="smc8-m11">
+            <resource_history id="ip-c2" orphan="false" migration-threshold="1000000">
+                <operation_history call="29" task="start" last-rc-change="Tue Feb 25 19:55:33 2020" last-run="Tue Feb 25 19:55:33 2020" exec-time="107ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="30" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="63ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+            <resource_history id="lnet" orphan="false" migration-threshold="1000000">
+                <operation_history call="15" task="probe" last-rc-change="Tue Feb 25 19:55:27 2020" last-run="Tue Feb 25 19:55:27 2020" exec-time="4ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="25" task="start" last-rc-change="Tue Feb 25 19:55:31 2020" last-run="Tue Feb 25 19:55:31 2020" exec-time="2117ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="28" task="monitor" interval="60000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="1ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+            <resource_history id="lnet-c2" orphan="false" migration-threshold="1000000">
+                <operation_history call="31" task="start" last-rc-change="Tue Feb 25 19:55:33 2020" last-run="Tue Feb 25 19:55:33 2020" exec-time="42ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="32" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="22ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+        </node>
+        <node name="smc7-m11">
+            <resource_history id="ip-c1" orphan="false" migration-threshold="1000000">
+                <operation_history call="61" task="start" last-rc-change="Tue Feb 25 20:08:36 2020" last-run="Tue Feb 25 20:08:36 2020" exec-time="80ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="62" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 20:08:36 2020" exec-time="49ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+            <resource_history id="lnet" orphan="false" migration-threshold="1000000">
+                <operation_history call="15" task="probe" last-rc-change="Tue Feb 25 19:55:27 2020" last-run="Tue Feb 25 19:55:27 2020" exec-time="4ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="25" task="start" last-rc-change="Tue Feb 25 19:55:31 2020" last-run="Tue Feb 25 19:55:31 2020" exec-time="2097ms" queue-time="1ms" rc="0" rc_text="ok" />
+                <operation_history call="28" task="monitor" interval="60000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="2ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+            <resource_history id="lnet-c1" orphan="false" migration-threshold="1000000">
+                <operation_history call="63" task="start" last-rc-change="Tue Feb 25 20:08:36 2020" last-run="Tue Feb 25 20:08:36 2020" exec-time="35ms" queue-time="0ms" rc="0" rc_text="ok" />
+                <operation_history call="64" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 20:08:36 2020" exec-time="20ms" queue-time="0ms" rc="0" rc_text="ok" />
+            </resource_history>
+        </node>
+    </node_history>
+    <fence_history>
+    </fence_history>
+    <tickets>
+    </tickets>
+    <bans>
+    </bans>
+</crm_mon>

--- a/pcswrap/tests/test_connector.py
+++ b/pcswrap/tests/test_connector.py
@@ -1,99 +1,25 @@
 # flake8: noqa
-import unittest
 import sys
 sys.path.insert(0, '..')
-from pcswrap.internal.connector import CliExecutor, CliConnector
-from pcswrap.exception import PcsNoStatusException
-from pcswrap.client import Client
 from unittest.mock import Mock, MagicMock
+from pcswrap.client import Client
+from pcswrap.exception import PcsNoStatusException
+from pcswrap.internal.connector import CliExecutor, CliConnector
+import unittest
+import os
 
-GOOD_XML = '''<?xml version="1.0"?>
-<crm_mon version="1.1.20">
-    <summary>
-        <stack type="corosync" />
-        <current_dc present="true" version="1.1.20-5.el7_7.1-3c4c782f70" name="smc8-m11" id="2" with_quorum="true" />
-        <last_update time="Wed Feb 26 14:07:26 2020" />
-        <last_change time="Tue Feb 25 20:08:36 2020" user="root" client="cibadmin" origin="smc7-m11" />
-        <nodes_configured number="2" expected_votes="unknown" />
-        <resources_configured number="6" disabled="0" blocked="0" />
-        <cluster_options stonith-enabled="false" symmetric-cluster="true" no-quorum-policy="ignore" maintenance-mode="false" />
-    </summary>
-    <nodes>
-        <node name="smc7-m11" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="3" type="member" />
-        <node name="smc8-m11" id="2" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="true" resources_running="3" type="member" />
-    </nodes>
-    <resources>
-        <clone id="lnet-clone" multi_state="false" unique="false" managed="true" failed="false" failure_ignored="false" >
-            <resource id="lnet" resource_agent="systemd:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
-                <node name="smc8-m11" id="2" cached="false"/>
-            </resource>
-            <resource id="lnet" resource_agent="systemd:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
-                <node name="smc7-m11" id="1" cached="false"/>
-            </resource>
-        </clone>
-        <group id="c1" number_resources="2" >
-             <resource id="ip-c1" resource_agent="ocf::heartbeat:IPaddr2" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
-                 <node name="smc7-m11" id="1" cached="false"/>
-             </resource>
-             <resource id="lnet-c1" resource_agent="ocf::seagate:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
-                 <node name="smc7-m11" id="1" cached="false"/>
-             </resource>
-        </group>
-        <group id="c2" number_resources="2" >
-             <resource id="ip-c2" resource_agent="ocf::heartbeat:IPaddr2" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
-                 <node name="smc8-m11" id="2" cached="false"/>
-             </resource>
-             <resource id="lnet-c2" resource_agent="ocf::seagate:lnet" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
-                 <node name="smc8-m11" id="2" cached="false"/>
-             </resource>
-        </group>
-    </resources>
-    <node_attributes>
-        <node name="smc7-m11">
-        </node>
-        <node name="smc8-m11">
-        </node>
-    </node_attributes>
-    <node_history>
-        <node name="smc8-m11">
-            <resource_history id="ip-c2" orphan="false" migration-threshold="1000000">
-                <operation_history call="29" task="start" last-rc-change="Tue Feb 25 19:55:33 2020" last-run="Tue Feb 25 19:55:33 2020" exec-time="107ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="30" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="63ms" queue-time="0ms" rc="0" rc_text="ok" />
-            </resource_history>
-            <resource_history id="lnet" orphan="false" migration-threshold="1000000">
-                <operation_history call="15" task="probe" last-rc-change="Tue Feb 25 19:55:27 2020" last-run="Tue Feb 25 19:55:27 2020" exec-time="4ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="25" task="start" last-rc-change="Tue Feb 25 19:55:31 2020" last-run="Tue Feb 25 19:55:31 2020" exec-time="2117ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="28" task="monitor" interval="60000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="1ms" queue-time="0ms" rc="0" rc_text="ok" />
-            </resource_history>
-            <resource_history id="lnet-c2" orphan="false" migration-threshold="1000000">
-                <operation_history call="31" task="start" last-rc-change="Tue Feb 25 19:55:33 2020" last-run="Tue Feb 25 19:55:33 2020" exec-time="42ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="32" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="22ms" queue-time="0ms" rc="0" rc_text="ok" />
-            </resource_history>
-        </node>
-        <node name="smc7-m11">
-            <resource_history id="ip-c1" orphan="false" migration-threshold="1000000">
-                <operation_history call="61" task="start" last-rc-change="Tue Feb 25 20:08:36 2020" last-run="Tue Feb 25 20:08:36 2020" exec-time="80ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="62" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 20:08:36 2020" exec-time="49ms" queue-time="0ms" rc="0" rc_text="ok" />
-            </resource_history>
-            <resource_history id="lnet" orphan="false" migration-threshold="1000000">
-                <operation_history call="15" task="probe" last-rc-change="Tue Feb 25 19:55:27 2020" last-run="Tue Feb 25 19:55:27 2020" exec-time="4ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="25" task="start" last-rc-change="Tue Feb 25 19:55:31 2020" last-run="Tue Feb 25 19:55:31 2020" exec-time="2097ms" queue-time="1ms" rc="0" rc_text="ok" />
-                <operation_history call="28" task="monitor" interval="60000ms" last-rc-change="Tue Feb 25 19:55:33 2020" exec-time="2ms" queue-time="0ms" rc="0" rc_text="ok" />
-            </resource_history>
-            <resource_history id="lnet-c1" orphan="false" migration-threshold="1000000">
-                <operation_history call="63" task="start" last-rc-change="Tue Feb 25 20:08:36 2020" last-run="Tue Feb 25 20:08:36 2020" exec-time="35ms" queue-time="0ms" rc="0" rc_text="ok" />
-                <operation_history call="64" task="monitor" interval="30000ms" last-rc-change="Tue Feb 25 20:08:36 2020" exec-time="20ms" queue-time="0ms" rc="0" rc_text="ok" />
-            </resource_history>
-        </node>
-    </node_history>
-    <fence_history>
-    </fence_history>
-    <tickets>
-    </tickets>
-    <bans>
-    </bans>
-</crm_mon>
-'''
+
+def contents(filename: str) -> str:
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    fullpath = f'{dirname}/{filename}'
+    assert os.path.isfile(fullpath), f'No such file: {fullpath}'
+    with open(fullpath) as f:
+        s = f.read()
+    return s
+
+
+GOOD_XML = contents('status-xml-w-clones.xml')
+XML_PLAIN_RESOURCES = contents('status-xml-plain-resources.xml')
 
 GOOD_STATUS_TEXT = '''Cluster name: mycluster
 
@@ -155,6 +81,32 @@ class PcsExecutorTest(unittest.TestCase):
             side_effect=[GOOD_STATUS_TEXT])
         connector = CliConnector(executor=stub_executor)
         self.assertEqual('mycluster', connector.get_cluster_name())
+
+    def test_get_resources_works(self):
+        stub_executor = CliExecutor()
+        stub_executor.get_full_status_xml = MagicMock(side_effect=[GOOD_XML])
+        connector = CliConnector(executor=stub_executor)
+        resources = connector.get_resources()
+        self.assertEqual(6, len(resources))
+
+    def test_plain_resources_parsed_also(self):
+        stub_executor = CliExecutor()
+        stub_executor.get_full_status_xml = MagicMock(
+            side_effect=[XML_PLAIN_RESOURCES])
+        connector = CliConnector(executor=stub_executor)
+        resources = connector.get_resources()
+        self.assertEqual(3, len(resources))
+        self.assertEqual(['c-259.stonith', 'c-260.stonith', 'MyResource'],
+                         [x.id for x in resources])
+
+    def test_get_stonith_resources_works(self):
+        stub_executor = CliExecutor()
+        stub_executor.get_full_status_xml = MagicMock(
+            side_effect=[XML_PLAIN_RESOURCES])
+        connector = CliConnector(executor=stub_executor)
+        resources = connector.get_stonith_resources()
+        self.assertEqual(['c-259.stonith', 'c-260.stonith'],
+                         [x.id for x in resources])
 
 
 class ClientTest(unittest.TestCase):


### PR DESCRIPTION
Solution:
1. Add support of two more commands to `pcswrap` tool: `{,un}maintenance
--all`
2. Those commands must control "smart maintenance" mode: disable STONITH
resources and then switch both of the nodes to standby.

Relates to: EOS-6446, EOS-5885.