### PR TITLE
EOS-8370: fix ees_ha teardown hung

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -243,11 +243,7 @@ sudo umount /var/mero2
 sudo umount /var/mero1
 sudo rm -r /var/mero1
 
-# We don't need `/var/mero` mounted anymore. `hax` systemd
-# unit will mount/umount it automatically on start/stop.
-while ! sudo umount /var/mero; do sleep 1; done
-
-ssh $rnode 'sudo mkdir -p /var/mero1 && while ! sudo umount /var/mero; do sleep 1; done'
+ssh $rnode 'sudo mkdir -p /var/mero1'
 
 echo 'Preparing Consul agents config files...'
 cmd='

--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -40,5 +40,5 @@ for r in ${resources[@]}; do
     pcs resource delete $r || true
 done
 
-while ! umount /var/mero2; do sleep 1; done
-while ! umount /var/mero1; do sleep 1; done
+while mountpoint /var/mero2 && ! umount /var/mero2; do sleep 1; done
+while mountpoint /var/mero1 && ! umount /var/mero1; do sleep 1; done


### PR DESCRIPTION
In commit 70c67039 we untroduced umount in loop to make sure
the volumes are unmounted. But the code was buggy - if the
volume is not mounted - we get stuck in the loop.

Solution: check that the mountpoint is mounted before trying
to unmount it.

Kudos to Andrei Zheregelia for finding this issue.

(cherry picked from commit b4c8b28366c4950bc7781c3cffa2dee9fd0c8f02)