### PR TITLE
Problem: m0crate-io-conf fails on EES setup

### DIFF
--- a/utils/m0crate-io-conf
+++ b/utils/m0crate-io-conf
@@ -3,6 +3,8 @@ set -eu -o pipefail
 # set -x
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
+PATH=$PATH:/opt/seagate/eos/hare/bin
+
 ## Return profile fid.
 ##
 ## Sample output:


### PR DESCRIPTION
```
[root@sm24-r18 ~]# /opt/seagate/eos/hare/libexec/m0crate-io-conf
/opt/seagate/eos/hare/libexec/m0crate-io-conf: line 24: consul: command not found
```

Solution: extend PATH with /opt/seagate/eos/hare/bin.