### PR TITLE
Problem: bootstrap shows noisy "Error!"s

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -117,10 +117,9 @@ wait_active() {
 
 process_started() {
     local fid=$1
-    case $(consul kv get processes/$fid |
-               jq '.state == "M0_CONF_HA_PROCESS_STARTED"' || true) in
-        true) return 0;;
-    esac
+    if [[ $(get-process-state $fid) == M0_CONF_HA_PROCESS_STARTED ]]; then
+        return 0
+    fi
     return 1
 }
 
@@ -179,7 +178,7 @@ for id in $IDs; do
         # (see utils/check-service also).
         while [[ -f /tmp/mero-mkfs-pass-$fid ||
                  -f /tmp/mero-mkfs-fail-$fid ]] ||
-              ! consul kv get processes/$fid | grep -q 'STOPPED'; do
+              [[ $(get-process-state $fid) != M0_CONF_HA_PROCESS_STOPPED ]]; do
             sleep 1
         done
         sleep 1

--- a/utils/get-process-state
+++ b/utils/get-process-state
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+PROG=${0##*/}
+
 usage() {
     cat <<EOF
-Usage: ${0##*/} [OPTION] FID
+Usage: $PROG [OPTION] FID
 
 Get state of the process with given FID from the Consul KV.
 
 Options:
   -h, --help    Show this help and exit.
+
+Examples:
+
+    \$ $PROG 0x7200000000000001:0x2f
+    M0_CONF_HA_PROCESS_STARTED
+
+    \$ $PROG not-a-fid-or-unknown-fid
+    \$
 EOF
 }
 
@@ -22,18 +32,4 @@ case $1 in
 esac
 
 fid=$1
-
-# Process state entry in the Consul KV:
-# processes/<process_fid>:{"state": "<process_state>"}
-# e.g
-#     processes/0x7200000000000001:0x2f:{"state": "M0_CONF_HA_PROCESS_STARTED"}
-
-# XXX FIXME: Process the output of `consul kv export` with `jq`.
-consul kv get processes/$fid | awk -F'[{:}]' '
-{
-    gsub(/"/, "", $2)
-    gsub(/"/, "", $3)
-    gsub(/^[ \t]+/, "", $3)
-    if ($2 == "state")
-        print $3
-}'
+consul kv export processes/$fid | jq -r '.[].value | @base64d' | jq -r '.state'

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -30,8 +30,8 @@ get_service_ids() {
 }
 
 get_service_ep() {
-    local id=$1
-    consul kv get m0conf/nodes/$node/processes/$id/endpoint
+    local process_fidk=$1
+    consul kv get m0conf/nodes/$node/processes/$process_fidk/endpoint
 }
 
 get_service_addr() {


### PR DESCRIPTION
Sometimes hctl bootstrap shows “Error!”s, which look worrisome but are,
in fact, quite harmless:
```
2020-05-18 17:33:18: Starting Consul server agent on this node............ OK
2020-05-18 17:33:28: Importing configuration into the KV store... OK
2020-05-18 17:33:28: Starting Consul agents on other cluster nodes.... OK
2020-05-18 17:33:29: Updating Consul agents configs from the KV store... OK
2020-05-18 17:33:30: Installing Mero configuration files... OK
2020-05-18 17:33:31: Waiting for the RC Leader to get elected.... OK
2020-05-18 17:33:32: Starting Mero (phase1, m0d)...Error! No key exists at: processes/0x7200000000000001:0x9
Error! No key exists at: processes/0x7200000000000001:0x2e
Error! No key exists at: processes/0x7200000000000001:0x9
Error! No key exists at: processes/0x7200000000000001:0x2e
 OK
2020-05-18 17:33:36: Starting Mero (phase2, m0d)...Error! No key exists at: processes/0x7200000000000001:0xc
Error! No key exists at: processes/0x7200000000000001:0x31
 OK
2020-05-18 17:33:42: Starting S3 servers (phase3)... OK
2020-05-18 17:33:43: Checking health of the services... OK
```

Solution: use `consul kv export <key-prefix>` instead of
`consul kv get <key>`.  The export command does not print "Error!"s.

Closes #1028.