### PR TITLE
EOS-8257: fix Mero nlx_core_tm_start rc=-2 errors during failover

### DIFF
--- a/pacemaker/lnet
+++ b/pacemaker/lnet
@@ -99,6 +99,10 @@ lnet_start() {
     if [ $? =  $OCF_SUCCESS ]; then
 	return $OCF_SUCCESS
     fi
+    # Make sure mero-kernel moule is stopped before we add the new
+    # endpoint address. This is workaround for EOS-8257 issue, a bug
+    # in Pacemaker - https://bugs.clusterlabs.org/show_bug.cgi?id=5428.
+    systemctl stop mero-kernel
     lnetctl net add --net ${OCF_RESKEY_nettype} --if ${OCF_RESKEY_iface}
 }
 


### PR DESCRIPTION
Due to a bug in Pacemaker (https://bugs.clusterlabs.org/show_bug.cgi?id=5428)
mero-kernel sometimes does not restart during the failover (especially, under
a load I/O). As a result, hax or mero-confd process would fail to startup:

```
mero[NNN]: 1d10 ERROR  [.../net/lnet/ulnet_core.c:1171:nlx_core_tm_start]  <! rc=-2
```

Solution: (or rather workaround for now) make sure mero-kernel is stopped
from the lnet RA before adding the IP into LNet configuration.

Testing: verified on smc20/19-m10 setup.

(cherry picked from commit 344c98bc351dd923e5e7aff748a1a1bdc6ee3019)