### PR TITLE
ci: test-pcs err - elasticsearch.service not loaded

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -476,7 +476,7 @@ units_to_disable=(
 )
 
 for u in ${units_to_disable[@]}; do
-    run_on_both "sudo systemctl stop $u && sudo systemctl disable $u"
+    run_on_both "sudo systemctl stop $u && sudo systemctl disable $u" || true
 done
 
 echo 'Adding ldap to Pacemaker...'


### PR DESCRIPTION
On CI build machines elasticsearch is not installed, so
test-pcs cannot pass after we started disabling the
systemd units at commit 64f2c2a.

Solution: check the result of disabling command and
don't fail the build script if there is some error.

Closes #1004.

(cherry picked from commit 073738c3138b68070bcf8862daf0b8e3f1d9a77e)