### PR TITLE
Problem: SSPL resource agent in external repo is hard to maintain

### DIFF
--- a/pacemaker/sspl
+++ b/pacemaker/sspl
@@ -1,0 +1,204 @@
+#!/bin/sh
+#
+# ocf:pacemaker:Stateful resource agent
+#
+# Copyright 2006-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+#
+# Example of a stateful OCF Resource Agent
+#
+# Return codes and its menaning
+# 0: OCF_SUCESS: Successful Execution
+# 9: OCF_MASTER_FAILED: Resource is failed in Master mode
+# 7: OCF_NOT_RUNNING: Resource is safely stopped.
+#######################################################################
+# Initialization:
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
+#######################################################################
+meta_data() {
+    cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="SSPL Stateful" version="1.1">
+<version>1.0</version>
+<longdesc lang="en">
+This is a stateful resource agent that implements two states
+</longdesc>
+<shortdesc lang="en">SSPL stateful resource agent</shortdesc>
+<parameters>
+<parameter name="state" unique="1">
+<longdesc lang="en">
+Location to store the resource state in
+</longdesc>
+<shortdesc lang="en">State file</shortdesc>
+<content type="string" default="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state" />
+</parameter>
+<parameter name="sspl_state_file" unique="1">
+<longdesc lang="en">
+Location to store the sspl mode. [ Active, Degraded ]
+</longdesc>
+<shortdesc lang="en">SSPL state file</shortdesc>
+<content type="string" default="/var/eos/sspl/data/state.txt" />
+</parameter>
+</parameters>
+<actions>
+<action name="start"   timeout="20s" />
+<action name="stop"    timeout="22s" />
+<action name="monitor" timeout="23s" interval="10s" role="Master"/>
+<action name="monitor" timeout="25s" interval="11s" role="Slave"/>
+<action name="promote" timeout="10s" />
+<action name="demote"  timeout="11s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
+</actions>
+</resource-agent>
+END
+    exit $OCF_SUCCESS
+}
+#######################################################################
+stateful_usage() {
+    cat <<END
+usage: $0 {start|stop|promote|demote|monitor|validate-all|meta-data}
+Expects to have a fully populated OCF RA-compliant environment set.
+END
+    exit $1
+}
+stateful_update() {
+    echo $1 > "${OCF_RESKEY_state}"
+}
+stateful_check_state() {
+    target="$1"
+    if [ -f "${OCF_RESKEY_state}" ]; then
+        state=$(cat "${OCF_RESKEY_state}")
+        if [ "$target" = "$state" ]; then
+            return 0
+        fi
+    else
+        if [ -z "$target" ]; then
+            return 0
+        fi
+    fi
+    # At first stage,/run/Stateful-sspl.state this file will not be present
+    # So, resource will not be either Master or Slave
+    # So, we can return as Resource is safely stopped (OCF_NOT_RUNNING i.e 7)
+    # So that, pacemaker will take action to start it
+    return 7
+}
+set_master_score() {
+    "${HA_SBIN_DIR}/crm_master" -l reboot -v "$1"
+}
+stateful_start() {
+    stateful_check_state "master"
+    if [ $? -eq 0 ]; then
+        # CRM Error - Should never happen
+        systemctl start sspl-ll
+        return $OCF_RUNNING_MASTER
+    fi
+    stateful_update "slave"
+    set_master_score "${slave_score}"
+    systemctl start sspl-ll
+    return $OCF_SUCCESS
+}
+stateful_demote() {
+    stateful_monitor
+    sspl_state=`systemctl is-active sspl-ll`
+    if [ $sspl_state != 'active' ]; then
+       systemctl start sspl-ll
+    fi
+    stateful_update "slave"
+    set_master_score "${slave_score}"
+
+    if [ -z $OCF_RESKEY_sspl_mode ]; then
+        OCF_RESKEY_sspl_mode="/var/eos/sspl/data/state.txt"
+    fi
+
+    echo "state=degrade" > /var/eos/sspl/data/state.txt
+    return 0
+}
+stateful_promote() {
+    sleep 5
+    sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
+    if [ -z $sspl_pid ]; then
+        "${HA_SBIN_DIR}/crm_master" -v
+        return stateful_monitor
+    fi
+    sspl_state=`systemctl is-active sspl-ll`
+    if [ $sspl_state != 'active' ]; then
+       systemctl start sspl-ll
+    fi
+    stateful_update "master"
+    set_master_score "${master_score}"
+
+    if [ -z $OCF_RESKEY_sspl_mode ]; then
+        OCF_RESKEY_sspl_mode="/var/eos/sspl/data/state.txt"
+    fi
+    echo "state=active" > /var/eos/sspl/data/state.txt
+    # This is required in promote in order to switch SSPL to active mode.
+    # Here active mode means, some of the SSPL modules will be resumed after
+    # this signal is received by SSPL. Without this sspl won't read updated
+    # configuration.
+    /usr/bin/kill -s SIGHUP $sspl_pid
+    return 0
+}
+stateful_stop() {
+    "${HA_SBIN_DIR}/crm_master" -l reboot -D
+    systemctl stop sspl-ll
+    return $OCF_SUCESS
+}
+stateful_monitor() {
+    sspl_state=`systemctl is-active sspl-ll`
+    stateful_check_state "master"
+    if [ $? -eq 0 ]; then
+        # Restore the master setting during probes
+        set_master_score "${master_score}"
+        case "$sspl_state" in
+              active) return $OCF_RUNNING_MASTER;;
+              failed) return $OCF_FAILED_MASTER;;
+              inactive) return $OCF_NOT_RUNNING;;
+                     *) return $OCF_ERR_GENERIC;;
+        esac
+    fi
+
+    set_master_score "${slave_score}"
+    case "$sspl_state" in
+           active) return $OCF_SUCCESS;;
+           failed) return $OCF_ERR_GENERIC;;
+                *) return $OCF_NOT_RUNNING;;
+    esac
+}
+
+stateful_validate() {
+    return $OCF_SUCCESS
+}
+
+: ${slave_score:=5}
+: ${master_score:=10}
+: ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
+if [ -z "$OCF_RESKEY_state" ]; then
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
+        state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
+        # Strip off the trailing clone marker
+        OCF_RESKEY_state=$(echo $state | sed s/:[0-9][0-9]*\.state/.state/)
+    else
+        OCF_RESKEY_state="${HA_VARRUN%%/}/Stateful-${OCF_RESOURCE_INSTANCE}.state"
+    fi
+fi
+case "$__OCF_ACTION" in
+meta-data)      meta_data;;
+start)          stateful_start;;
+promote)        stateful_promote;;
+demote)         stateful_demote;;
+stop)           stateful_stop;;
+monitor)        stateful_monitor;;
+validate-all)   stateful_validate;;
+usage|help)     stateful_usage $OCF_SUCCESS;;
+*)              stateful_usage $OCF_ERR_UNIMPLEMENTED;;
+esac
+exit $?

--- a/utils/build-ees-ha-sspl
+++ b/utils/build-ees-ha-sspl
@@ -93,7 +93,7 @@ hare_dir=/var/lib/hare
 echo 'Adding sspl resource and constraints...'
 
 pcs cluster cib ssplcfg
-pcs -f ssplcfg resource create sspl ocf:seagate:sspl_stateful_resource_agent \
+pcs -f ssplcfg resource create sspl ocf:eos:sspl \
     master meta migration-threshold=10 failure-timeout=10s is-managed=true
 pcs -f ssplcfg constraint order consul-c1 then sspl-master
 pcs -f ssplcfg constraint order consul-c2 then sspl-master


### PR DESCRIPTION
Solution: incorporate ocf script for SSPL resource agent into Hare repo.

The original `sspl_stateful_resource_agent` script from SSPL repository,
as of commit [0cb9a062838ec72485b90a17fc417e8c4bc5b65f](http://gitlab.mero.colo.seagate.com/eos/sspl/blob/0cb9a062838ec72485b90a17fc417e8c4bc5b65f/low-level/files/opt/seagate/sspl/bin/pacemaker/sspl_stateful_resource_agent) "Problem: Resource
agent copy command fails with same file error", has been copied to
'pacemaker/sspl'.