### PR TITLE
Problem: no interface link state monitoring for private data interface

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -462,6 +462,14 @@ sudo pcs -f mcfg constraint order mero-confd-c1 then mero-ios-c2
 sudo pcs -f mcfg constraint order mero-confd-c2 then mero-ios-c1
 sudo pcs cluster cib-push mcfg --config
 
+echo 'Configuring ClusterIP constrains in Pacemaker...'
+sudo pcs cluster cib clustercfg
+sudo pcs -f clustercfg constraint location ClusterIP-clone \
+         rule score=-INFINITY ethmonitor-enp175s0f1 ne 1
+sudo pcs -f clustercfg constraint order c1 then ClusterIP-clone
+sudo pcs -f clustercfg constraint order c2 then ClusterIP-clone
+sudo pcs cluster cib-push clustercfg --config
+
 # Copy only the updated files from each side.
 sudo rsync -u /etc/sysconfig/m0d-* $rnode:/etc/sysconfig/
 sudo rsync -u "$rnode:/etc/sysconfig/m0d-*" /etc/sysconfig/


### PR DESCRIPTION
Solution:
- add ocf:heartbeat:ethmonitor resource agent which will monitor private
  data interface and change state of ethmonitor-<iface> CIB attribute.
- add location constraint for ip-c1/2 based on rule that current node
  should be avoided (not banned!) if ethmonitor indicates link down via
  aforementioned CIB attribute. This also causes ip-c1/2 to failback if
  interface is UP again.
- set ip-c1/2 monitoring interval to "when necessary" (0) to avoid
  permanent ban of current node when ip-c1/2 notices that interface is
  down - it reacts much faster then ethmonitor which allows 6 retry
  attempts.

For ClusterIP:
- add location constraint based on ethmonitor RA agent CIB attribute
  indication. ClusteIP instance will change location when private data
  interface set down.
- add order constraint to run ClusterIP only when resources in both c1
  and c2 groups are ready

Note:
  failure-timeout meta attribute is not used since it causes global
  unconditional failback attempt.

[ci skip]

Presumably fixes: https://jts.seagate.com/browse/EOS-7222

cc: @dmitriy.chumak @vvv @max-seagate @konstantin.nekrasov @mandar.sawant