### PR TITLE
Problem: s3server resources are not added properly

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -481,6 +481,10 @@ sudo pcs constraint order els-search-clone then statsd-clone
 echo 'Adding haproxy to pacemaker...'
 sudo pcs resource create haproxy-c1 systemd:haproxy op monitor interval=30s
 sudo pcs resource create haproxy-c2 systemd:haproxy op monitor interval=30s
+sudo pcs constraint location haproxy-c1 prefers $lnode=INFINITY
+sudo pcs constraint location haproxy-c1 avoids $rnode=INFINITY
+sudo pcs constraint location haproxy-c2 prefers $rnode=INFINITY
+sudo pcs constraint location haproxy-c2 avoids $lnode=INFINITY
 
 echo 'Adding S3server to Pacemaker...'
 get_s3_svc() {
@@ -498,12 +502,18 @@ echo 'Adding s3background services...'
 sudo pcs cluster cib s3bcfg
 sudo pcs -f s3bcfg resource create s3backcons-c1 systemd:s3backgroundconsumer
 sudo pcs -f s3bcfg resource create s3backcons-c2 systemd:s3backgroundconsumer
+sudo pcs -f s3bcfg constraint location s3backcons-c1 prefers $lnode=INFINITY
+sudo pcs -f s3bcfg constraint location s3backcons-c1 avoids $rnode=INFINITY
+sudo pcs -f s3bcfg constraint location s3backcons-c2 prefers $rnode=INFINITY
+sudo pcs -f s3bcfg constraint location s3backcons-c2 avoids $lnode=INFINITY
 sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backcons-c1
 sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backcons-c2
 sudo pcs -f s3bcfg resource create s3backprod systemd:s3backgroundproducer op \
     monitor interval=30s
-sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c1 score=50000
-sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c2 score=50000
+sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c1 \
+    score=50000
+sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c2 \
+    score=50000
 sudo pcs cluster cib-push s3bcfg --config
 
 s3_resource_add() {
@@ -513,8 +523,8 @@ s3_resource_add() {
    local s3servers=""
 
    local conf_dir=consul-server-$suffix-conf
-   local s3server_fids=$(get_s3_svc $hare_dir/$conf_dir/$conf_dir.json \
-                                    s3service)
+   local s3server_fids=($(get_s3_svc $hare_dir/$conf_dir/$conf_dir.json s3service))
+
    sudo pcs cluster cib s3cfg
    local count=1
    for i in ${s3server_fids[@]}; do
@@ -531,12 +541,15 @@ s3_resource_add() {
       # on the local s3authserver
       sudo pcs -f s3cfg constraint colocation add s3server-$suffix-$count \
           with s3auth-clone score=INFINITY
-      (( count++ ))
       s3servers+=" s3server-$suffix-$count"
+      (( count++ ))
    done
-   sudo pcs constraint order set $s3servers require-all=false sequential=false \
+   sudo pcs cluster cib-push s3cfg --config
+
+   sudo pcs cluster cib s3cfg
+   sudo pcs -f s3cfg constraint order set $s3servers require-all=false sequential=false \
        set s3backcons-$suffix
-   sudo pcs constraint order set $s3servers require-all=false sequential=false \
+   sudo pcs -f s3cfg constraint order set $s3servers require-all=false sequential=false \
        set haproxy-$suffix
    sudo pcs cluster cib-push s3cfg --config
 }

--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -23,9 +23,9 @@ for ctrl in c2 c1; do
 done
 
 resources=(
-    s3back{prod,cons}
-    s3back{prod,cons}
-    haproxy
+    s3backcons-c{2,1}
+    s3backprod
+    haproxy-c{2,1}
     statsd
     els-search
     s3auth


### PR DESCRIPTION
In the function s3_resource_add(), s3server resource names are appended to
a list which is done after the counter is incremented. This appends an
additional non-existing s3server resource causing the subsequent order
constraint command to fail.
Also the newly added individual haproxy and s3backgroundconsumer resources
per node which replaced their clones, are not cleaned up properly.

Solution:
- Fix the s3server resource names list compilation.
- Add additional location constraints for per node haproxy and s3backgroundconsumer
  resources.
- Update cleanup script to cleanup per node haproxy and s3backgroundconsumer
  resources.

[ci skip]