### PR TITLE
Problem: starting Consul on a stale data directory may cause problems

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -267,6 +267,28 @@ cmd_deregister_node() {
 EOF
 }
 
+# Cleanup Consul data directory before starting the agent to
+# avoid possible inconsistencies related to consensus when Consul
+# agent joins the Consul cluster. Mainly problems related to leader
+# election.
+
+consul_c2_cfg_dir=$hare_dir/consul-$ip2
+consul_c1_cfg_dir=$hare_dir/consul-$ip1
+
+sudo sed \
+ -e "/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c2_cfg_dir" \
+ -i /usr/lib/systemd/system/hare-consul-agent-c2.service
+sudo systemctl daemon-reload
+
+cmd="
+sudo sed
+ -e '/ExecStart=/iExecStartPre=/bin/rm -rf $consul_c1_cfg_dir'
+ -i /usr/lib/systemd/system/hare-consul-agent-c1.service &&
+sudo systemctl daemon-reload"
+ssh $rnode $cmd
+
+unset consul_c1_cfg_dir consul_c2_cfg_dir
+
 sudo cp $hare_dir/consul-env $hare_dir/consul-env-c1
 scp $rnode:$hare_dir/consul-env $hare_dir/consul-env-c2
 sudo sed -r \


### PR DESCRIPTION
Starting Consul agent on a stale data directory may potentially lead to
consensus issues leading to failure in leader election. Old Consul
directory was cleaned up prior to #1011.The problem was seen during testing
of EOS-7038.

Solution:
Start Consul agent on a fresh data directory.

[ci skip]

(cherry picked from commit d73a5f53af0bb652ab1d00dd43c6c795e554be75)