### PR TITLE
Problem: excessive word in the title of 14/HW

### DIFF
--- a/rfc/14/README.md
+++ b/rfc/14/README.md
@@ -1,46 +1,45 @@
 ---
 domain: gitlab.mero.colo.seagate.com
 shortname: 14/HW
-name: EES Hardware Specification
+name: EES Hardware
 status: raw
 editor: Maksym Medvied <max.medved@seagate.com>
+contributors:
+  - Valery V. Vorotyntsev <valery.vorotyntsev@seagate.com>
 ---
 
-# EES Hardware Specification
+## EES Hardware
 
-## Hardware components
-
-| Component | Subcomponent | Number of units | A part of EES | Can lose power | Can be replaced after failure | SSPL Monitors | Is FRU? | Comment |
-| --------- | ------------ | --------------- | ------------- | -------------- | ----------------------------- | ------------- | ------- | ------- |
-| TOR switch for data | | 1 | No | Yes | ? | No | ? | |
-| | Port | 2 | No | No | No | No | ? | |
-| | 50GbE cable | 2 | ? | No | Yes | No | ? | |
-| TOR switch for management | | 1 | No | Yes | ? | No | ? | |
-| | Port | 2 | No | No | No | No | ? | |
-| | Network cable | 2 | ? | No | Yes | No | ? | |
-| EES server | | 2 | Yes | Yes | Yes | No | ? | |
-| | CPU | 4 | Yes | Yes | No | No | No | |
-| | RAM | ? | Yes | Yes | No | No | No | |
-| | HDD | ? | Yes | Yes | Yes | ? | ? | |
-| | NIC for data | 2 | Yes | Yes | ? | No | No | |
-| | NIC for data: 50GbE port | 4 | Yes | No | ? | No | ? | |
-| | NIC for management | 2 | Yes | Yes | ? | No | No | |
-| | NIC for management: port | 2 | Yes | No | ? | No | ? | |
-| | Cross-server 50GbE cable | 1 | Yes | No | ? | ? | ? | |
-| | BMC | 2 | Yes | Yes | No | No | ? | |
-| | BMC network cable | ? | Yes | No | No | No | ? | |
-| | SAS HBA | 2 | Yes | Yes | No | No | No | |
-| | SAS x2 cable | 8 | Yes | No | No | No | ? | |
-| | PSUs | ? | ? | ? | ? | ? | ? | |
-| | Fans | ? | ? | ? | ? | ? | ? | |
-| 5U84 | Enclosure | 1 | Yes | Yes | No | Yes | ? | |
-| | Controller | 2 | Yes | Yes | Yes | Yes | ? | |
-| | Disk | 84 | Yes | Yes | Yes | Yes | ? | |
-| | Fan modules | 3 | Yes | Yes | Yes | Yes | ? | |
-| | PSUs | 2 | Yes | Yes | Yes | Yes | ? | |
-| | Sideplan expanders | 2 | Yes | Yes | Yes | Yes | ? | |
-| | SAS ports | 8 | Yes | ? | No | No | ? | |
-
+| Component | Subcomponent | Number of units | Part of EES | Can lose power | Can be replaced after failure | SSPL Monitors | Is FRU? |
+| --------- | ------------ | :-------------: | :---------: | :------------: | :---------------------------: | :-----------: | :-----: |
+| TOR switch for data | | 1 | No | Yes | ? | No | ? |
+| | Port | 2 | No | No | No | No | ? |
+| | 50GbE cable | 2 | ? | No | Yes | No | ? |
+| TOR switch for management | | 1 | No | Yes | ? | No | ? |
+| | Port | 2 | No | No | No | No | ? |
+| | Network cable | 2 | ? | No | Yes | No | ? |
+| EES server | | 2 | Yes | Yes | Yes | No | ? |
+| | CPU | 4 | Yes | Yes | No | No | No |
+| | RAM | ? | Yes | Yes | No | No | No |
+| | HDD | ? | Yes | Yes | Yes | ? | ? |
+| | NIC for data | 2 | Yes | Yes | ? | No | No |
+| | NIC for data: 50GbE port | 4 | Yes | No | ? | No | ? |
+| | NIC for management | 2 | Yes | Yes | ? | No | No |
+| | NIC for management: port | 2 | Yes | No | ? | No | ? |
+| | Cross-server 50GbE cable | 1 | Yes | No | ? | ? | ? |
+| | BMC | 2 | Yes | Yes | No | No | ? |
+| | BMC network cable | ? | Yes | No | No | No | ? |
+| | SAS HBA | 2 | Yes | Yes | No | No | No |
+| | SAS x2 cable | 8 | Yes | No | No | No | ? |
+| | PSUs | ? | ? | ? | ? | ? | ? |
+| | Fans | ? | ? | ? | ? | ? | ? |
+| 5U84 | Enclosure | 1 | Yes | Yes | No | Yes | ? |
+| | Controller | 2 | Yes | Yes | Yes | Yes | ? |
+| | Disk | 84 | Yes | Yes | Yes | Yes | ? |
+| | Fan modules | 3 | Yes | Yes | Yes | Yes | ? |
+| | PSUs | 2 | Yes | Yes | Yes | Yes | ? |
+| | Sideplan expanders | 2 | Yes | Yes | Yes | Yes | ? |
+| | SAS ports | 8 | Yes | ? | No | No | ? |
 
 ## See also
 

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -20,7 +20,7 @@ processes.
   * [11/HCTL](11/README.md) - Hare Controller CLI
   * [12/CHECK](12/README.md) - EES HA Health Checks
   * [13/UHA](13/README.md) — Universal EES HA
-  * [14/HW](14/README.md) — EES Hardware Specification
+  * [14/HW](14/README.md) — EES Hardware
 * Draft
   * [3/CFGEN](3/README.md) — Configuration Generation
   * [4/KV](4/README.md) — Consul KV Schema


### PR DESCRIPTION
Every text file in rfc/ directory is a specification.  It is
superfluous to put the word "specification" in the title.

"Hardware components" heading does not add anything useful also.

Solution:
- remove " Specification" from the title;
- remove unneeded heading.

Also
- center numeric and boolean values within columns;
- "Comment" column is empty — delete it.