### PR TITLE
Problem: test-pcs CI job uses wrong kernel version

### DIFF
--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -71,6 +71,7 @@ M0_VM_HOSTNAME_PREFIX=$(ci_vm_name_prefix)
 EOF
     if [[ $CI_JOB_NAME == 'test-pcs' ]]; then
         $M0VG env add M0_VM_POD_SIMULATION=yes M0_VM_POD_DISKS=10
+        $M0VG env add M0_VM_DISABLE_PACKAGES_UPGRADE=yes
     fi
 
     local host=


### PR DESCRIPTION
The VMs used by CI jobs are created with `ci_init_m0vg` function.
This function executes `m0vg up --no-provision` for test-boot1 and
test-boot2 CI jobs, but it cannot use `--no-provision` for test-pcs
job, otherwise iSCSI wouldn't work. (`--no-provision` disables
"provision" step of VM creation, which is needed for iSCSI to work.)

Solution: set `M0_VM_DISABLE_PACKAGES_UPGRADE=yes` m0vg environment
variable for test-pcs CI job.  This ensures that yum packages (including
Linux kernel) won't be upgraded even when "provision" step of `m0vg up`
is enabled.

`M0_VM_DISABLE_PACKAGES_UPGRADE` variable is added to `m0vg` by Mero change
[c/19367](http://gerrit.mero.colo.seagate.com/c/mero/+/19367).