### PR TITLE
Problem: Missing order constraint for s3backgroundproducer service

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -519,11 +519,14 @@ sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backcons-c1
 sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backcons-c2
 sudo pcs -f s3bcfg resource create s3backprod systemd:s3backgroundproducer op \
     monitor interval=30s
+sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backprod
 sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c1 \
     score=50000
 sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c2 \
     score=50000
 sudo pcs cluster cib-push s3bcfg --config
+
+s3servers_all=
 
 add_s3server_resources() {
    local suffix=$1
@@ -554,6 +557,7 @@ add_s3server_resources() {
       sudo pcs -f s3cfg constraint colocation add s3server-$suffix-$count \
           with s3auth-clone score=INFINITY
       s3servers+=" s3server-$suffix-$count"
+      s3servers_all+=" s3server-$suffix-$count"
       (( count++ ))
    done
    sudo pcs cluster cib-push s3cfg --config
@@ -574,6 +578,11 @@ run_on_both $cmd
 
 add_s3server_resources c1 $lnode $rnode
 add_s3server_resources c2 $rnode $lnode
+
+sudo pcs cluster cib s3cfg
+sudo pcs -f s3cfg constraint order set $s3servers_all require-all=false \
+    sequential=false set s3backprod
+sudo pcs cluster cib-push s3cfg --config
 
 echo 'Adding mero-free-space-monitor to pacemaker...'
 sudo pcs resource create mero-free-space-mon systemd:mero-free-space-monitor \


### PR DESCRIPTION
Although s3backgroundproducer resource is colocated with s3backgroundconsumer
pacemaker resource, it is possible that in case of frequent failover/failback
sequences s3backgroundproducer may fail to start as it has dependency on s3servers.

Solution:
Add order constraint of all the s3servers with s3backgroundproducer service.

Jira: EOS-8228