### PR TITLE
Problem: nodes hostname changes are not supported

### DIFF
--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -36,10 +36,12 @@ cleanup() {
     pkill -f 'sh.*proto-rc' || true
 }
 
+node_name=$(cat /var/lib/hare/node-name 2>/dev/null || hostname --fqdn)
+
 # If the session is already set - the leader is elected, so
 # there is nothing to do (except cleanup after ourself).
 get_session_id | grep -q ^- || {
-    if [[ $(get_leader_node) != $(hostname --fqdn) ]]; then
+    if [[ $(get_leader_node) != $node_name ]]; then
         cleanup
     fi
     exit 0
@@ -49,7 +51,7 @@ cleanup
 
 # Create session with the service:confd Health Checker:
 create_session() {
-    local checks_a=($(consul kv get -recurse m0conf/nodes/$(hostname --fqdn)|
+    local checks_a=($(consul kv get -recurse m0conf/nodes/$node_name |
                       egrep -w 'confd|ha' |
                       sed -r 's/.*processes.([0-9]+).*/"service:\1"/'))
     # See the trick comma separated list explained here:
@@ -79,7 +81,7 @@ while true; do
     sleep $((RANDOM % 10))
     SID=$(create_session || true)
     if [[ $SID ]]; then
-        consul kv put -acquire -session=$SID leader $(hostname --fqdn) \
+        consul kv put -acquire -session=$SID leader $node_name \
                       2>/dev/null && break
         destroy_session $SID
     fi

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -211,3 +211,5 @@ sudo sed -r "s;(http://)localhost;\1$(get_service_ip_addr $HAX_EP);" \
          -i $CONF_FILE
 
 consul reload > /dev/null
+
+echo $node_name > /var/lib/hare/node-name


### PR DESCRIPTION
If host name or network domain name of a node change while the cluster is running,
Hare will stop working: `elect-rc-leader` script relies on hostnames not to change.

Solution: remember node's hostname in `/var/lib/hare/node-name` file during bootstrap
and use this value in `elect-rc-leader` script instead of calling `hostname` command.

Closes #877.\
Relates to EOS-6330.