### PR TITLE
EOS-8396: hctl doesn't tell whether the cluster is started

### DIFF
--- a/pcswrap/tests/test_cli_arguments.py
+++ b/pcswrap/tests/test_cli_arguments.py
@@ -63,10 +63,10 @@ class AppRunnerTest(unittest.TestCase):
 
         # Note that any method except for get_all_nodes will raise an
         # exception immediately.
-        stub_client.get_all_nodes = MagicMock()
+        stub_client.get_status = MagicMock()
 
         runner.run(['status'])
-        self.assertTrue(stub_client.get_all_nodes.called)
+        self.assertTrue(stub_client.get_status.called)
 
     def test_standby_single_node_works(self):
         stub_client, runner = self._create_client_and_runner()


### PR DESCRIPTION
Wider problem: The provisioners need to learn programmatically whether
all the resources have been already started or not (it takes a while
to start all of them and it is not clear how many of them must be
started in every particular case).

Solution: support `hctl node status --full` flag so that it prints a
JSON of the following (enriched) layout:

```json
{
  "resources": {
    "statistics": {
      "started": 0,
      "stopped": 2,
      "awaiting_start": 0
    }
  },
  "nodes": [
    {
      "name": "ssc-vm-0018",
      "online": true,
      "shutdown": false,
      "standby": true,
      "unclean": false,
      "resources_running": 0
    }
  ]
}
```

"nodes" subtree is just the same to what "hctl node status" emits - it is an array of node data.
"resources.statistics.awaiting_start" contains the number of resources that are planned to start by Pacemaker but not started yet. This is what provisioners are interested in.


cc @ivan.poddubnyy, @yashodhan.pise