### PR TITLE
Problem: directory name doesn't conform to FHS

### DIFF
--- a/ha/dispatch
+++ b/ha/dispatch
@@ -13,7 +13,7 @@ set +eu
 . $OCF_ROOT/lib/heartbeat/ocf-shellfuncs
 set -eu
 
-RUN_DIR=/tmp/eos  #XXX /var/run/eos
+RUN_DIR=/tmp/eos  #XXX /run/eos
 STATE_PATH=$RUN_DIR/$OCF_RESKEY_check.state
 
 metadata() {


### PR DESCRIPTION
[Filesystem Hierarchy Standard][FHS], Version 3.0:

> # 3.15. /run : Run-time variable data
>
> ## 3.15.1. Purpose
>
> This directory contains system information data describing the system
> since it was booted. Files under this directory must be cleared
> (removed or truncated as appropriate) at the beginning of the boot
> process.
>
> The purposes of this directory were once served by `/var/run`. In
> general, programs may continue to use `/var/run` to fulfill the
> requirements set out for `/run` for the purposes of backwards
> compatibility. Programs which have migrated to use `/run` should cease
> their usage of `/var/run`, except as noted in the section on
> `/var/run`.
>
> Programs may have a subdirectory of `/run`; this is encouraged for
> programs that use more than one run-time file.

Solution: replace `/var/run` with `/run`.

[FHS]: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html