### PR TITLE
Problem: CI creates unneeded loop devices

### DIFF
--- a/ci/m0vg/init-node
+++ b/ci/m0vg/init-node
@@ -5,12 +5,6 @@ set -x
 
 . /data/hare/ci/_env  # MERO_COMMIT_REF, RPMSYNC_DIR
 
-sudo mkdir -p /var/mero
-for i in {0..9}; do
-    sudo dd if=/dev/zero of=/var/mero/disk$i.img bs=1M seek=9999 count=1
-    sudo losetup /dev/loop$i /var/mero/disk$i.img
-done
-
 if [[ -n ${MERO_COMMIT_REF:-} ]]; then
     # `systemctl start hare-hax` command, called by `bootstrap-node`,
     # will fail unless `mero-kernel` systemd service is installed.

--- a/ci/m0vg/test-boot1
+++ b/ci/m0vg/test-boot1
@@ -33,5 +33,12 @@ test_cluster() {
 }
 
 cd /data/hare/
+
+sudo mkdir -p /var/mero
+for i in {0..9}; do
+    sudo dd if=/dev/zero of=/var/mero/disk$i.img bs=1M seek=9999 count=1
+    sudo losetup /dev/loop$i /var/mero/disk$i.img
+done
+
 test_cluster cfgen/examples/singlenode.yaml
 test_cluster cfgen/examples/ci-boot1-2ios.yaml


### PR DESCRIPTION
Loop devices are only needed for `test-boot1` CI job.

Solution: create loop devices for `test-boot1` job only.