### PR TITLE
ci: test-pcs err - elasticsearch.service not loaded

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -454,7 +454,7 @@ units_to_disable=(
 )
 
 for u in ${units_to_disable[@]}; do
-    run_on_both "sudo systemctl stop $u && sudo systemctl disable $u"
+    run_on_both "sudo systemctl stop $u && sudo systemctl disable $u" || true
 done
 
 echo 'Adding ldap to Pacemaker...'


### PR DESCRIPTION
On CI build machines elasticsearch is not installed, so
test-pcs cannot pass after we started disabling the
systemd units at commit 64f2c2a.

Solution: check the result of disabling command and
report warning if it fails. This will allow the build
script to continue even if some systemd unit is not
installed.

Closes #1004.