### PR TITLE
ci: fix test-pcs race with IPs config

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -170,8 +170,6 @@ sudo pcs -f lcfg constraint order lnet-clone then lnet-c1
 sudo pcs -f lcfg constraint order lnet-clone then lnet-c2
 sudo pcs cluster cib-push lcfg --config
 
-sleep 5 # Allow Pacemaker to configure the IPs
-
 # Check the IPs
 check_msg="
 Check the following:
@@ -179,11 +177,26 @@ Check the following:
  2) Run 'pcs status' and make sure LNet is configured.
  3) STONITH is configured or disabled in Pacemaker."
 
-ip a | grep -qF $ip1 ||
-    die "IP address $ip1 doesn't appear to be configured at $lnode. $check_msg"
+# Allow Pacemaker to configure the IPs
+count=10 # On CI VMs it may be quite slow
+while [[ $((count--)) -ne 0 ]]; do
+  sleep 5
+  sudo lctl list_nids | fgrep -q $ip1 || continue
+  ssh $rnode "sudo lctl list_nids | fgrep -q $ip2" || continue
+  break
+done
 
-ssh $rnode "ip a | grep -qF $ip2" ||
-    die "IP address $ip2 doesn't appear to be configured at $rnode. $check_msg"
+ip a | fgrep -q $ip1 ||
+  die "IP address $ip1 doesn't appear to be configured at $lnode. $check_msg"
+
+ssh $rnode "ip a | fgrep -q $ip2" ||
+  die "IP address $ip2 doesn't appear to be configured at $rnode. $check_msg"
+
+sudo lctl list_nids | fgrep -q $ip1 ||
+  die "LNet endpoint $ip1 doesn't appear to be configured at $lnode. $check_msg"
+
+ssh $rnode "sudo lctl list_nids | fgrep -q $ip2" ||
+  die "LNet endpoint $ip2 doesn't appear to be configured at $rnode. $check_msg"
 
 if ! $skip_mkfs; then
     sudo mkfs.ext4 -q $lvolume >/dev/null <<< y


### PR DESCRIPTION
CI VMs may be quite slow and waiting for the IPs to be
configured by Pacemaker only for 5 secs may be not enough.
Moreover, we don't check for the LNet endpoints to be
ready, so this may lead to the situation when hctl
bootstrap is already started and Mero processes are tried
to be started, but the LNet endpoints are not ready yet.
(See http://gitlab.mero.colo.seagate.com/mandar.sawant/hare/-/jobs/167431.)

Solution: check for the IPs in loop and check for the LNet
endpoints configuration to be ready also.