### PR TITLE
EOS-7904: pcswrap standby <node> always treated as standby --all

### DIFF
--- a/pcswrap/pcswrap/client.py
+++ b/pcswrap/pcswrap/client.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import sys
-from typing import Callable, List
+from typing import Any, Callable, List
 
 from pcswrap.exception import CliException, MaintenanceFailed, TimeoutException
 from pcswrap.internal.connector import CliConnector
@@ -121,112 +121,27 @@ class Client():
                         predicate=all_started)
         waiter.wait()
 
+    def cluster_maintenance(self, timeout: int = 120):
+        logging.info('Disabling stonith resources first')
 
-def parse_opts(argv: List[str]):
-    prog_name = os.environ.get('PCSCLI_PROG_NAME')
+        try:
+            self.disable_stonith(timeout)
+        except TimeoutException:
+            raise MaintenanceFailed()
+        logging.debug('Switching to standby mode')
+        try:
+            self.standby_all(timeout)
+        except Exception:
+            raise MaintenanceFailed()
 
-    p = argparse.ArgumentParser(prog=prog_name,
-                                description='Manages the nodes in HA cluster.')
-    p.add_argument('--verbose',
-                   help='Be verbose while executing',
-                   action='store_true',
-                   default=False,
-                   dest='verbose')
+        logging.info('All nodes are in standby mode now')
 
-    p.add_argument('--username',
-                   help='Username for local authentication at pcsd.'
-                   f' This setting must be specified if {prog_name} is '
-                   ' invoked with non-root privileges.',
-                   dest='username',
-                   nargs=1,
-                   type=str)
-
-    p.add_argument('--password',
-                   help='Password for local authentication at pcsd.'
-                   ' Makes sense if --username is specified.',
-                   dest='password',
-                   nargs=1,
-                   type=str)
-
-    subparsers = p.add_subparsers()
-    status_parser = subparsers.add_parser(
-        'status',
-        help='Show status of all cluster nodes',
-    )
-    unstandby_parser = subparsers.add_parser('unstandby',
-                                             help='Unstandby a node')
-    standby_parser = subparsers.add_parser('standby', help='Standby a node')
-    shutdown_parser = subparsers.add_parser(
-        'shutdown', help='Shutdown (power off) the node by name')
-
-    standby_parser.add_argument('standby_node',
-                                type=str,
-                                nargs='?',
-                                help='Name of the node to standby')
-    standby_parser.add_argument(
-        '--all',
-        action='store_true',
-        dest='standby_node_all',
-        help='Standby all the nodes in the cluster (no node name is required)')
-    unstandby_parser.add_argument('unstandby_node',
-                                  type=str,
-                                  nargs='?',
-                                  help='Name of the node to unstandby')
-    unstandby_parser.add_argument(
-        '--all',
-        action='store_true',
-        dest='unstandby_node_all',
-        help='Unstandby all the nodes in the cluster '
-        '(no node name is required)')
-    status_parser.add_argument('--stub',
-                               dest='show_status',
-                               default=True,
-                               help=argparse.SUPPRESS)
-    shutdown_parser.add_argument('shutdown_node',
-                                 type=str,
-                                 nargs=1,
-                                 help='Name of the node to poweroff')
-    shutdown_parser.add_argument(
-        '--timeout-sec',
-        type=int,
-        dest='timeout_sec',
-        default=120,
-        help='Maximum time that this command will'
-        ' wait for any operation to complete before raising an error')
-
-    maintenance_parser = subparsers.add_parser(
-        'maintenance',
-        help='Switch the cluster to maintenance mode',
-    )
-    maintenance_parser.add_argument('--all',
-                                    dest='maintenance_all',
-                                    action='store_true')
-
-    maintenance_parser.add_argument(
-        '--timeout-sec',
-        type=int,
-        dest='timeout_sec',
-        default=120,
-        help='Maximum time that this command will'
-        ' wait for any operation to complete before raising an error')
-
-    unmaintenance_parser = subparsers.add_parser(
-        'unmaintenance',
-        help='Move the cluster from maintenance back to normal mode',
-    )
-    unmaintenance_parser.add_argument('--all',
-                                      dest='unmaintenance_all',
-                                      action='store_true')
-
-    unmaintenance_parser.add_argument(
-        '--timeout-sec',
-        type=int,
-        dest='timeout_sec',
-        default=120,
-        help='Maximum time that this command will'
-        ' wait for any operation to complete before raising an error')
-    opts = p.parse_args(argv)
-    return opts
+    def cluster_unmaintenance(self, timeout: int = 120):
+        self.unstandby_all(timeout=timeout)
+        logging.info('All nodes are back to normal mode.')
+        self.enable_stonith(timeout=timeout)
+        logging.info(
+            'Stonith resources are enabled. Cluster is functional now.')
 
 
 def _setup_logging(verbose: bool) -> None:
@@ -238,34 +153,11 @@ def _setup_logging(verbose: bool) -> None:
                         format='%(asctime)s [%(levelname)s] %(message)s')
 
 
-def _cluster_maintenance(client: Client, timeout: int = 120):
-    logging.info('Disabling stonith resources first')
+class AppRunner:
+    def __init__(self):
+        self._get_client = self._get_client_default
 
-    try:
-        client.disable_stonith(timeout)
-    except TimeoutException:
-        raise MaintenanceFailed()
-    logging.debug('Switching to standby mode')
-    try:
-        client.standby_all(timeout)
-    except Exception:
-        raise MaintenanceFailed()
-
-    logging.info('All nodes are in standby mode now')
-
-
-def _cluster_unmaintenance(client: Client, timeout: int = 120):
-    client.unstandby_all(timeout=timeout)
-    logging.info('All nodes are back to normal mode.')
-    client.enable_stonith(timeout=timeout)
-    logging.info('Stonith resources are enabled. Cluster is functional now.')
-
-
-def _run(args) -> None:
-    is_verbose = args.verbose
-    _setup_logging(is_verbose)
-
-    def _get_client() -> Client:
+    def _get_client_default(args: Any) -> Client:
         creds = None
         if args.username:
             if not args.password:
@@ -275,33 +167,157 @@ def _run(args) -> None:
                                 password=args.password[0])
         return Client(credentials=creds)
 
-    if hasattr(args, 'standby_node'):
-        if hasattr(args, 'standby_node_all'):
-            _get_client().standby_all()
-        else:
-            _get_client().standby_node(args.standby_node)
-    elif hasattr(args, 'unstandby_node'):
-        if hasattr(args, 'unstandby_node_all'):
-            _get_client().unstandby_all()
-        else:
-            _get_client().unstandby_node(args.stop_node)
-    elif hasattr(args, 'show_status'):
-        nodes = [node._asdict() for node in _get_client().get_all_nodes()]
-        json_str = json.dumps(nodes)
-        print(json_str)
-    elif hasattr(args, 'shutdown_node'):
-        node = args.shutdown_node[0]
-        _get_client().shutdown_node(node, timeout=args.timeout_sec)
-    elif hasattr(args, 'maintenance_all'):
-        _cluster_maintenance(_get_client(), timeout=args.timeout_sec)
-    elif hasattr(args, 'unmaintenance_all'):
-        _cluster_unmaintenance(_get_client(), timeout=args.timeout_sec)
+    def run(self, argv: List[str]) -> None:
+        args = self._parse_opts(argv)
+
+        def client() -> Client:
+            # This function is added to shorten the code below (no need for
+            # "self." prefix and no need to add parameters)
+            return self._get_client(args)
+
+        is_verbose = args.verbose
+        _setup_logging(is_verbose)
+
+        if hasattr(args, 'standby_node'):
+            if args.standby_node_all:
+                client().standby_all()
+            else:
+                client().standby_node(args.standby_node)
+        elif hasattr(args, 'unstandby_node'):
+            if args.unstandby_node_all:
+                client().unstandby_all()
+            else:
+                client().unstandby_node(args.unstandby_node)
+        elif hasattr(args, 'show_status'):
+            nodes = [node._asdict() for node in client().get_all_nodes()]
+            json_str = json.dumps(nodes)
+            print(json_str)
+        elif hasattr(args, 'shutdown_node'):
+            node = args.shutdown_node[0]
+            client().shutdown_node(node, timeout=args.timeout_sec)
+        elif hasattr(args, 'maintenance_all'):
+            client().cluster_maintenance(timeout=args.timeout_sec)
+        elif hasattr(args, 'unmaintenance_all'):
+            client().cluster_unmaintenance(timeout=args.timeout_sec)
+
+    def _parse_opts(self, argv: List[str]) -> Any:
+        prog_name = os.environ.get('PCSCLI_PROG_NAME')
+
+        p = argparse.ArgumentParser(
+            prog=prog_name, description='Manages the nodes in HA cluster.')
+        p.add_argument('--verbose',
+                       help='Be verbose while executing',
+                       action='store_true',
+                       default=False,
+                       dest='verbose')
+
+        p.add_argument('--username',
+                       help='Username for local authentication at pcsd.'
+                       f' This setting must be specified if {prog_name} is '
+                       ' invoked with non-root privileges.',
+                       dest='username',
+                       nargs=1,
+                       type=str)
+
+        p.add_argument('--password',
+                       help='Password for local authentication at pcsd.'
+                       ' Makes sense if --username is specified.',
+                       dest='password',
+                       nargs=1,
+                       type=str)
+
+        subparsers = p.add_subparsers()
+        status_parser = subparsers.add_parser(
+            'status',
+            help='Show status of all cluster nodes',
+        )
+        unstandby_parser = subparsers.add_parser(
+            'unstandby', help='Remove the given node from standby mode.')
+        standby_parser = subparsers.add_parser(
+            'standby', help='Put the given node into standby mode.')
+        shutdown_parser = subparsers.add_parser(
+            'shutdown', help='Shutdown (power off) the node by name.')
+
+        standby_parser.add_argument('standby_node',
+                                    type=str,
+                                    nargs='?',
+                                    help='Name of the node the operation must '
+                                    'be applied to.')
+        standby_parser.add_argument(
+            '--all',
+            action='store_true',
+            default=False,
+            dest='standby_node_all',
+            help='Put all the nodes in the cluster to standby mode (no node '
+            'name is required)')
+        unstandby_parser.add_argument('unstandby_node',
+                                      type=str,
+                                      nargs='?',
+                                      help='Name of the node the operation '
+                                      'must be applied to.')
+        unstandby_parser.add_argument(
+            '--all',
+            action='store_true',
+            default=False,
+            dest='unstandby_node_all',
+            help='Remove all the nodes in the cluster from standby mode '
+            '(no node name is required).')
+        status_parser.add_argument('--stub',
+                                   dest='show_status',
+                                   default=True,
+                                   help=argparse.SUPPRESS)
+        shutdown_parser.add_argument('shutdown_node',
+                                     type=str,
+                                     nargs=1,
+                                     help='Name of the node to poweroff')
+        shutdown_parser.add_argument(
+            '--timeout-sec',
+            type=int,
+            dest='timeout_sec',
+            default=120,
+            help='Maximum time that this command will'
+            ' wait for any operation to complete before raising an error')
+
+        maintenance_parser = subparsers.add_parser(
+            'maintenance',
+            help='Switch the cluster to maintenance mode',
+        )
+        maintenance_parser.add_argument('--all',
+                                        dest='maintenance_all',
+                                        default=False,
+                                        action='store_true')
+
+        maintenance_parser.add_argument(
+            '--timeout-sec',
+            type=int,
+            dest='timeout_sec',
+            default=120,
+            help='Maximum time that this command will'
+            ' wait for any operation to complete before raising an error')
+
+        unmaintenance_parser = subparsers.add_parser(
+            'unmaintenance',
+            help='Move the cluster from maintenance back to normal mode',
+        )
+        unmaintenance_parser.add_argument('--all',
+                                          dest='unmaintenance_all',
+                                          default=False,
+                                          action='store_true')
+
+        unmaintenance_parser.add_argument(
+            '--timeout-sec',
+            type=int,
+            dest='timeout_sec',
+            default=120,
+            help='Maximum time that this command will'
+            ' wait for any operation to complete before raising an error')
+        opts = p.parse_args(argv)
+        return opts
 
 
 def main() -> None:
-    args = parse_opts(sys.argv[1:])
     try:
-        _run(args)
+        AppRunner().run(sys.argv[1:])
     except MaintenanceFailed:
         logging.error('Failed to switch to maintenance mode.')
         logging.error(

--- a/pcswrap/tests/test_cli_arguments.py
+++ b/pcswrap/tests/test_cli_arguments.py
@@ -1,0 +1,122 @@
+# flake8: noqa: E401
+import sys
+sys.path.insert(0, '..')
+from unittest.mock import MagicMock, call
+from pcswrap.client import Client, AppRunner
+from pcswrap.internal.connector import CliExecutor, CliConnector
+from typing import Tuple
+import unittest
+import os
+import inspect
+
+
+def contents(filename: str) -> str:
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    fullpath = f'{dirname}/{filename}'
+    assert os.path.isfile(fullpath), f'No such file: {fullpath}'
+    with open(fullpath) as f:
+        s = f.read()
+    return s
+
+
+def mock_methods(obj):
+    # [KN] By some reason there is no clean way to make all public methods
+    # mocked just by default. But in test we are usually interested in the
+    # certain methods only, if other ones are invoked,
+    # this should mean FAILURE.
+
+    assert obj is not None
+    members = inspect.getmembers(obj)
+    func_names = [
+        name for (name, val) in members
+        if not name.startswith('_') and inspect.ismethod(val)
+    ]
+
+    for n in func_names:
+        setattr(
+            obj, n,
+            MagicMock(
+                side_effect=Exception(f'Unexpected invocation: function {n}')))
+    return obj
+
+
+GOOD_XML = contents('status-xml-w-clones.xml')
+XML_PLAIN_RESOURCES = contents('status-xml-plain-resources.xml')
+
+
+class AppRunnerTest(unittest.TestCase):
+    def _create_client_and_runner(self) -> Tuple[Client, AppRunner]:
+        stub_executor = CliExecutor()
+        stub_executor.get_full_status_xml = MagicMock()
+        stub_executor.get_full_status_xml.return_value = GOOD_XML
+
+        connector = CliConnector(executor=stub_executor)
+        stub_client = Client(connector=connector)
+        stub_client = mock_methods(stub_client)
+
+        runner = AppRunner()
+        runner._get_client = lambda x: stub_client
+        return (stub_client, runner)
+
+    def test_status_works(self):
+        stub_client, runner = self._create_client_and_runner()
+
+        # Note that any method except for get_all_nodes will raise an
+        # exception immediately.
+        stub_client.get_all_nodes = MagicMock()
+
+        runner.run(['status'])
+        self.assertTrue(stub_client.get_all_nodes.called)
+
+    def test_standby_single_node_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.standby_node = MagicMock()
+
+        runner.run(['standby', 'mynode'])
+        self.assertTrue(stub_client.standby_node.called)
+        self.assertEqual([call('mynode')],
+                         stub_client.standby_node.call_args_list)
+
+    def test_standby_all_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.standby_all = MagicMock()
+        runner.run(['standby', '--all'])
+        self.assertTrue(stub_client.standby_all.called)
+
+    def test_unstandby_single_node_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.unstandby_node = MagicMock()
+
+        runner.run(['unstandby', 'mynode'])
+        self.assertTrue(stub_client.unstandby_node.called)
+        self.assertEqual([call('mynode')],
+                         stub_client.unstandby_node.call_args_list)
+
+    def test_unstandby_all_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.unstandby_all = MagicMock()
+        runner.run(['unstandby', '--all'])
+        self.assertTrue(stub_client.unstandby_all.called)
+
+    def test_maintenance_all_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.cluster_maintenance = MagicMock()
+
+        runner.run(['maintenance', '--all'])
+        self.assertTrue(stub_client.cluster_maintenance.called)
+
+    def test_unmaintenance_all_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.cluster_unmaintenance = MagicMock()
+
+        runner.run(['unmaintenance', '--all'])
+        self.assertTrue(stub_client.cluster_unmaintenance.called)
+
+    def test_shutdown_node_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.shutdown_node = MagicMock()
+
+        runner.run(['shutdown', 'node01'])
+        self.assertTrue(stub_client.shutdown_node.called)
+        self.assertEqual([call('node01', timeout=120)],
+                         stub_client.shutdown_node.call_args_list)


### PR DESCRIPTION
There was a bug in CLI parsing logic (argparse behaves fuzzy sometimes).
Even if the node is given, the application treats it as '--all' flag.

Solution:
1. Fix the CLI logic (the bug itself)
2. Cover CLI argument parsing with unit tests (refactor the code a bit
to make it testable).

Closes #1021