### PR TITLE
EOS-7994: avoid lazy umount during provisioning

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -249,9 +249,9 @@ sudo rm -r /var/mero1
 
 # We don't need `/var/mero` mounted anymore. `hax` systemd
 # unit will mount/umount it automatically on start/stop.
-sudo umount --lazy /var/mero
+while ! sudo umount /var/mero; do sleep 1; done
 
-ssh $rnode 'sudo mkdir -p /var/mero1 && sudo umount --lazy /var/mero'
+ssh $rnode 'sudo mkdir -p /var/mero1 && while ! sudo umount /var/mero; do sleep 1; done'
 
 echo 'Preparing Consul agents config files...'
 cmd='

--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -40,5 +40,5 @@ for r in ${resources[@]}; do
     pcs resource delete $r || true
 done
 
-umount --lazy /var/mero2 || true
-umount --lazy /var/mero1 || true
+while ! umount /var/mero2; do sleep 1; done
+while ! umount /var/mero1; do sleep 1; done


### PR DESCRIPTION
According to Max Medved, the uncontrolled lazy umount
can cause data corruption later when the cluster is started
and some failover happens. So we better avoid it altogether.