### PR TITLE
EOS-7904: pcswrap fails due to missed 'self' argument

### DIFF
--- a/pcswrap/pcswrap/client.py
+++ b/pcswrap/pcswrap/client.py
@@ -157,7 +157,7 @@ class AppRunner:
     def __init__(self):
         self._get_client = self._get_client_default
 
-    def _get_client_default(args: Any) -> Client:
+    def _get_client_default(self, args: Any) -> Client:
         creds = None
         if args.username:
             if not args.password:


### PR DESCRIPTION
Any CLI command fails with the traceback as follows

```
sudo hctl node status
2020-05-20 04:52:04,066 [ERROR] Unexpected error happened
Traceback (most recent call last):
  File "/home/720599/projects/hare/pcswrap/pcswrap/client.py", line 320, in main
    AppRunner().run(sys.argv[1:])
  File "/home/720599/projects/hare/pcswrap/pcswrap/client.py", line 192, in run
    nodes = [node._asdict() for node in client().get_all_nodes()]
  File "/home/720599/projects/hare/pcswrap/pcswrap/client.py", line 176, in client
    return self._get_client(args)
TypeError: _get_client_default() takes 1 positional argument but 2 were given
```

The actual reason is that one method misses 'self' argument.