### PR TITLE
EOS-8362: prevent /var/mero fs corruption

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -332,12 +332,11 @@ unset conf_dir
 echo 'Adding Consul to Pacemaker...'
 sudo pcs resource create consul-c1 systemd:hare-consul-agent-c1
 sudo pcs resource create consul-c2 systemd:hare-consul-agent-c2
-sudo pcs resource group add c1 consul-c1
-sudo pcs resource group add c2 consul-c2
+sudo pcs resource group add c1 consul-c1 --after ip-c1
+sudo pcs resource group add c2 consul-c2 --after ip-c2
 
 echo 'Adding Mero kernel module to Pacemaker...'
-sudo pcs resource create mero-kernel systemd:mero-kernel
-sudo pcs resource clone mero-kernel
+sudo pcs resource create mero-kernel systemd:mero-kernel clone
 sudo pcs constraint order lnet-c1 then mero-kernel-clone
 sudo pcs constraint order lnet-c2 then mero-kernel-clone
 
@@ -380,8 +379,8 @@ echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
 ssh $rnode $cmd
 
 sudo pcs cluster cib mcfg
-sudo pcs -f mcfg resource create hax-c1 systemd:hare-hax-c1
-sudo pcs -f mcfg resource create hax-c2 systemd:hare-hax-c2
+sudo pcs -f mcfg resource create hax-c1 systemd:hare-hax-c1 op stop timeout=30
+sudo pcs -f mcfg resource create hax-c2 systemd:hare-hax-c2 op stop timeout=30
 sudo pcs -f mcfg resource group add c1 hax-c1
 sudo pcs -f mcfg resource group add c2 hax-c2
 sudo pcs -f mcfg constraint order mero-kernel-clone then hax-c1


### PR DESCRIPTION
Currently, it is possible that when /var/mero cannot be unmounted
for some reason and hax stop fails by timeout (after 1 min 30 secs) -
Pacemaker does not treat it as a failure and can migrate it to
another node where hax would mount the same /var/mero again. So
we will end up in a situation when /var/mero is mounted from two
nodes at the same time and this, of course, could lead to the
filesystem and data corruption/loss.

Solution: set stop timeout to 30 secs for hax resources in Pacemaker.
(Currently, it is 100 secs - the default value, which is bigger than
1 min and 30 secs (90 secs). That's why Pacemaker does not see it
as a failure.) If hax could not be stopped within this time frame -
it will be treated as a stop operation failure and Pacemaker will
fence the node. So the situation with /var/mero mounted at the same
time will be eliminated.