### PR TITLE
Problem: Hare CI uses outdated Mero RPM

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   # Mero git reference to build and use.
   #
   # If `MERO_COMMIT_REF` is empty or undefined, CI will use rpms from
-  # http://ci-storage.mero.colo.seagate.com/releases/eos/BLATEST/
+  # http://ci-storage.mero.colo.seagate.com/releases/master/BLATEST/
   MERO_COMMIT_REF: ''
 
   DOCKER_REGISTRY: registry.gitlab.mero.colo.seagate.com

--- a/ci/rpmbuild
+++ b/ci/rpmbuild
@@ -10,7 +10,7 @@ set -x
 
 # `BLATEST` is a symlink, which may be reset at any moment.
 # Store the path of its current target into a variable.
-latest_release_dir=$(readlink -f /releases/eos/BLATEST)
+latest_release_dir=$(readlink -f /releases/master/BLATEST)
 
 # Build Hare rpm.  This requires mero{,-devel} packages to be installed.
 _time yum install -y $latest_release_dir/eos-core{,-devel}-[0-9]*.rpm
@@ -24,8 +24,8 @@ cp -v \
    /root/rpmbuild/RPMS/x86_64/eos-hare*.rpm \
    $latest_release_dir/eos-core{,-devel}-[0-9]*.rpm \
    $latest_release_dir/eos-s3server-[0-9]*.rpm \
-   /releases/eos/s3server_uploads/log4cxx_eos{,-devel}-[0-9]*.rpm \
-   /releases/eos/s3server_uploads/s3cmd-[0-9]*.rpm \
+   /releases/master/s3server_uploads/log4cxx_eos{,-devel}-[0-9]*.rpm \
+   /releases/master/s3server_uploads/s3cmd-[0-9]*.rpm \
    $RPMSYNC_DIR/
 cd $RPMSYNC_DIR
 createrepo -v .  # see https://wiki.centos.org/HowTos/CreateLocalRepos


### PR DESCRIPTION
http://ci-storage.mero.colo.seagate.com/releases/eos/ has not been updated
for some time.

Solution: `s:/releases/eos/:/releases/master/:`.