### PR TITLE
Problem: no support for consul-leader in OCF dispatcher

### DIFF
--- a/ha/dispatch
+++ b/ha/dispatch
@@ -70,10 +70,11 @@ monitor() {
     if ! $OCF_RESKEY_check; then
         return $OCF_ERR_GENERIC
     fi
+    checks/$OCF_RESKEY_check
 }
 
 case $OCF_RESKEY_check in
-    foo|bar|baz)  # XXX-TODO: the list of supported checks can be generated
+    foo|bar|baz|consul-leader)  # XXX-TODO: the list of supported checks can be generated
         ;;
     *)
         ocf_log err "Unsupported check id: $OCF_RESKEY_check"


### PR DESCRIPTION
Need some initial suport to test entier tool in cluster environment.

Solution: just add consul-leader to list of supported functions and
actually invoke checker in monitor function.