### PR TITLE
Problem: OCF particulars leak into ha/checks

### DIFF
--- a/ha/checks/foo
+++ b/ha/checks/foo
@@ -3,34 +3,4 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 # set -x
 
-[[ -n ${OCF_ROOT:-} ]] || OCF_ROOT=/usr/lib/ocf
-set +eu
-. $OCF_ROOT/lib/heartbeat/ocf-shellfuncs
-set -eu
-
-run_dir=/run/eos
-state=$run_dir/check-${0##*/}.state
-
-start() {
-    sudo mkdir --parents $run_dir
-    touch $state
-}
-
-stop() {
-    rm $state
-    sudo rmdir --parents --ignore-fail-on-non-empty $run_dir
-}
-
-monitor() {
-    [[ -e $state ]] || return $OCF_NOT_RUNNING
-}
-
-case ${1:-} in
-    start|stop|monitor)
-        $1
-        ;;
-    *)
-        echo 'Invalid argument' >&2
-        exit $OCF_ERR_GENERIC
-        ;;
-esac
+echo "Hello from $0!"

--- a/ha/dispatch
+++ b/ha/dispatch
@@ -13,6 +13,9 @@ set +eu
 . $OCF_ROOT/lib/heartbeat/ocf-shellfuncs
 set -eu
 
+RUN_DIR=/tmp/eos  #XXX /var/run/eos
+STATE_PATH=$RUN_DIR/$OCF_RESKEY_check.state
+
 metadata() {
     cat <<'EOF'
 <?xml version="1.0"?>
@@ -47,23 +50,30 @@ END
 }
 
 start() {
-    if ! monitor; then
-        $OCF_RESKEY_check start
+    if [[ ! -e $STATE_PATH ]]; then
+        mkdir -p $RUN_DIR
+        touch $STATE_PATH
     fi
 }
 
 stop() {
-    if monitor; then
-        $OCF_RESKEY_check stop
+    if [[ -e $STATE_PATH ]]; then
+        rm $STATE_PATH
+        rmdir -p $RUN_DIR 2>/dev/null || true
     fi
 }
 
 monitor() {
-    $OCF_RESKEY_check monitor
+    if [[ ! -e $STATE_PATH ]]; then
+        return $OCF_NOT_RUNNING
+    fi
+    if ! $OCF_RESKEY_check; then
+        return $OCF_ERR_GENERIC
+    fi
 }
 
 case $OCF_RESKEY_check in
-    foo|bar|baz)  # supported checks
+    foo|bar|baz)  # XXX-TODO: the list of supported checks can be generated
         ;;
     *)
         ocf_log err "Unsupported check id: $OCF_RESKEY_check"


### PR DESCRIPTION
Only RA (resource agent) scripts need to care about OCF.
There is no good reason for ha/checks/* to implement start(), stop(),
monitor(), or use OCF API (environment variables and functions).

Solution: move the logic of updating "state file" from ha/checks/*
to `ha/dispatch`.