### PR TITLE
Problem: check to confirm if m0d has started may fail

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -115,6 +115,15 @@ wait_active() {
     done
 }
 
+process_started() {
+    local fid=$1
+    case $(consul kv get processes/$fid |
+               jq '.state == "M0_CONF_HA_PROCESS_STARTED"' || true) in
+        true) return 0;;
+    esac
+    return 1
+}
+
 # m0d sends 'active' to systemd before the startup is actually finished,
 # so we need to parse the output of m0d this way to make sure it is
 # really started.
@@ -123,7 +132,7 @@ wait_m0d_started() {
     local timeout=$2  # seconds
     local count=0
 
-    while ! sudo systemctl status "m0d@$fid" | grep -q ': Started$'; do
+    while ! process_started $fid; do
         (($count < $timeout)) || die "Unable to start m0d@$fid service"
         sleep 1
         ((++count))


### PR DESCRIPTION
Deployment for ees_ha fails in build #2055 as the check to confirm if m0d
has started in bootstrap-node fails because mero generates following IEM
messages,
```
May 09 15:04:41 smc22-m10.colo.seagate.com mero-server[13343]: IEC: ES0020020004:RPC_ITEM_FAILED kind="REQUEST" opcode=32 xid=18446744073709551615 state="WAITING_FOR_REPLY" rpc_machine_ep=192.168.0.4@o2ib:12345:2:1 remote_machine_ep=192.168.0.3@o2ib:12345:2:2 error=-110
May 09 15:04:41 smc22-m10.colo.seagate.com mero-server[13343]: IEC: ES0020020004:RPC_ITEM_FAILED kind="REQUEST" opcode=32 xid=18446744073709551615 state="WAITING_FOR_REPLY" rpc_machine_ep=192.168.0.4@o2ib:12345:2:1 remote_machine_ep=192.168.0.3@o2ib:12345:2:2 error=-110
```
These messages seem to be generated when mero-confd-c1 tries to connect to
mero-confd-c2 which is not up yet.

Solution:
Every mero process updates its status to Hare which is persisted in Consul.
Check the corresponding process status saved in Consul.