### PR TITLE
Problem: build-ees-ha fails on umount /var/mero

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -247,9 +247,9 @@ sudo rm -r /var/mero1
 
 # We don't need `/var/mero` mounted anymore. `hax` systemd
 # unit will mount/umount it automatically on start/stop.
-sudo umount /var/mero
+sudo umount --lazy /var/mero
 
-ssh $rnode 'sudo mkdir -p /var/mero1 && sudo umount /var/mero'
+ssh $rnode 'sudo mkdir -p /var/mero1 && sudo umount --lazy /var/mero'
 
 echo 'Preparing Consul agents config files...'
 cmd='


### PR DESCRIPTION
build-ees-ha script quite often fails on `umount /var/mero`
on a real HW setups because s3server may crash during
`hctl shutdown` and generate a lot of core dumps and,
as result, a lot of I/O to /var/mero.

Solution: do lazy umount and don't let build-ees-ha fail
because of other component bugs.

Note: it is still possible to mount /var/mero again later
(we do it when hax is started) even if the lazy umount
is still unfinished - checked.

[skip ci]