### PR TITLE
Problem: pcswrap requires root permissions

### DIFF
--- a/pcswrap/pcswrap/types.py
+++ b/pcswrap/pcswrap/types.py
@@ -1,5 +1,7 @@
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Optional
 from abc import ABC, abstractmethod
+
+Credentials = NamedTuple('Credentials', [('username', str), ('password', str)])
 
 Node = NamedTuple('Node', [('name', str), ('online', bool), ('shutdown', bool),
                            ('standby', bool), ('unclean', bool)])
@@ -13,6 +15,8 @@ Resource = NamedTuple('Resource', [('id', str), ('resource_agent', str),
 
 
 class PcsConnector(ABC):
+    credentials = None
+
     @abstractmethod
     def get_nodes(self) -> List[Node]:
         pass
@@ -56,3 +60,13 @@ class PcsConnector(ABC):
     @abstractmethod
     def enable_resource(self, resource: Resource) -> None:
         pass
+
+    @abstractmethod
+    def ensure_authorized(self) -> None:
+        pass
+
+    def set_credentials(self, credentials: Credentials):
+        self.credentials = credentials
+
+    def get_credentials(self) -> Optional[Credentials]:
+        return self.credentials


### PR DESCRIPTION
Solution: add optional --username and --password parameters and leverage
local pcsd authenication internally.

Relates to EOS-6827

Here is how the process works at the real machine:




```
$ hctl node --verbose --username tester --password=tester1 maintenance
2020-04-13 05:37:01,113 [DEBUG] Issuing CLI command: ['pcs', 'client', 'local-auth', '-u', 'tester', '-p', 'tester1']
2020-04-13 05:37:02,297 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:02,305 [DEBUG] Issuing CLI command: ['pcs', 'status', '--full', 'xml']
2020-04-13 05:37:02,466 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:02,467 [INFO] Disabling stonith resources first
2020-04-13 05:37:02,470 [DEBUG] Issuing CLI command: ['pcs', 'status', '--full', 'xml']
2020-04-13 05:37:02,639 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:02,643 [DEBUG] Issuing CLI command: ['pcs', 'resource', 'disable', 'c-259.stonith']
2020-04-13 05:37:02,842 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:02,844 [DEBUG] Issuing CLI command: ['pcs', 'resource', 'disable', 'c-260.stonith']
2020-04-13 05:37:03,075 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:03,075 [DEBUG] Waiting for condition "stonith resources are disabled", timeout = 120 sec
2020-04-13 05:37:03,078 [DEBUG] Issuing CLI command: ['pcs', 'status', '--full', 'xml']
2020-04-13 05:37:03,252 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:03,254 [DEBUG] The following resources are found: [Resource(id='c-259.stonith', resource_agent='stonith:fence_dummy', role='Stopped', target_role='Stopped', active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0), Resource(id='c-260.stonith', resource_agent='stonith:fence_dummy', role='Stopped', target_role='Stopped', active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0)]
2020-04-13 05:37:03,255 [DEBUG] stonith resources are disabled? - True
2020-04-13 05:37:03,255 [DEBUG] Condition "stonith resources are disabled" is met, exiting
2020-04-13 05:37:03,255 [DEBUG] Switching to standby mode
2020-04-13 05:37:03,257 [DEBUG] Issuing CLI command: ['pcs', 'node', 'standby', '--all']
2020-04-13 05:37:03,478 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:03,479 [DEBUG] Waiting for condition "no running resources", timeout = 120 sec
2020-04-13 05:37:03,491 [DEBUG] Issuing CLI command: ['pcs', 'status', '--full', 'xml']
2020-04-13 05:37:03,675 [DEBUG] Finished. Exit code: 0
2020-04-13 05:37:03,677 [DEBUG] The following resources are found: [Resource(id='c-259.stonith', resource_agent='stonith:fence_dummy', role='Stopped', target_role='Stopped', active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0), Resource(id='c-260.stonith', resource_agent='stonith:fence_dummy', role='Stopped', target_role='Stopped', active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0), Resource(id='MyResource', resource_agent='ocf::heartbeat:anything', role='Stopped', target_role='Stopped', active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0), Resource(id='MyResource', resource_agent='ocf::heartbeat:anything', role='Stopped', target_role='Stopped', active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0), Resource(id='mr2', resource_agent='ocf::heartbeat:anything', role='Stopped', target_role=None, active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0), Resource(id='mr2', resource_agent='ocf::heartbeat:anything', role='Stopped', target_role=None, active=False, orphaned=False, blocked=False, managed=True, failed=False, failure_ignored=False, nodes_running_on=0)]
2020-04-13 05:37:03,677 [DEBUG] no running resources? - True
2020-04-13 05:37:03,677 [DEBUG] Condition "no running resources" is met, exiting
2020-04-13 05:37:03,677 [INFO] All nodes are in standby mode now
```