### PR TITLE
Problem: CI doesn't run linters

### DIFF
--- a/ci/docker/test-utils
+++ b/ci/docker/test-utils
@@ -13,5 +13,6 @@ if [[ -z ${MERO_COMMIT_REF:-} ]]; then
     yum install -y eos-hare mero-devel
 fi
 
+make check
 make test
 make install


### PR DESCRIPTION
Solution: run `make check` in `test-utils` CI job.