### PR TITLE
Follow-up from "Problem: no health-checker for consul"

### DIFF
--- a/ha/checks/consul-leader
+++ b/ha/checks/consul-leader
@@ -1,28 +1,11 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 #set -x
 
-[[ -n ${OCF_ROOT:-} ]] || OCF_ROOT=/usr/lib/ocf
-set +eu
-. $OCF_ROOT/lib/heartbeat/ocf-shellfuncs
-set -eu
-
-run_dir=/run/eos
-state=$run_dir/check-${0##*/}.state
-
-start() {
-    sudo mkdir --parents $run_dir
-    touch $state
-}
-
-stop() {
-    rm $state
-    sudo rmdir --parents --ignore-fail-on-non-empty $run_dir
-}
-
 export PATH="$PATH:/opt/seagate/eos/hare/bin"
-
 PROG=${0##*/}
+DEFAULT_TIMEOUT=5
 
 # move this to some library if you are copying this 3rd time
 log() {
@@ -36,57 +19,48 @@ die() {
 
 usage() {
     cat <<EOF
-Usage: $PROG <timeout>
+Usage: $PROG [timeout]
        $PROG [-h | --help]
 
 Check that cluster leader can be requrested via consul command.
 Uses timeout to wait before termination in case internal command freezes for
 some reason. Returns error if timeout was triggered.
-Script expectes that consul writes errors to stderr and data to
+The script expects that consul writes errors to stderr and data to
 stdout.
 
 Positional arguments:
   timeout   Natural number of seconds to wait before kill leader request.
+            Default value: 5 sec
 
 Options:
   -h, --help   Show this help and exit.
 EOF
 }
 
-case "${1:-none}" in
+case ${1:-none} in
     -h|--help) usage; exit;;
     0) die "Zero timeout is not allowed" ;;
-    none) die "Timeout is mandatory. Check -h option." ;;
 esac
 
-tout_sec=$1
-log_file="$(mktemp)"
+timeout_sec=${1:-$DEFAULT_TIMEOUT}
+hare_log_file="$(mktemp)"
+raft_log_file="$(mktemp)"
 
 exec 5>&2
 exec 2> >(logger -s -t $PROG >&2)
-
-consul kv get leader 1> $log_file &
-consul_pid=$!
+timeout --signal SIGKILL $timeout_sec consul kv get leader > $hare_log_file  &
+timeout --signal SIGKILL $timeout_sec curl --silent --max-time $timeout_sec http://127.0.0.1:8500/v1/status/leader > $raft_log_file &
 exec 2>&5
-consul_cmd=$(ps -q $consul_pid -o comm=)
 
-# check once in a second whether command is finished
-consul_stuck=0
-for ((i=1; i<=$tout_sec; i++)); do
-    sleep 1
-    ps -p $consul_pid &> /dev/null && consul_stuck=1 || consul_stuck=0
-    [[ $consul_stuck -eq 0 ]] && break
-done
+wait
 
-if [[ $consul_stuck -eq 1 ]]; then
-    log "killing $consul_pid : $consul_cmd"
-    kill -9 $consul_pid
-    exit 1
-fi
+hare_result=
+raft_result=
+[[ -f $hare_log_file ]] && hare_result=$(<$hare_log_file)
+[[ -f $raft_log_file ]] && raft_result=$(<$raft_log_file)
+rm $hare_log_file $raft_log_file 2>/dev/null
 
-result=
-[[ -f $log_file ]] && result=$(<$log_file)
+[[ -n $hare_result ]] || log "No HA elected leader reported by consul"
+[[ -n $raft_result ]] || log "No Raft leader reported by consul"
 
-rm -f $log_file 2>/dev/null
-
-[[ -n "$result" ]]
+[[ -n $hare_result && -n $raft_result ]]


### PR DESCRIPTION
Fixes for review findings.
@max-seagate, please pay attention that logic is not in monitor function, cause at this moment dispatcher is a better place to take care about OCF related interface. The check-script itself is not OCF-compatible. It is a topic for discussion.

Closes #854.