### PR TITLE
Problem: Hax is shown in syslog as 'sh'

### DIFF
--- a/systemd/hare-hax.service
+++ b/systemd/hare-hax.service
@@ -5,6 +5,7 @@ After=hare-consul-agent.service mero-kernel.service
 
 [Service]
 # TODO: '/opt/seagate/eos/hare' prefix can be different, e.g. '/usr'
+SyslogIdentifier=hare-hax
 Environment=PYTHONPATH=/opt/seagate/eos/hare/lib64/python3.6/site-packages:/opt/seagate/eos/hare/lib/python3.6/site-packages
 ExecStart=/bin/sh -c 'cd /var/mero/hax && exec /opt/seagate/eos/hare/bin/hax'
 KillMode=process


### PR DESCRIPTION
Solution: specify the proper SyslogIdentifier in the hax systemd unit file.
(cherry picked from commit 84a441278a3a59bfa4fde7f19fd8b5d7078c236c)