### PR TITLE
EOS-7258: fix failover regression caused by pdifmon

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -135,7 +135,8 @@ netmask=$(ip -oneline -4 address show dev $iface |
 
 echo 'Adding private interface monitoring to Pacemaker...'
 sudo pcs resource create pdifmon ocf:heartbeat:ethmonitor \
-         interface=$iface link_status_only=true op monitor interval=10s clone
+         interface=$iface link_status_only=true op monitor interval=10s \
+         timeout=60s clone
 
 echo 'Adding the roaming IP addresses into Pacemaker...'
 sudo pcs cluster cib icfg


### PR DESCRIPTION
Pacemaker's transition can be aborted due to pdifmon resource
monitor failure:

```
Apr 27 12:15:27 sm24-r18.pun.seagate.com kernel: mlx5_core 0000:af:00.1 enp175s0f1: Link up
...
Apr 27 12:15:28 sm24-r18.pun.seagate.com lrmd[50775]:  warning: pdifmon_monitor_10000 process (PID 152973) timed out
Apr 27 12:15:28 sm24-r18.pun.seagate.com lrmd[50775]:  warning: pdifmon_monitor_10000:152973 - timed out after 20000ms
Apr 27 12:15:28 sm24-r18.pun.seagate.com crmd[50778]:    error: Result of monitor operation for pdifmon on sm24-r18.pun.seagate.com: Timed Out
Apr 27 12:15:28 sm24-r18.pun.seagate.com crmd[50778]:   notice: Transition aborted by operation pdifmon_monitor_10000 'create' on sm24-r18.pun.seagate.com: Old event
```

Because of the abort mero-kernel might not be reloaded and, as
result, hax and Mero processes would fail to start.

The private data network is cross-linked with another node,
so when another node crashes - the link goes down for some time,
along with its IB network interface - that's why the monitoring
fails.

Solution: increase pdifmon's monitor timeout to 60 seconds.