### PR TITLE
Problem: pcswrap operations are not syslogged

### DIFF
--- a/pcswrap/mypy.ini
+++ b/pcswrap/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.6
+
+[mypy-systemd]
+ignore_missing_imports = True
+
+[mypy-urllib3.exceptions]
+ignore_missing_imports = True

--- a/pcswrap/pcswrap/client.py
+++ b/pcswrap/pcswrap/client.py
@@ -9,6 +9,7 @@ from pcswrap.exception import CliException, MaintenanceFailed, TimeoutException
 from pcswrap.internal.connector import CliConnector
 from pcswrap.internal.waiter import Waiter
 from pcswrap.types import Credentials, Node, PcsConnector, Resource
+from systemd import journal
 
 __all__ = ['Client', 'main']
 
@@ -230,8 +231,10 @@ def parse_opts(argv: List[str]):
 
 def _setup_logging(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.INFO
+    console = logging.StreamHandler(stream=sys.stderr)
+    journald = journal.JournaldLogHandler(identifier='pcswrap')
     logging.basicConfig(level=level,
-                        stream=sys.stderr,
+                        handlers=[console, journald],
                         format='%(asctime)s [%(levelname)s] %(message)s')
 
 

--- a/pcswrap/requirements.txt
+++ b/pcswrap/requirements.txt
@@ -1,2 +1,3 @@
 dataclasses
 defusedxml
+systemd


### PR DESCRIPTION
`pcswrap` can provide good insights on what decisions are taken.
This information is useful for debugging.

Solution: enable journald logging for `pcswrap`.

Jira: EOS-7494
