### PR TITLE
EOS-8414: fix failover dead-loop when m0d can't start

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -34,7 +34,6 @@ Requires: mero = %{h_mero_version}
 Requires: pacemaker
 Requires: pcs
 Requires: python36
-Requires: rsync
 
 Conflicts: halon
 

--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -242,24 +242,24 @@ for f in $hare_dir/{confd.xc,consul-kv.json}; do
         -i $f
 done
 
+run_on_both 'sudo rm -f /etc/sysconfig/m0d-*'
+
 hctl bootstrap -c $hare_dir/
 hctl shutdown
 
-# Prepare symlinks for the failover so that m0d processes
-# from both nodes could access their files at `/var/mero`:
-sudo mkdir -p /var/mero1
+# Create /var/mero dirs for the foreign data-stacks:
 sudo mkdir -p /var/mero2
-sudo mount $lvolume /var/mero1
-sudo mount $rvolume /var/mero2
-sudo ln -sf $(find /var/mero2/m0d-* -maxdepth 0 -type d) \
-           /var/mero1/ || true
-sudo ln -sf $(find /var/mero1/m0d-* -maxdepth 0 -type d) \
-           /var/mero2/ || true
-sudo umount /var/mero2
-sudo umount /var/mero1
-sudo rm -r /var/mero1
-
 ssh $rnode 'sudo mkdir -p /var/mero1'
+
+# Prepare Mero conf files on each node:
+lm0confs=$(echo /etc/sysconfig/m0d-*)
+rm0confs=$(sudo ssh $rnode 'echo /etc/sysconfig/m0d-*')
+sudo scp -q $lm0confs $rnode:/etc/sysconfig/
+sudo scp -q $rnode:\{${rm0confs/ /,}\} /etc/sysconfig/
+for f in $rm0confs; do sudo sed '1iMERO_M0D_DATA_DIR=/var/mero2' -i $f; done
+ssh $rnode "for f in $lm0confs; do \
+                       sudo sed '1iMERO_M0D_DATA_DIR=/var/mero1' -i \$f; done"
+
 
 echo 'Preparing Consul agents config files...'
 cmd='
@@ -382,11 +382,10 @@ sudo cp /usr/lib/systemd/system/hare-hax.service \
         /usr/lib/systemd/system/hare-hax-c2.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
          -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero || /bin/mount $lvolume /var/mero'" \
-         -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n native-data-stack-present' \
-         -e '/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n native-data-stack-present' \
          -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero || while ! /bin/umount /var/mero; do lsof +D /var/mero; sleep 1; done'" \
          -i /usr/lib/systemd/system/hare-hax-c1.service
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
+         -e 's;ExecStart.*cd /var/mero;&2;' \
          -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
          -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero2 || /bin/mount $rvolume /var/mero2'" \
          -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero2 || while ! /bin/umount /var/mero2; do lsof +D /var/mero2; sleep 1; done'" \
@@ -397,6 +396,7 @@ cmd="
 sudo cp /usr/lib/systemd/system/hare-hax.service
         /usr/lib/systemd/system/hare-hax-c1.service &&
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/'
+         -e 's;ExecStart.*cd /var/mero;&1;' \
          -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
          -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero1 || /bin/mount $lvolume /var/mero1'\"
          -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero1 || while ! /bin/umount /var/mero1; do lsof +D /var/mero1; sleep 1; done'\"
@@ -405,8 +405,6 @@ sudo cp /usr/lib/systemd/system/hare-hax.service
         /usr/lib/systemd/system/hare-hax-c2.service &&
 sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
          -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero || /bin/mount $rvolume /var/mero'\"
-         -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n native-data-stack-present' \
-         -e '/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n native-data-stack-present' \
          -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero || while ! /bin/umount /var/mero; do lsof +D /var/mero; sleep 1; done'\"
          -i /usr/lib/systemd/system/hare-hax-c2.service &&
 echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
@@ -421,12 +419,6 @@ sudo pcs -f mcfg constraint order mero-kernel-clone then hax-c1
 sudo pcs -f mcfg constraint order mero-kernel-clone then hax-c2
 sudo pcs -f mcfg constraint order consul-c2 then hax-c1
 sudo pcs -f mcfg constraint order consul-c1 then hax-c2
-# Don't allow the foreign data-stack to start without
-# native data-stack present on the node:
-sudo pcs -f mcfg constraint location hax-c1 rule score=-INFINITY \
-                     '#uname' eq $rnode and native-data-stack-present ne 1
-sudo pcs -f mcfg constraint location hax-c2 rule score=-INFINITY \
-                     '#uname' eq $lnode and native-data-stack-present ne 1
 sudo pcs cluster cib-push mcfg --config
 
 echo 'Adding Mero to Pacemaker...'
@@ -481,10 +473,6 @@ if ! is_virtual; then
     sudo pcs -f clustercfg constraint order c2 then ClusterIP-clone
     sudo pcs cluster cib-push clustercfg --config
 fi
-
-# Copy only the updated files from each side.
-sudo rsync -u /etc/sysconfig/m0d-* $rnode:/etc/sysconfig/
-sudo rsync -u "$rnode:/etc/sysconfig/m0d-*" /etc/sysconfig/
 
 echo 'Disabling some systemd units...'
 units_to_disable=(


### PR DESCRIPTION
In commit 0e9bc32 we introduced transient nodes attributes
(which indicate the native data stack presence on the node)
and the location constraint rules to avoid foreign data
stack presence without the native one. Unfortunately, because
we need to restart the native data stack during the failover
(due to EOS-6023) this logic may lead to failover dead-loops.

For example, consider the case when some Mero process crashes
on node1 and fails to start. Pacemaker decides to failover
the data stack to node2. But the native data stack on node2
needs to restart during the failover, so it begins stopping.
As soon as it stops, Pacemaker notices it, aborts the current
transition and creates the new transition plan. But now,
as the native data stack is not available on node2 anymore,
the migration is also not possible anymore. So Pacemaker just
restarts the native stack back on node2. As soon as it is
started, Pacemaker again aborts the transition and tries to
migrate the data stack from node1 to node2 again. And so on
in the endless loop.

Solution: unfortunately, looks like the only way to solve
this problem is to allow the foreign data stack to be present
on the node without the native one. So we do it as follows:
1) roll-back commit 0e9bc32;
2) start foreign hax process in the foreign /var/mero{1,2}/
   directory instead of the native /var/mero/ to allow the
   latter to be unmounted whenever Pacemaker decides it;
3) add MERO_M0D_DATA_DIR=/var/mero{1,2} to the foreign
   Mero /etc/sysconfig/m0d-* conf files instead of using
   the symlinks at /var/mero dir.

Testing: checked on smc7/8-m11 setup:

```
$ sudo pcs status
...
Node srvnode-1: standby
Online: [ srvnode-2 ]
...
 Resource Group: c1
     ip-c1      (ocf::heartbeat:IPaddr2):       Started srvnode-2
     consul-c1  (systemd:hare-consul-agent-c1): Started srvnode-2
     lnet-c1    (ocf::eos:lnet):        Started srvnode-2
     hax-c1     (systemd:hare-hax-c1):  Started srvnode-2
     mero-confd-c1      (systemd:m0d@0x7200000000000001:0x9):   Started srvnode-2
     mero-ios-c1        (systemd:m0d@0x7200000000000001:0xc):   Stopped
 Resource Group: c2
     ip-c2      (ocf::heartbeat:IPaddr2):       Started srvnode-2
     consul-c2  (systemd:hare-consul-agent-c2): Started srvnode-2
     lnet-c2    (ocf::eos:lnet):        Started srvnode-2
     hax-c2     (systemd:hare-hax-c2):  Stopped (disabled)
     mero-confd-c2      (systemd:m0d@0x7200000000000001:0x52):  Stopped
     mero-ios-c2        (systemd:m0d@0x7200000000000001:0x55):  Stopped
```

As one can see from the above, the foreign data-stack is able to
start on srvnode-2 (hax-c1 is started) without the native one
being present (hax-c2 is stopped).