### PR TITLE
Problem: no teardown for pdifmon resource (ethmonitor)

### DIFF
--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -34,6 +34,7 @@ resources=(
     c{2,1}
     mero-kernel
     lnet
+    pdifmon
 )
 for r in ${resources[@]}; do
     pcs resource delete $r || true


### PR DESCRIPTION
Solution: add resource name to prov-ha-reset file which is called during
ees_ha teardown.

[ci skip]

cc: @andriy.tkachuk