### PR TITLE
Minor edits of build_ees_ha

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -526,14 +526,17 @@ sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c2 \
     score=50000
 sudo pcs cluster cib-push s3bcfg --config
 
-s3_resource_add() {
+add_s3server_resources() {
    local suffix=$1
    local node_local=$2
    local node_remote=$3
-   local s3servers=""
+   local s3servers=
 
    local conf_dir=consul-server-$suffix-conf
-   local s3server_fids=($(get_s3_svc $hare_dir/$conf_dir/$conf_dir.json s3service))
+   local s3server_fids=(
+       $(get_s3_svc $hare_dir/$conf_dir/$conf_dir.json s3service)
+   )
+   ((${#s3server_fids[@]} == 0)) && return
 
    sudo pcs cluster cib s3cfg
    local count=1
@@ -570,5 +573,5 @@ sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=7sec/"
 sudo systemctl daemon-reload'
 run_on_both $cmd
 
-s3_resource_add c1 $lnode $rnode
-s3_resource_add c2 $rnode $lnode
+add_s3server_resources c1 $lnode $rnode
+add_s3server_resources c2 $rnode $lnode


### PR DESCRIPTION
# Problem: build-ees-ha fails if there are no s3servers in CDF

Error message:
```
Adding haproxy to pacemaker...
Adding S3server to Pacemaker...
Adding rabbit-mq resources and constraints...
Adding s3background services...
Adding rabbitmq-clone s3backcons-c1 (kind: Mandatory) (Options: first-action=start then-action=start)
Adding rabbitmq-clone s3backcons-c2 (kind: Mandatory) (Options: first-action=start then-action=start)
CIB updated

Usage: pcs constraint [constraints]...
    order set <resource1> [resourceN]... [options] [set
              <resourceX> ... [options]]
              [setoptions [constraint_options]]
        Create an ordered set of resources.
        Available options are sequential=true/false, require-all=true/false and
        action=start/promote/demote/stop. Available constraint_options are
        id=<constraint-id>, kind=Optional/Mandatory/Serialize and
        symmetrical=true/false.
```

Solution: modify `build-ees-ha` script to not add s3server resources and
constraints if there is no s3servers specified in the CDF.

# Problem: build-ees-ha hides errors of mkfs.ext4

Solution: do not suppress stderr of `mkfs.ext4`.