### PR TITLE
Problem: SSPL-Consul pacemaker dependency generates warnings/error

### DIFF
--- a/utils/build-ees-ha-sspl
+++ b/utils/build-ees-ha-sspl
@@ -95,8 +95,8 @@ echo 'Adding sspl resource and constraints...'
 pcs cluster cib ssplcfg
 pcs -f ssplcfg resource create sspl ocf:seagate:sspl_stateful_resource_agent \
     master meta migration-threshold=10 failure-timeout=10s is-managed=true
-pcs -f ssplcfg constraint order --force consul-c1 then sspl
-pcs -f ssplcfg constraint order --force consul-c2 then sspl
+pcs -f ssplcfg constraint order consul-c1 then sspl-master
+pcs -f ssplcfg constraint order consul-c2 then sspl-master
 pcs cluster cib-push ssplcfg --config
 
 echo 'Copying Consul configuration files...'


### PR DESCRIPTION
SSPL is a master/slave resource. Using resource name as `sspl`
instead of `sspl-master` makes pacemaker unhappy, which generates the
following errors,
```
Apr 20 21:21:18 [4132] smc21-m10.colo.seagate.com stonith-ng:  warning: pe_find_constraint_tag: No template/tag named 'sspl'
Apr 20 21:21:18 [4132] smc21-m10.colo.seagate.com stonith-ng:    error: unpack_order_tags:      Constraint 'order-consul-c1-sspl-mandatory': Invalid reference to 'sspl'
Apr 20 21:21:18 [4132] smc21-m10.colo.seagate.com stonith-ng:  warning: pe_find_constraint_tag: No template/tag named 'sspl'
Apr 20 21:21:18 [4132] smc21-m10.colo.seagate.com stonith-ng:    error: unpack_order_tags:      Constraint 'order-consul-c2-sspl-mandatory': Invalid reference to 'sspl'
Apr 20 21:21:18 [4132] smc21-m10.colo.seagate.com stonith-ng:     info: cib_device_update:      Device stonith-c1 has been disabled on smc21-m10.colo.seagate.com: score=-INFINITY
Apr 20 21:21:18 [4132] smc21-m10.colo.seagate.com stonith-ng:     info: update_cib_stonith_devices_v2:  Updating device list from the cib: modify lrm_rsc_op[@id='s3server-c2-2_monitor_60000']
```

Pacemaker does complain while adding such a constraint but it can
be over-ridden with --force flag which was used to avoid restricting
the constraint to just sspl-master by using sspl.
```
[root@smc21-m10 520478]# pcs constraint order consul-c1 then sspl
Error: sspl is a master/slave resource, you should use the master id: sspl-master when adding constraints. Use --force to override.
```
Aparently this leads to the above error in the corosync.log.

Solution:
Use `sspl-master` instead of `sspl` in the order constraint.
Confirmed via testing that the resource name change does not affect the
expected results.

[ci skip]