### PR TITLE
Problem: bootstrap fails on non-fqdn hostnames

### DIFF
--- a/systemd/consul-env.in
+++ b/systemd/consul-env.in
@@ -1,4 +1,5 @@
 # mandatory:
+NODE=
 MODE=server
 BIND={{GetPrivateIP}}
 CLIENT=127.0.0.1 {{GetPrivateIP}}

--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -9,6 +9,6 @@ PATH="$HARE_BASE_DIR/bin:$PATH"
 export PATH
 
 # TODO: should it be `consul` and PATH=/opt/seagate/eos/hare/bin:$PATH ?
-exec consul agent -bind $BIND -client "$CLIENT" $JOIN \
+exec consul agent -node $NODE -bind $BIND -client "$CLIENT" $JOIN \
      -config-dir=/var/lib/hare/consul-$MODE-conf \
      -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -53,7 +53,8 @@ done
     exit 1
 }
 
-sed -r -e "s/^(MODE).*/\1=$mode/" \
+sed -r -e "s/^(NODE).*/\1=$(hostname --fqdn)/" \
+       -e "s/^(MODE).*/\1=$mode/" \
        -e "s/^(BIND).*/\1=$bind_addr/" \
        -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" $ENV_TEMPLATE |
     sudo tee $ENV_FILE >/dev/null

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -203,8 +203,7 @@ done
 
 tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)
 trap "rm -f $tmpfile" EXIT # delete automatically on exit
-jq ".services = [$SVCS_CONF] |
-    .node_name = \"$node_name\"" <$CONF_FILE >$tmpfile
+jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
 sudo cp $tmpfile $CONF_FILE
 
 sudo sed -r "s;(http://)localhost;\1$(get_service_ip_addr $HAX_EP);" \


### PR DESCRIPTION
hctl bootstrap still fails if `hostname` command return
non-fqdn name on any of the cluster nodes. Although we
tried to fix it in commit a4896cd earlier, the fix did
not work, as appeared, because `consul reload` command
does not update the node names. (See
https://www.consul.io/docs/agent/options.html#reloadable-configuration)

Solution: add the node_name into consul-env file and
start Consul agent with `-node` parameter from it.

Closes EOS-7049.