### PR TITLE
Problem: the output of test-pcs is uninformative

### DIFF
--- a/ci/m0vg/test-pcs
+++ b/ci/m0vg/test-pcs
@@ -104,4 +104,11 @@ bash -x /opt/seagate/eos/hare/libexec/build-ees-ha \
     --right-node ${hosts[1]} \
     --left-volume ${disks[0]} \
     --right-volume ${disks[1]} \
-    ci/m0vg/_test-pcs.yaml
+    ci/m0vg/_test-pcs.yaml || {
+
+    rc=$?
+    (($rc != 0))  # "assert"
+    sudo pcs status
+    exit $rc
+}
+sudo pcs status


### PR DESCRIPTION
Solution: run `sudo pcs status` after `build-ees-ha`.