### PR TITLE
EOS-7904: hctl node shutdown won't work when it is the last alive node

### DIFF
--- a/pcswrap/pcswrap/types.py
+++ b/pcswrap/pcswrap/types.py
@@ -14,6 +14,11 @@ Resource = NamedTuple('Resource', [('id', str), ('resource_agent', str),
                                    ('failed', bool), ('failure_ignored', bool),
                                    ('nodes_running_on', int)])
 
+StonithResource = NamedTuple('StonithResource',
+                             [('klass', str), ('typename', str),
+                              ('pcmk_host_list', str), ('ipaddr', str),
+                              ('login', str), ('passwd', str)])
+
 
 class PcsConnector(ABC):
     credentials = None
@@ -71,3 +76,16 @@ class PcsConnector(ABC):
 
     def get_credentials(self) -> Optional[Credentials]:
         return self.credentials
+
+    @abstractmethod
+    def manual_shutdown_node(self, node_name: str) -> None:
+        '''
+        Powers off the given node by name using explicit ipmi_tool invocation.
+        The necessary IPMI parameters are extracted from the corresponding
+        stonith resource which is registered in Pacemaker
+        '''
+        pass
+
+    @abstractmethod
+    def ensure_shutdown_possible(self, node_name: str) -> None:
+        pass

--- a/pcswrap/tests/test_stonith_parser.py
+++ b/pcswrap/tests/test_stonith_parser.py
@@ -1,0 +1,53 @@
+# flake8: noqa: E401
+import sys
+sys.path.insert(0, '..')
+from unittest.mock import MagicMock, call
+from pcswrap.types import StonithResource
+from pcswrap.internal.connector import StonithParser
+from typing import Tuple
+import unittest
+
+
+class StonithParserTest(unittest.TestCase):
+    def test_parser_works(self):
+        p = StonithParser()
+        raw_text = '''
+ Resource: stonith-c1 (class=stonith type=fence_ipmilan)
+  Attributes: delay=5 ipaddr=10.230.244.112 login=ADMIN passwd=adminBMC! pcmk_host_check=static-list pcmk_host_list=srvnode-1 power_timeout=40
+  Operations: monitor interval=10s (stonith-c1-monitor-interval-10s)
+'''        
+        result = p.parse(raw_text)
+        self.assertIsNotNone(result)
+        self.assertEqual('stonith', result.klass)
+        self.assertEqual('fence_ipmilan', result.typename)
+        self.assertEqual('10.230.244.112', result.ipaddr)
+        self.assertEqual('ADMIN', result.login)
+        self.assertEqual('adminBMC!', result.passwd)
+
+    def test_only_ipmi_supported(self):
+        p = StonithParser()
+        raw_text = '''
+ Resource: stonith-c1 (class=stonith type=fence_dummy)
+  Attributes: delay=5 ipaddr=10.230.244.112 login=ADMIN passwd=adminBMC! pcmk_host_check=static-list pcmk_host_list=srvnode-1 power_timeout=40
+  Operations: monitor interval=10s (stonith-c1-monitor-interval-10s)
+'''        
+        with self.assertRaises(AssertionError):
+            p.parse(raw_text)
+
+    def test_emptyilnes_ignored(self):
+        p = StonithParser()
+        raw_text = '''
+
+ Resource: stonith-c1 (class=stonith type=fence_ipmilan)
+
+  Attributes: delay=5 ipaddr=10.230.244.112 login=ADMIN passwd=adminBMC! pcmk_host_check=static-list pcmk_host_list=test-2 power_timeout=40
+  Operations: monitor interval=10s (stonith-c1-monitor-interval-10s)
+'''        
+        result = p.parse(raw_text)
+        self.assertIsNotNone(result)
+        self.assertEqual('stonith', result.klass)
+        self.assertEqual('fence_ipmilan', result.typename)
+        self.assertEqual('10.230.244.112', result.ipaddr)
+        self.assertEqual('ADMIN', result.login)
+        self.assertEqual('adminBMC!', result.passwd)
+        self.assertEqual('test-2', result.pcmk_host_list)


### PR DESCRIPTION
Solution: implement a workaround: extract the IPMI parameters
from Pacemaker but use explicit ipmitool command
line under the hood.

Closes #1054

(cherry picked from commit beaccc77eaecdeae05ff04efe08c11f99ac7943a)

"master" MR: #1059