### PR TITLE
Problem: 'uds' pcs resource may remain unconstrained

### DIFF
--- a/utils/build-ees-ha-uds
+++ b/utils/build-ees-ha-uds
@@ -32,6 +32,9 @@ while true; do
     esac
 done
 
+# Abort (set -e) if `csm-web` resource does not exist.
+sudo pcs resource show csm-web >/dev/null
+
 echo 'Adding UDS resource and constraints...'
 sudo pcs cluster cib udscfg
 sudo pcs -f udscfg resource create uds systemd:uds op monitor interval=30s


### PR DESCRIPTION
`build-ees-ha-uds` creates `uds` resource and co-locates it with `csm-web`.
But what if there is no `csm-web` resource?  This situation should be
handled.

Solution: do not configure UDS HA unless `csm-web` resource exists.

Closes #951.