### PR TITLE
Problem: hctl commands not seen in the syslog

### DIFF
--- a/hctl
+++ b/hctl
@@ -92,7 +92,7 @@ case $cmd in
         PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
         export PYTHONPATH
 
-        logger --tag $PROG -- $PROG $cmd "$@"
+        systemd-cat --identifier $PROG <<< "$PROG $cmd $@"
         exec $HARE_BASE_DIR/libexec/hare-$cmd "$@"
         ;;
     *) die "Unknown command: '$cmd'" ;;


### PR DESCRIPTION
`logger` commands have no effect on some systems:
```
[root@sm27-r22 ~]# logger --tag XXX-prog -- Hello world
[root@sm27-r22 ~]# journalctl -l -S $(date -d '- 10 seconds' +%T) | grep XXX
[root@sm27-r22 ~]#
```

Solution: use `systemd-cat` instead of `logger`.

Closes #1018.