### PR TITLE
EOS-8412: fix missing facter symlink in /usr/bin/

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -71,6 +71,12 @@ groupadd --force hare
 chgrp hare /var/lib/hare
 chmod --changes g+w /var/lib/hare
 
+# puppet-agent provides a newer version of facter, but sometimes it might not be
+# available in /usr/bin/, so we need to fix this
+if [[ ! -e /usr/bin/facter && -e /opt/puppetlabs/bin/facter ]] ; then
+    ln -vsf /opt/puppetlabs/bin/facter /usr/bin/facter
+fi
+
 %postun
 systemctl daemon-reload
 


### PR DESCRIPTION
If an older version of 'puppet-agent' is installed via RHEL subscription
manager, it doesn't get symlinked into /usr/bin/ directory. We handle
this in the post install script of Hare rpm.