### PR TITLE
EOS-7937: fix order constraint for mero-free-space-mon

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -554,5 +554,5 @@ add_s3server_resources c2 $rnode $lnode
 echo 'Adding mero-free-space-monitor to pacemaker...'
 sudo pcs resource create mero-free-space-mon systemd:mero-free-space-monitor \
      op monitor interval=30s
-sudo pcs constraint order c1 then mero-free-space-mon
-sudo pcs constraint order c2 then mero-free-space-mon
+sudo pcs constraint order mero-ios-c1 then mero-free-space-mon
+sudo pcs constraint order mero-ios-c2 then mero-free-space-mon


### PR DESCRIPTION
The order constraint on the whole group c{1,2} does not seem
to work - the resource is not stopping before some resources
in the group start stopping:

```
$ sudo pcs status
...
 Resource Group: c1
     ip-c1	(ocf::heartbeat:IPaddr2):	Started smc20-m10.colo.seagate.com
     lnet-c1	(ocf::eos:lnet):	Started smc20-m10.colo.seagate.com
     consul-c1	(systemd:hare-consul-agent-c1):	Started smc20-m10.colo.seagate.com
     hax-c1	(systemd:hare-hax-c1):	Started smc20-m10.colo.seagate.com
     mero-confd-c1	(systemd:m0d@0x7200000000000001:0x9):	Stopping smc20-m10.colo.seagate.com
     mero-ios-c1	(systemd:m0d@0x7200000000000001:0xc):	Stopped
 Resource Group: c2
     ip-c2	(ocf::heartbeat:IPaddr2):	Started smc19-m10.colo.seagate.com
     lnet-c2	(ocf::eos:lnet):	Started smc19-m10.colo.seagate.com
     consul-c2	(systemd:hare-consul-agent-c2):	Started smc19-m10.colo.seagate.com
     hax-c2	(systemd:hare-hax-c2):	Started smc19-m10.colo.seagate.com
     mero-confd-c2	(systemd:m0d@0x7200000000000001:0x52):	Stopping smc19-m10.colo.seagate.com
     mero-ios-c2	(systemd:m0d@0x7200000000000001:0x55):	Stopped
...
 mero-free-space-mon	(systemd:mero-free-space-monitor):	Started smc20-m10.colo.seagate.com
```

Solution: base the order constraint on mero-ios-c{1,2}.