### PR TITLE
Problem: minor code style deviation in build-ees-ha

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -170,6 +170,14 @@ sudo pcs -f lcfg constraint order lnet-clone then lnet-c1
 sudo pcs -f lcfg constraint order lnet-clone then lnet-c2
 sudo pcs cluster cib-push lcfg --config
 
+# Give Pacemaker time to configure the IPs
+for i in {1..10}; do
+    sleep 5
+    sudo lctl list_nids | grep -qF $ip1 || continue
+    ssh $rnode "sudo lctl list_nids | grep -qF $ip2" || continue
+    break
+done
+
 # Check the IPs
 check_msg="
 Check the following:
@@ -177,25 +185,16 @@ Check the following:
  2) Run 'pcs status' and make sure LNet is configured.
  3) STONITH is configured or disabled in Pacemaker."
 
-# Allow Pacemaker to configure the IPs
-count=10 # On CI VMs it may be quite slow
-while [[ $((count--)) -ne 0 ]]; do
-  sleep 5
-  sudo lctl list_nids | fgrep -q $ip1 || continue
-  ssh $rnode "sudo lctl list_nids | fgrep -q $ip2" || continue
-  break
-done
-
-ip a | fgrep -q $ip1 ||
+ip a | grep -qF $ip1 ||
   die "IP address $ip1 doesn't appear to be configured at $lnode. $check_msg"
 
-ssh $rnode "ip a | fgrep -q $ip2" ||
+ssh $rnode "ip a | grep -qF $ip2" ||
   die "IP address $ip2 doesn't appear to be configured at $rnode. $check_msg"
 
-sudo lctl list_nids | fgrep -q $ip1 ||
+sudo lctl list_nids | grep -qF $ip1 ||
   die "LNet endpoint $ip1 doesn't appear to be configured at $lnode. $check_msg"
 
-ssh $rnode "sudo lctl list_nids | fgrep -q $ip2" ||
+ssh $rnode "sudo lctl list_nids | grep -qF $ip2" ||
   die "LNet endpoint $ip2 doesn't appear to be configured at $rnode. $check_msg"
 
 if ! $skip_mkfs; then


### PR DESCRIPTION
Solution:
- simplify the loop expression;
- use `grep -F` instead of `fgrep`, which is deprecated by [grep(1)](https://linux.die.net/man/1/grep) man page.

Closes #1049.

