### PR TITLE
[for-beta] ci: fix test-pcs race with IPs config

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -166,6 +166,14 @@ sudo pcs -f lcfg constraint order lnet-clone then lnet-c1
 sudo pcs -f lcfg constraint order lnet-clone then lnet-c2
 sudo pcs cluster cib-push lcfg --config
 
+# Give Pacemaker time to configure the IPs
+for i in {1..10}; do
+    sleep 5
+    sudo lctl list_nids | grep -qF $ip1 || continue
+    ssh $rnode "sudo lctl list_nids | grep -qF $ip2" || continue
+    break
+done
+
 # Check the IPs
 check_msg="
 Check the following:
@@ -173,25 +181,16 @@ Check the following:
  2) Run 'pcs status' and make sure LNet is configured.
  3) STONITH is configured or disabled in Pacemaker."
 
-# Allow Pacemaker to configure the IPs
-count=10 # On CI VMs it may be quite slow
-while [[ $((count--)) -ne 0 ]]; do
-  sleep 5
-  sudo lctl list_nids | fgrep -q $ip1 || continue
-  ssh $rnode "sudo lctl list_nids | fgrep -q $ip2" || continue
-  break
-done
-
-ip a | fgrep -q $ip1 ||
+ip a | grep -qF $ip1 ||
   die "IP address $ip1 doesn't appear to be configured at $lnode. $check_msg"
 
-ssh $rnode "ip a | fgrep -q $ip2" ||
+ssh $rnode "ip a | grep -qF $ip2" ||
   die "IP address $ip2 doesn't appear to be configured at $rnode. $check_msg"
 
-sudo lctl list_nids | fgrep -q $ip1 ||
+sudo lctl list_nids | grep -qF $ip1 ||
   die "LNet endpoint $ip1 doesn't appear to be configured at $lnode. $check_msg"
 
-ssh $rnode "sudo lctl list_nids | fgrep -q $ip2" ||
+ssh $rnode "sudo lctl list_nids | grep -qF $ip2" ||
   die "LNet endpoint $ip2 doesn't appear to be configured at $rnode. $check_msg"
 
 if ! $skip_mkfs; then


### PR DESCRIPTION
ci: fix test-pcs race with IPs config

CI VMs may be quite slow and waiting for the IPs to be
configured by Pacemaker only for 5 secs may be not enough.
Moreover, we don't check for the LNet endpoints to be
ready, so this may lead to the situation when hctl
bootstrap is already started and Mero processes are tried
to be started, but the LNet endpoints are not ready yet.

Solution: check for the IPs in loop and check for the LNet
endpoints configuration to be ready also.

(cherry picked from commit b68a1f6876a009cff7731c50bb15721beffa1a71)

master MR: #1048

---

Problem: minor code style deviation in build-ees-ha

Solution:
- simplify the loop expression;
- use `grep -F` instead of `fgrep`, which is deprecated by grep(1) man page.

Closes #1049.

(cherry picked from commit b81d3b4970bc8e05a70b71b97ee7501b5580879e)

master MR: #1052