### PR TITLE
Problem: hctl commands not seen in the syslog

### DIFF
--- a/hctl
+++ b/hctl
@@ -10,7 +10,6 @@ PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
 M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
 
-
 die() {
     local LightRed="$(tput bold ; tput setaf 1)"
     local NC="$(tput sgr0)" # No Color
@@ -93,6 +92,7 @@ case $cmd in
         PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
         export PYTHONPATH
 
+        systemd-cat --identifier $PROG <<< "$PROG $cmd $@"
         exec $HARE_BASE_DIR/libexec/hare-$cmd "$@"
         ;;
     *) die "Unknown command: '$cmd'" ;;


### PR DESCRIPTION
`logger` commands have no effect on some systems:
```
[root@sm27-r22 ~]# logger --tag XXX-prog -- Hello world
[root@sm27-r22 ~]# journalctl -l -S $(date -d '- 10 seconds' +%T) | grep XXX
[root@sm27-r22 ~]#
```

Solution: use `systemd-cat` instead of `logger`.

Closes #1018.

(cherry picked from commit 96d99c822206f7edd5e83954204a0941e3348132)

“master” MR: #1019