### PR TITLE
Problem: hctl commands are not logged

### DIFF
--- a/hctl
+++ b/hctl
@@ -10,7 +10,6 @@ PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
 M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
 
-
 die() {
     local LightRed="$(tput bold ; tput setaf 1)"
     local NC="$(tput sgr0)" # No Color
@@ -93,6 +92,7 @@ case $cmd in
         PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
         export PYTHONPATH
 
+        logger --tag $PROG -- $PROG $cmd "$@"
         exec $HARE_BASE_DIR/libexec/hare-$cmd "$@"
         ;;
     *) die "Unknown command: '$cmd'" ;;


### PR DESCRIPTION
hctl commands may be quite disruptive.  During debugging, it helps
to know which hctl command were called and when.

Solution: record `hctl` commands (excluding hctl help) in the system log.