### PR TITLE
Problem: pcswrap dependencies not shipped with RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,9 +226,14 @@ $(HAX_EGG_LINK) $(HAX_EXE): $(HAX_WHL)
 	@$(call _info,Installing hax with '$(HAX_INSTALL_CMD)')
 	@cd hax && $(HAX_INSTALL_CMD)
 
+.PHONY: install-pcswrap-deps
+install-pcswrap-deps: pcswrap/requirements.txt $(PY_VENV_DIR)
+	@$(call _info,Installing pcswrap dependencies)
+	@$(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) -r $<
+
 .PHONY: install-pcswrap
 install-pcswrap: PCSWRAP_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(PCSWRAP_WHL:pcswrap/%=%)
-install-pcswrap: $(PCSWRAP_EXE)
+install-pcswrap: install-pcswrap-deps $(PCSWRAP_EXE)
 
 $(PCSWRAP_EGG_LINK) $(PCSWRAP_EXE): $(PCSWRAP_WHL)
 	@$(call _info,Installing pcswrap with '$(PCSWRAP_INSTALL_CMD)')


### PR DESCRIPTION
Solution: fix install-pcswrap similarly to install-cfgen where
dependencies are installed explicitly.

How to check the fix:
1. Download the RPM file with the fix (e.g. from here http://ci-storage.mero.colo.seagate.com/releases/dev/konstantin.nekrasov/hare/fix-pcswrap-deps/)
2. List the files in the archive and make sure that 'defusedxml' and 'dataclasses' are shipped:
```
$ rpm -qlp eos-hare-1.0.0-1_git6c69dd5.el7.x86_64.rpm | grep -E 'site-packages/(defusedxml)|(dataclasses)' | wc -l
61
```

Closes EOS-6826