### PR TITLE
Problem: build-ees-ha adds nonessential instructions to hare-consul systemd unit

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -271,28 +271,6 @@ cmd_deregister_node() {
 EOF
 }
 
-consul_c2_cfg_dir=$hare_dir/consul-$ip2
-consul_c1_cfg_dir=$hare_dir/consul-$ip1
-consul_exe=/opt/seagate/eos/hare/bin/consul
-
-sudo sed \
- -e "/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c2_cfg_dir" \
- -e "/ExecStart=/iExecStartPre=-$consul_exe force-leave $rnode" \
- -e "/ExecStartPost=/aExecStartPost=$(cmd_deregister_node $rnode)" \
- -i /usr/lib/systemd/system/hare-consul-agent-c2.service
-sudo systemctl daemon-reload
-
-cmd="
-sudo sed
- -e '/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c1_cfg_dir'
- -e '/ExecStart=/iExecStartPre=-$consul_exe force-leave $lnode'
- -e \"/ExecStartPost=/aExecStartPost=$(cmd_deregister_node $lnode)\"
- -i /usr/lib/systemd/system/hare-consul-agent-c1.service &&
-sudo systemctl daemon-reload"
-ssh $rnode $cmd
-
-unset consul_exe consul_c1_cfg_dir consul_c2_cfg_dir
-
 sudo cp $hare_dir/consul-env $hare_dir/consul-env-c1
 scp $rnode:$hare_dir/consul-env $hare_dir/consul-env-c2
 sudo sed -r \


### PR DESCRIPTION
With introduction of persistent consul node-id, force-leave and de-registration
of a consul node on termination is not required.

Solution:
Remove force-leave and deregistering consul node instructions from build-ees-ha.