### PR TITLE
Problem: Hax is shown in syslog as 'sh'

### DIFF
--- a/systemd/hare-hax.service
+++ b/systemd/hare-hax.service
@@ -5,6 +5,7 @@ After=hare-consul-agent.service mero-kernel.service
 
 [Service]
 # TODO: '/opt/seagate/eos/hare' prefix can be different, e.g. '/usr'
+SyslogIdentifier=hare-hax
 Environment=PYTHONPATH=/opt/seagate/eos/hare/lib64/python3.6/site-packages:/opt/seagate/eos/hare/lib/python3.6/site-packages
 ExecStart=/bin/sh -c 'cd /var/mero/hax && exec /opt/seagate/eos/hare/bin/hax'
 KillMode=process


### PR DESCRIPTION
Solution: specify the proper SyslogIdentifier in the hax systemd unit file.

Closes #942


Here is how journalctl shows hax logs with the fix applied:

```
May 06 05:43:42 ssc-vm-0018.colo.seagate.com hare-hax[22398]: 2020-05-06 05:43:42,551 [DEBUG] {qconsumer} http://127.0.0.1:8500 "GET /v1/kv/m0conf/nodes?recurse=1 HTTP/1.1" 200 475
May 06 05:43:42 ssc-vm-0018.colo.seagate.com hare-hax[22398]: 2020-05-06 05:43:42,553 [DEBUG] {qconsumer} http://127.0.0.1:8500 "GET /v1/health/node/ssc-vm-0018.colo.seagate.com HTTP/1.1" 200 308
May 06 05:43:42 ssc-vm-0018.colo.seagate.com hare-hax[22398]: 2020-05-06 05:43:42,554 [DEBUG] {qconsumer} Replying ha nvec of length 1
```