### PR TITLE
Problem: hare.spec omits jq

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -29,6 +29,7 @@ BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
 Requires: facter
+Requires: jq
 Requires: mero = %{h_mero_version}
 Requires: pacemaker
 Requires: pcs


### PR DESCRIPTION
Hare scripts (e.g., `hare-bootstrap`) use `jq` command, yet jq is not
mentioned among the RPM dependencies.

Solution: add `Requires: jq` to hare.spec.

Closes #903.