### PR TITLE
Problem: csm order constraints are missing

### DIFF
--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -128,6 +128,11 @@ sudo pcs -f csmcfg resource create csm-web systemd:csm_web op \
 
 sudo pcs -f csmcfg resource group add \
      csm-kibana kibana-vip kibana csm-web csm-agent
+
+sudo pcs -f csmcfg constraint order consul-c1 then csm-web
+sudo pcs -f csmcfg constraint order consul-c2 then csm-web
+sudo pcs -f csmcfg constraint order els-search-clone then csm-kibana
+
 sudo pcs -f csmcfg constraint colocation add csm-kibana with els-search-clone \
     score=INFINITY
 sudo pcs -f csmcfg constraint colocation add csm-kibana with consul-c1 \


### PR DESCRIPTION
CSM depends on consul and elasticsearch resources, order constraints
are missing for the same which may lead to dependency issues if any
during start up of CSM resources.

Solution:
- Add order constraints for csm_web service with consul.
- Add order constraints for csm resource group with elasticsearch.

[ci skip]

(cherry picked from commit 61c4e616cffc3c96ef046b09da9867d6533fd0b9)