### PR TITLE
Problem: hctl node shutdown turns into reboot

### DIFF
--- a/pcswrap/pcswrap/internal/connector.py
+++ b/pcswrap/pcswrap/internal/connector.py
@@ -4,9 +4,8 @@ from subprocess import PIPE, Popen
 from typing import Any, List
 
 import defusedxml.ElementTree as ET
-
 from pcswrap.exception import CliException, PcsNoStatusException
-from pcswrap.types import Resource, Node, PcsConnector
+from pcswrap.types import Node, PcsConnector, Resource
 
 
 def _to_bool(value: str) -> bool:
@@ -72,7 +71,8 @@ class CliConnector(PcsConnector):
                         online=b(tag.attrib['online']),
                         shutdown=b(tag.attrib['shutdown']),
                         unclean=b(tag.attrib['unclean']),
-                        standby=b(tag.attrib['standby']))
+                        standby=b(tag.attrib['standby']),
+                        resources_running=int(tag.attrib['resources_running']))
 
         xml_str = self.executor.get_full_status_xml()
         xml = self._parse_xml(xml_str)

--- a/pcswrap/pcswrap/types.py
+++ b/pcswrap/pcswrap/types.py
@@ -1,10 +1,11 @@
-from typing import List, NamedTuple, Optional
 from abc import ABC, abstractmethod
+from typing import List, NamedTuple, Optional
 
 Credentials = NamedTuple('Credentials', [('username', str), ('password', str)])
 
 Node = NamedTuple('Node', [('name', str), ('online', bool), ('shutdown', bool),
-                           ('standby', bool), ('unclean', bool)])
+                           ('standby', bool), ('unclean', bool),
+                           ('resources_running', int)])
 
 Resource = NamedTuple('Resource', [('id', str), ('resource_agent', str),
                                    ('role', str), ('target_role', str),


### PR DESCRIPTION
Solution: set the node to standby mode first (so that Pacemaker will not
manage the node) and only after that send shutdown signal.

Jira: EOS-7904