### PR TITLE
Problem: hax cannot compile with local Mero sources

### DIFF
--- a/hax/setup.py
+++ b/hax/setup.py
@@ -108,7 +108,8 @@ setup(
         Extension(
             name='libhax',
             sources=['hax/hax.c'],
-            include_dirs=[get_mero_dir()],
+            include_dirs=[get_mero_dir(),
+                          get_mero_dir() + '/extra-libs/galois/include'],
             define_macros=[('M0_INTERNAL', ''), ('M0_EXTERN', 'extern')],
             library_dirs=[get_mero_libs_dir()],
             runtime_library_dirs=[get_mero_libs_dir()],


### PR DESCRIPTION
```
$ $M0_SRC_DIR/scripts/m0 make
$ make
[...]
running build_ext
building 'libhax' extension
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/hax
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DM0_INTERNAL= -DM0_EXTERN=extern -I/data/eos/mero -I/data/eos/hare/.py3venv/include -I/usr/include/python3.6m -c hax/hax.c -o build/temp.linux-x86_64-3.6/hax/hax.o -g -Werror -Wall -Wextra -Wno-attributes -Wno-unused-parameter -fPIC
In file included from /data/eos/mero/sns/matvec.h:27:0,
                 from /data/eos/mero/sns/parity_math.h:30,
                 from /data/eos/mero/layout/pdclust.h:69,
                 from /data/eos/mero/conf/obj.h:28,
                 from hax/hax.c:26:
/data/eos/mero/sns/parity_ops.h:26:27: fatal error: galois/galois.h: No such file or directory
 #include "galois/galois.h"
                           ^
compilation terminated.
error: command 'gcc' failed with exit status 1
make: *** [hax/dist/hax-1.0.0-cp36-cp36m-linux_x86_64.whl] Error 1
```

Solution: explain `hax/setup.py` where to look for `galois/galois.h`.

Closes #940.