### PR TITLE
Problem: the name of new HA spec is silly

### DIFF
--- a/rfc/13/README.md
+++ b/rfc/13/README.md
@@ -1,7 +1,7 @@
 ---
 domain: gitlab.mero.colo.seagate.com
-shortname: 13/UHA
-name: Universal EES HA
+shortname: 13/HALC
+name: EES HA, Loosely Coupled
 status: draft
 editor: Valery V. Vorotyntsev <valery.vorotyntsev@seagate.com>
 ---

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -19,7 +19,7 @@ processes.
   * [10/GLOSS](10/README.md) — Hare User's Glossary
   * [11/HCTL](11/README.md) - Hare Controller CLI
   * [12/CHECK](12/README.md) - EES HA Health Checks
-  * [13/UHA](13/README.md) — Universal EES HA
+  * [13/HALC](13/README.md) — EES HA, Loosely Coupled
   * [14/HW](14/README.md) — EES Hardware
 * Draft
   * [3/CFGEN](3/README.md) — Configuration Generation


### PR DESCRIPTION
...but insufficiently so.  Also the characteristic buzzword is missing.

Solution: rechristen the spec to 13/HALC and add "loosely coupled"
to the full name.