### PR TITLE
Problem: bootstrap fails on non-fqdn hostnames

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -314,7 +314,6 @@ ssh $rnode $cmd
 sudo cp $hare_dir/consul-server-conf.json \
         $hare_dir/consul-server-c1-conf.json
 sudo sed -e 's/"--hax"/"--svc", "hare-hax-c1"/' \
-         -e "/\"server\"/a\ \ \"node_name\": \"$lnode\"," \
          -i $hare_dir/consul-server-c1-conf.json
 cp $hare_dir/consul-server-c1-conf.json \
    /tmp/consul-server-c1-conf.json
@@ -326,7 +325,6 @@ cmd="
 sudo cp $hare_dir/consul-server-conf.json \
         $hare_dir/consul-server-c2-conf.json &&
 sudo sed -e 's/\"--hax\"/\"--svc\", \"hare-hax-c2\"/' \
-         -e '/\"server\"/a\ \ \"node_name\": \"$rnode\",' \
          -i $hare_dir/consul-server-c2-conf.json &&
 cp $hare_dir/consul-server-c2-conf.json \
    /tmp/consul-server-c2-conf.json &&

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -229,13 +229,15 @@ echo ' OK'
 say 'Starting Consul agents on other cluster nodes...'
 pids=()
 while read node bind_ip; do
-    ssh $node "$(which mk-consul-env) --mode server --bind $bind_ip --join $join_ip &&
+    ssh $node "$(which mk-consul-env) --mode server \
+                                      --bind $bind_ip --join $join_ip &&
                sudo systemctl start hare-consul-agent" &
     pids+=($!)
 done < <(get_server_nodes | grep -vw $(hostname --fqdn) || true)
 
 while read node bind_ip; do
-    ssh $node "$(which mk-consul-env) --mode client --bind $bind_ip --join $join_ip &&
+    ssh $node "$(which mk-consul-env) --mode client \
+                                      --bind $bind_ip --join $join_ip &&
                sudo systemctl start hare-consul-agent" &
     pids+=($!)
 done < <(get_client_nodes)

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -20,17 +20,18 @@ case "$*" in
     *) usage >&2; exit 1;;
 esac
 
+node_name=$(hostname --fqdn)
+
 get_service_ids() {
     local filter=$1
-    local host=$(hostname --fqdn)
-    local cmd="consul kv get -recurse m0conf/nodes/$host/processes/ |
+    local cmd="consul kv get -recurse m0conf/nodes/$node_name/processes/ |
                   $filter | sed 's/.*processes.//' | cut -d/ -f1"
     eval $cmd || true
 }
 
 get_service_ep() {
     local id=$1
-    consul kv get m0conf/nodes/$(hostname --fqdn)/processes/$id/endpoint
+    consul kv get m0conf/nodes/$node_name/processes/$id/endpoint
 }
 
 get_service_addr() {
@@ -52,7 +53,7 @@ id2fid() {
 HAX_ID=$(get_service_ids 'grep -iw ha')
 [[ $HAX_ID ]] || {
     cat >&2 <<.
-Cannot get information about Hax from Consul for this host ($(hostname --fqdn)).
+Cannot get information about Hax from Consul for this host ($node_name).
 Please verify that the host name matches the one stored in the Consul KV.
 .
     usage >&2
@@ -202,7 +203,8 @@ done
 
 tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)
 trap "rm -f $tmpfile" EXIT # delete automatically on exit
-jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
+jq ".services = [$SVCS_CONF] |
+    .node_name = \"$node_name\"" <$CONF_FILE >$tmpfile
 sudo cp $tmpfile $CONF_FILE
 
 sudo sed -r "s;(http://)localhost;\1$(get_service_ip_addr $HAX_EP);" \


### PR DESCRIPTION
Bootstrap fails if `hostname` returns non-fqdn names
on the setup nodes. (See EOS-7049, for example.)

The root cause of the problem lies in the fact that
Consul uses `hostname` to name the nodes by default,
but we use fqdn node names everywhere in our scripts.

Solution: specify fqdn node names to Consul also.