### PR TITLE
EOS-7695: fix ha_link_outgoing_fop_replied warnings for s3servers

### DIFF
--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -14,9 +14,22 @@
     {
       "type": "service",
       "service": "ios",
-      "args": [
-        "/opt/seagate/eos/hare/libexec/watch-service"
-      ]
+      "args": [ "/opt/seagate/eos/hare/libexec/watch-service" ]
+    },
+    {
+      "type": "service",
+      "service": "s3service",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:8008",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
+      "type": "service",
+      "service": "s3service",
+      "args": [ "/opt/seagate/eos/hare/libexec/watch-service" ]
     }
   ],
   "services": []

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -4,9 +4,7 @@
     {
       "type": "key",
       "key": "leader",
-      "args": [
-        "/opt/seagate/eos/hare/libexec/elect-rc-leader"
-      ]
+      "args": [ "/opt/seagate/eos/hare/libexec/elect-rc-leader" ]
     },
     {
       "type": "service",
@@ -21,9 +19,7 @@
     {
       "type": "service",
       "service": "confd",
-      "args": [
-        "/opt/seagate/eos/hare/libexec/watch-service"
-      ]
+      "args": [ "/opt/seagate/eos/hare/libexec/watch-service" ]
     },
     {
       "type": "service",
@@ -38,9 +34,22 @@
     {
       "type": "service",
       "service": "ios",
-      "args": [
-        "/opt/seagate/eos/hare/libexec/watch-service"
-      ]
+      "args": [ "/opt/seagate/eos/hare/libexec/watch-service" ]
+    },
+    {
+      "type": "service",
+      "service": "s3service",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:8008",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
+      "type": "service",
+      "service": "s3service",
+      "args": [ "/opt/seagate/eos/hare/libexec/watch-service" ]
     }
   ],
   "enable_local_script_checks": true,


### PR DESCRIPTION
ha_link failure state must be sent for a Mero process when it
disconnects. This was not the case for s3server processes so
there were warnings in syslog from hax:

```
WARN  [ha/link.c:1254:ha_link_outgoing_fop_replied]  rc=-110 hl=0x7fb12800e2e0
```

Solution: add service watches for s3services into Consul.

Testing: verified on smc20/19-m10 setup.