### PR TITLE
Problem: ees-ha: node failover is not working

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -144,8 +144,6 @@ echo 'Adding LNet...'
 sudo pcs cluster cib lcfg
 sudo pcs -f lcfg resource create lnet systemd:lnet
 sudo pcs -f lcfg resource clone lnet
-sudo pcs -f lcfg constraint order ip-c1 then lnet-clone
-sudo pcs -f lcfg constraint order ip-c2 then lnet-clone
 sudo pcs cluster cib-push lcfg --config
 
 run_on_both() {


### PR DESCRIPTION
A node failover stopped working after we introduced LNet
kernel module reloading at commit d0ba14d. LNet just gets
stuck during stopping.

Solution: don't touch LNet during failover/failback.

Note: it looks like the problem which was tried to be solved
at commit d0ba14d (hax startup failure) was caused by some
issue with mero-kernel module which was not reloaded by
Pacemaker during failover/failback for some reason.

Closes EOS-7371.

[skip ci]