### PR TITLE
Problem: garbage in 'stats/filesystem' value

### DIFF
--- a/hax/hax/hax.c
+++ b/hax/hax/hax.c
@@ -182,7 +182,7 @@ PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx)
 	M0_ASSERT(rc == 0);
 	Py_END_ALLOW_THREADS PyObject *hax_mod = getModule("hax.types");
 	PyObject *fs_stats = PyObject_CallMethod(
-	    hax_mod, "FsStats", "(KKKKKkk)", stats.fs_free_seg,
+	    hax_mod, "FsStats", "(KKKKKII)", stats.fs_free_seg,
 	    stats.fs_total_seg, stats.fs_free_disk, stats.fs_avail_disk,
 	    stats.fs_total_disk, stats.fs_svc_total, stats.fs_svc_replied);
 	Py_DECREF(hax_mod);

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -113,6 +113,7 @@ class Uint128:
         return Uint128Struct(self.hi, self.lo)
 
 
+# struct m0_fs_stats
 FsStats = NamedTuple('FsStats', [('fs_free_seg', int), ('fs_total_seg', int),
                                  ('fs_free_disk', int), ('fs_avail_disk', int),
                                  ('fs_total_disk', int), ('fs_svc_total', int),


### PR DESCRIPTION
```
$ /opt/seagate/eos/hare/bin/consul kv get stats/filesystem | jq .
{
  "stats": {
    "fs_free_seg": 8590424952,
    "fs_total_seg": 8590951744,
    "fs_free_disk": 104689827840,
    "fs_avail_disk": 104689827840,
    "fs_total_disk": 104689827840,
    "fs_svc_total": 140196322476034,
    "fs_svc_replied": 140196322476034
  },
  "timestamp": 1588614753.264395,
  "date": "2020-05-04T17:52:33.264395"
}
```
The actual value of stats.fs_svc_total = stats.fs_svc_replied = 2.

Solution: fix type conversion error in `m0_ha_filesystem_stats_fetch()`.

Closes #960

(cherry picked from commit 7c6ceaae5b345f991ade6f0df7f144e5fd134552)