### PR TITLE
Problem: utils/README.md omits HA scripts

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,8 +1,10 @@
 # Hare utilities
 
-- `prov-*` scripts are hooks for Provisioner.
-- `hare-*` scripts are plugins (subcommands) for `hctl` script
-  (e.g., `hctl bootstrap` calls `hare-bootstrap`).  These scripts can
-  also be invoked independently.
+- `build-ees-ha*` are [Pacemaker][] HA scripts.
+- `hare-*` scripts are the implementations of `hctl` subcommands
+  (e.g., `hctl bootstrap` calls `hare-bootstrap`).
+- `prov-*` scripts are the hooks for Provisioner.
 
 The rest are... misc.
+
+[Pacemaker]: https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/2.0/html-single/Clusters_from_Scratch/index.html#_what_is_emphasis_pacemaker_emphasis


### PR DESCRIPTION
HA scripts became an inherent part of the repository.

Solution: mention HA scripts in `utils/README.md`.