### PR TITLE
Problem: Consul node-id changes after every reboot

### DIFF
--- a/systemd/consul-env.in
+++ b/systemd/consul-env.in
@@ -1,5 +1,6 @@
 # mandatory:
 NODE=
+NODE_ID=
 MODE=server
 BIND={{GetPrivateIP}}
 CLIENT=127.0.0.1 {{GetPrivateIP}}

--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -9,6 +9,6 @@ PATH="$HARE_BASE_DIR/bin:$PATH"
 export PATH
 
 # TODO: should it be `consul` and PATH=/opt/seagate/eos/hare/bin:$PATH ?
-exec consul agent -node $NODE -bind $BIND -client "$CLIENT" $JOIN \
+exec consul agent -node $NODE -node-id $NODE_ID -bind $BIND -client "$CLIENT" $JOIN \
      -config-dir=/var/lib/hare/consul-$MODE-conf \
      -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -5,8 +5,10 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 PROG=${BASH_SOURCE[0]##*/}
 
-# TODO: '/opt/seagate/eos/hare' prefix can be different
-ENV_TEMPLATE=/opt/seagate/eos/hare/share/consul/consul-env.in
+# XXX '/opt/seagate/eos/hare' prefix can be different
+HARE_DIR=/opt/seagate/eos/hare
+
+ENV_TEMPLATE=$HARE_DIR/share/consul/consul-env.in
 ENV_FILE=/var/lib/hare/consul-env
 
 usage() {
@@ -53,7 +55,9 @@ done
     exit 1
 }
 
-sed -r -e "s/^(NODE).*/\1=$(hostname --fqdn)/" \
+FQDN=$(hostname --fqdn)
+sed -r -e "s/^(NODE)[^(_ID)].*/\1=$FQDN/" \
+       -e "s/^(NODE_ID).*/\1=$($HARE_DIR/libexec/node-uuid $FQDN)/" \
        -e "s/^(MODE).*/\1=$mode/" \
        -e "s/^(BIND).*/\1=$bind_addr/" \
        -e "s/^(CLIENT).*/\1=127.0.0.1 $bind_addr/" $ENV_TEMPLATE |
@@ -73,5 +77,5 @@ sudo rm -rf /var/lib/hare/consul-$bind_addr
 
 conf_dir=consul-$mode-conf
 sudo mkdir -p /var/lib/hare/$conf_dir
-sudo cp /opt/seagate/eos/hare/share/consul/$conf_dir.json.in \
+sudo cp $HARE_DIR/share/consul/$conf_dir.json.in \
      /var/lib/hare/$conf_dir/$conf_dir.json

--- a/utils/node-uuid
+++ b/utils/node-uuid
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+# Generates a uuid for node using node name as seed.
+
+from socket import getfqdn
+import uuid
+from sys import argv
+
+name = argv[1] if len(argv) > 1 else getfqdn()
+print(uuid.uuid3(uuid.NAMESPACE_DNS, name))


### PR DESCRIPTION
On every node reboot, Consul generates a new node id which is used to
start the Consul agent. In this case the node registration fails as
the same node is registered with a different node id.
e.g.

```
Apr 25 03:44:19 smc21-m10.colo.seagate.com hare-consul[7555]: 2020-04-25T03:44:19.027Z [ERROR] agent.anti_entropy: failed to sync remote state: error="rpc error making c
Apr 25 03:44:19 smc21-m10.colo.seagate.com hare-consul[7555]: 2020-04-25T03:44:19.063Z [WARN]  agent.server.fsm: EnsureRegistration failed: error="failed inserting node:
Apr 25 03:44:40 smc21-m10.colo.seagate.com hare-consul[7555]: 2020-04-25T03:44:40.474Z [WARN]  agent: Syncing node info failed.: error="rpc error making call: failed ins
```

Solution:
- Generate a deterministic node uuid for a node based on hostname.
- Pass the saved node uuid as a parameter to the Consul agent.