### PR TITLE
Problem: 13/UHA is missing from the index of RFCs

### DIFF
--- a/rfc/README.md
+++ b/rfc/README.md
@@ -19,6 +19,7 @@ processes.
   * [10/GLOSS](10/README.md) — Hare User's Glossary
   * [11/HCTL](11/README.md) - Hare Controller CLI
   * [12/CHECK](12/README.md) - EES HA Health Checks
+  * [13/UHA](13/README.md) — Universal EES HA
 * Draft
   * [3/CFGEN](3/README.md) — Configuration Generation
   * [4/KV](4/README.md) — Consul KV Schema


### PR DESCRIPTION
Solution: mention 13/UHA in `rfc/README.md`.

_(I cannot do anything right from the first try, can I?)_