### PR TITLE
Problem: no time for s3server to stop cleanly

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -483,7 +483,7 @@ s3_resource_add() {
    pcs cluster cib-push s3cfg --config
 }
 
-cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
+cmd='sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=7sec/"
               -i /usr/lib/systemd/system/s3server@.service &&
      sudo systemctl daemon-reload'
 run_on_both $cmd


### PR DESCRIPTION
s3server need to call various mero fini calls for operations,
objects and indexes, which may take sometime. Currently, 5 secs
systemd timeout is not enough to stop s3server cleanly. To be
on the safe side it's better to increase it to a slightly higher
value. According to S3-team (Rajesh Nambiar), 7 secs is Ok.

Solution: increase the systemd stop timeout to 7 secs.

[skip ci]