### PR TITLE
EOS-7937: fix /var/mero umount fails on failover/failback

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -371,12 +371,12 @@ sudo cp /usr/lib/systemd/system/hare-hax.service \
         /usr/lib/systemd/system/hare-hax-c2.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
          -e "/ExecStart=/iExecStartPre=/bin/mount $lvolume /var/mero" \
-         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero' \
+         -e "/ExecStart=/aExecStopPost=/bin/sh -c 'while ! /bin/umount /var/mero; do sleep 1; done'" \
          -i /usr/lib/systemd/system/hare-hax-c1.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
          -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
          -e "/ExecStart=/iExecStartPre=/bin/mount $rvolume /var/mero2" \
-         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero2' \
+         -e "/ExecStart=/aExecStopPost=/bin/sh -c 'while ! /bin/umount /var/mero2; do sleep 1; done'" \
          -i /usr/lib/systemd/system/hare-hax-c2.service
 echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
@@ -386,13 +386,13 @@ sudo cp /usr/lib/systemd/system/hare-hax.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/'
          -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
          -e '/ExecStart=/iExecStartPre=/bin/mount $lvolume /var/mero1'
-         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero1'
+         -e \"/ExecStart=/aExecStopPost=/bin/sh -c 'while ! /bin/umount /var/mero1; do sleep 1; done'\"
          -i /usr/lib/systemd/system/hare-hax-c1.service &&
 sudo cp /usr/lib/systemd/system/hare-hax.service
         /usr/lib/systemd/system/hare-hax-c2.service &&
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
          -e '/ExecStart=/iExecStartPre=/bin/mount $rvolume /var/mero'
-         -e '/ExecStart=/aExecStopPost=/bin/umount /var/mero'
+         -e \"/ExecStart=/aExecStopPost=/bin/sh -c 'while ! /bin/umount /var/mero; do sleep 1; done'\"
          -i /usr/lib/systemd/system/hare-hax-c2.service &&
 echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
 ssh $rnode $cmd


### PR DESCRIPTION
In commit 7802d24 we dropped lazy flag from umount to avoid
potential data corruption/loss issues. But now umount fails
sometimes during failover/failback when /var/mero is still
busy with some I/O.

Solution: try to umount in a loop once in 1 sec.
(cherry picked from commit 25e3bf62e62ab3a7a20b22a1885b733aa17138a9)