### PR TITLE
Problem: mero-free-space-monitor service is not part of HA

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -557,10 +557,10 @@ add_s3server_resources() {
    sudo pcs cluster cib-push s3cfg --config
 
    sudo pcs cluster cib s3cfg
-   sudo pcs -f s3cfg constraint order set $s3servers require-all=false sequential=false \
-       set s3backcons-$suffix
-   sudo pcs -f s3cfg constraint order set $s3servers require-all=false sequential=false \
-       set haproxy-$suffix
+   sudo pcs -f s3cfg constraint order set $s3servers require-all=false \
+       sequential=false set s3backcons-$suffix
+   sudo pcs -f s3cfg constraint order set $s3servers require-all=false \
+       sequential=false set haproxy-$suffix
    sudo pcs cluster cib-push s3cfg --config
 }
 
@@ -572,3 +572,9 @@ run_on_both $cmd
 
 add_s3server_resources c1 $lnode $rnode
 add_s3server_resources c2 $rnode $lnode
+
+echo 'Adding mero-free-space-monitor to pacemaker...'
+sudo pcs resource create mero-free-space-mon systemd:mero-free-space-monitor op \
+    monitor interval=30s
+sudo pcs constraint order c1 then mero-free-space-mon
+sudo pcs constraint order c2 then mero-free-space-mon


### PR DESCRIPTION
Solution:
Update build-ees-ha script to add mero-free-space-monitor service and its
dependency constraints to pacemaker.

Closes EOS-6614

[ci-skip]

(cherry picked from commit 2c2b8a9dd1e789ff5d72c60ec80e1b10bd0ad9f1)