### PR TITLE
Problem: build-ees-ha fails with cryptic error

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -130,8 +130,12 @@ fi
 [[ -b $lvolume ]] || die "meta-data volume $lvolume is not available"
 [[ -b $rvolume ]] || die "meta-data volume $rvolume is not available"
 
+# Sample output:
+#   $ ip -oneline -4 address show dev eno1
+#   2: eno1    inet 10.230.249.241/20 brd 10.230.255.255 scope global noprefixroute dynamic eno1\       valid_lft 327971sec preferred_lft 327971sec
+#   2: eno1    inet 10.230.255.1/24 brd 10.230.255.255 scope global eno1:v1\       valid_lft forever preferred_lft forever
 netmask=$(ip -oneline -4 address show dev $iface |
-              awk '{print $4}' | cut -d/ -f2)
+              awk '{print $4}' | cut -d/ -f2 | head -1)
 
 echo 'Adding the roaming IP addresses into Pacemaker...'
 sudo pcs cluster cib icfg


### PR DESCRIPTION
`build-ees-ha`, which is not idempotent, fails with cryptic error message
if it's started the second time, when floating IPs are already assigned:
```
[root@smc7-m11 520422]# /opt/seagate/eos/hare/libexec/build-ees-ha /var/lib/hare/cluster.yaml /var/lib/hare/build-ees-ha-args.yaml
Adding the roaming IP addresses into Pacemaker...
Error: missing value of '24' option
```

The `ip` command, used in calculating netmask value, outputs two lines
in this case -- one for actual, another for virtual interface.

Solution: take the first netmask value.

Closes #1001.

