### PR TITLE
EOS-7736: fix potential /var/mero data corruption/loss

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -371,12 +371,12 @@ sudo cp /usr/lib/systemd/system/hare-hax.service \
         /usr/lib/systemd/system/hare-hax-c2.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
          -e "/ExecStart=/iExecStartPre=/bin/mount $lvolume /var/mero" \
-         -e '/ExecStart=/aExecStopPost=/bin/umount --lazy /var/mero' \
+         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero' \
          -i /usr/lib/systemd/system/hare-hax-c1.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
          -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
          -e "/ExecStart=/iExecStartPre=/bin/mount $rvolume /var/mero2" \
-         -e '/ExecStart=/aExecStopPost=/bin/umount --lazy /var/mero2' \
+         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero2' \
          -i /usr/lib/systemd/system/hare-hax-c2.service
 echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
@@ -386,13 +386,13 @@ sudo cp /usr/lib/systemd/system/hare-hax.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/'
          -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
          -e '/ExecStart=/iExecStartPre=/bin/mount $lvolume /var/mero1'
-         -e '/ExecStart=/aExecStopPost=/bin/umount --lazy /var/mero1'
+         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero1'
          -i /usr/lib/systemd/system/hare-hax-c1.service &&
 sudo cp /usr/lib/systemd/system/hare-hax.service
         /usr/lib/systemd/system/hare-hax-c2.service &&
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
          -e '/ExecStart=/iExecStartPre=/bin/mount $rvolume /var/mero'
-         -e '/ExecStart=/aExecStopPost=/bin/umount --lazy /var/mero'
+         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero'
          -i /usr/lib/systemd/system/hare-hax-c2.service &&
 echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
 ssh $rnode $cmd


### PR DESCRIPTION
The usage of lazy flag for umount can potentially lead to
/var/mero filesystem data corruption (and hence - data loss)
during failover/failback scenarios. For example, if /var/mero
is mounted on node1 before it is really unmounted on node2
yet, the filesystem might end up with a data corruption/loss.

Solution: remove the lazy flag from umount /var/mero cmd.

Note: it is possible that umount will fail because /var/mero
could be busy with dumping some core files, for example.
In this case Pacemaker will fence the node before /var/mero
is mounted on another node, so we are safe here.

Kudos to Maxim Medved for reporting the issue.