### PR TITLE
ees-ha: fix mero-free-space-mon resource cleanup

### DIFF
--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -31,6 +31,7 @@ resources=(
     s3auth
     ldap
     rabbitmq
+    mero-free-space-mon
     c{2,1}
     mero-kernel
     lnet


### PR DESCRIPTION
Looks like mero-free-space-mon resource was forgotten to be
added into the list of resources to clean up at utils/prov-ha-reset.