### PR TITLE
Problem: Not all services are controlled by pacemaker cluster

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -465,6 +465,20 @@ fi
 sudo rsync -u /etc/sysconfig/m0d-* $rnode:/etc/sysconfig/
 sudo rsync -u "$rnode:/etc/sysconfig/m0d-*" /etc/sysconfig/
 
+echo 'Disabling some systemd units...'
+units_to_disable=(
+    elasticsearch
+    haproxy
+    rabbitmq-server
+    statsd
+    slapd
+    s3authserver
+)
+
+for u in ${units_to_disable[@]}; do
+    run_on_both "sudo systemctl stop $u && sudo systemctl disable $u"
+done
+
 echo 'Adding ldap to Pacemaker...'
 sudo pcs resource create ldap systemd:slapd clone op monitor interval=30s
 

--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -95,6 +95,12 @@ die() {
     exit 1
 }
 
+run_on_both() {
+    local cmd=$*
+    eval $cmd
+    ssh $rnode $cmd
+}
+
 systemctl is-active --quiet hare-consul-agent-c1 ||
     die 'No active Consul instance found'
 ssh $rnode "systemctl is-active --quiet hare-consul-agent-c2" ||
@@ -109,6 +115,17 @@ systemctl is-active --quiet rabbitmq-server ||
     die 'No active rabbitmq instance found'
 ssh $rnode "systemctl is-active --quiet rabbitmq-server" ||
     die 'No active rabbitmq instance found'
+
+echo 'Disabling csm and kibana systemd units...'
+units_to_disable=(
+    kibana
+    csm_web
+    csm_agent
+)
+
+for u in ${units_to_disable[@]}; do
+    run_on_both "sudo systemctl stop $u && sudo systemctl disable $u"
+done
 
 echo 'Adding kibana resources...'
 sudo pcs resource create kibana-vip ocf:heartbeat:IPaddr2 \

--- a/utils/build-ees-ha-sspl
+++ b/utils/build-ees-ha-sspl
@@ -78,6 +78,12 @@ die() {
     exit 1
 }
 
+run_on_both() {
+    local cmd=$*
+    eval $cmd
+    ssh $rnode $cmd
+}
+
 systemctl is-active --quiet hare-consul-agent-c1 ||
     die 'No active Consul instance found'
 ssh $rnode "systemctl is-active --quiet hare-consul-agent-c2" ||
@@ -89,6 +95,10 @@ ssh $rnode "systemctl is-active --quiet rabbitmq-server" ||
     die 'No active rabbitmq instance found'
 
 hare_dir=/var/lib/hare
+
+echo 'Disable sspl systemd unit...'
+cmd='sudo systemctl stop sspl-ll && sudo systemctl disable sspl-ll'
+run_on_both $cmd
 
 echo 'Adding sspl resource and constraints...'
 


### PR DESCRIPTION
Systemd units of following services are not disabled,
```
sspl-ll.service                               enabled
statsd.service                                enabled
slapd.service                                 enabled
s3authserver.service                          enabled
rabbitmq-server.service                       enabled
kibana.service                                enabled
haproxy.service                               enabled
elasticsearch.service                         enabled
csm_agent.service                             enabled
csm_web.service                               enabled
```
This may lead to inconsistencies between their dependencies during start and
service failures and restarts.

Solution:
Stop and disable systemd units for above services before adding them to pacemaker cluster.

[ci skip]

(cherry picked from commit 64f2c2a1dcbf29961f336f894f70b9f72e0032c7)