### PR TITLE
Problem: awaiting_start is always 0 at the real HW

### DIFF
--- a/pcswrap/pcswrap/client.py
+++ b/pcswrap/pcswrap/client.py
@@ -167,31 +167,25 @@ class Client():
             return json.dumps(nodes)
 
         def safe_lower(s: Optional[str]) -> str:
-            if not s:
-                return ''
-            return s.lower()
+            return (s or '').lower()
+
+        eligible = self.connector.get_eligible_resource_count()
 
         started = 0
         stopped = 0
-        unstarted = 0
         for res in self.connector.get_resources():
             role = safe_lower(res.role)
-            target_role = safe_lower(res.target_role)
-            if 'started' == role:
+            if role == 'started':
                 started += 1
-            elif 'stopped' == role:
+            elif role == 'stopped':
                 stopped += 1
-                if target_role == 'started':
-                    # if target_role = Started while currently the resource
-                    # is not running then this resource is still planned
-                    # for start (i.e. it is not disabled)
-                    unstarted += 1
+
         result = {
             'resources': {
                 'statistics': {
                     'started': started,
                     'stopped': stopped,
-                    'awaiting_start': unstarted
+                    'starting': eligible - started
                 }
             },
             'nodes': nodes

--- a/pcswrap/pcswrap/internal/connector.py
+++ b/pcswrap/pcswrap/internal/connector.py
@@ -4,6 +4,7 @@ from subprocess import PIPE, Popen
 from typing import Any, Dict, List, Match, Optional, Tuple
 
 import defusedxml.ElementTree as ET
+
 from pcswrap.exception import CliException, PcsNoStatusException
 from pcswrap.types import Node, PcsConnector, Resource, StonithResource
 
@@ -248,3 +249,12 @@ class CliConnector(PcsConnector):
         if not resource:
             raise RuntimeError(
                 f'No stonith resource is found for node {node_name}.')
+
+    def get_eligible_resource_count(self) -> int:
+        xml_str = self.executor.get_full_status_xml()
+        xml = self._parse_xml(xml_str)
+        tag = xml.find('./summary/resources_configured')
+        total = int(tag.attrib['number'])
+        disabled = int(tag.attrib['disabled'])
+        blocked = int(tag.attrib['blocked'])
+        return total - disabled - blocked

--- a/pcswrap/pcswrap/types.py
+++ b/pcswrap/pcswrap/types.py
@@ -80,7 +80,7 @@ class PcsConnector(ABC):
     @abstractmethod
     def manual_shutdown_node(self, node_name: str) -> None:
         '''
-        Powers off the given node by name using explicit ipmi_tool invocation.
+        Powers off the given node by name using explicit ipmitool invocation.
         The necessary IPMI parameters are extracted from the corresponding
         stonith resource which is registered in Pacemaker
         '''
@@ -88,4 +88,13 @@ class PcsConnector(ABC):
 
     @abstractmethod
     def ensure_shutdown_possible(self, node_name: str) -> None:
+        pass
+
+    @abstractmethod
+    def get_eligible_resource_count(self) -> int:
+        '''
+        Looks into "summary" information provided by Pacemaker and extracts the
+        number of resources that are expected to run with respect to disabled
+        and blocked resources.
+        '''
         pass

--- a/pcswrap/tests/status-xml-w-clones.xml
+++ b/pcswrap/tests/status-xml-w-clones.xml
@@ -6,7 +6,7 @@
         <last_update time="Wed Feb 26 14:07:26 2020" />
         <last_change time="Tue Feb 25 20:08:36 2020" user="root" client="cibadmin" origin="smc7-m11" />
         <nodes_configured number="2" expected_votes="unknown" />
-        <resources_configured number="6" disabled="0" blocked="0" />
+        <resources_configured number="6" disabled="2" blocked="0" />
         <cluster_options stonith-enabled="false" symmetric-cluster="true" no-quorum-policy="ignore" maintenance-mode="false" />
     </summary>
     <nodes>

--- a/pcswrap/tests/test_connector.py
+++ b/pcswrap/tests/test_connector.py
@@ -84,6 +84,12 @@ class PcsExecutorTest(unittest.TestCase):
         connector = CliConnector(executor=stub_executor)
         self.assertEqual('mycluster', connector.get_cluster_name())
 
+    def test_get_eligible_resource_count_works(self):
+        stub_executor = CliExecutor()
+        stub_executor.get_full_status_xml = MagicMock(return_value = GOOD_XML)
+        connector = CliConnector(executor=stub_executor)
+        self.assertEqual(4, connector.get_eligible_resource_count())
+
     def test_get_resources_works(self):
         stub_executor = CliExecutor()
         stub_executor.get_full_status_xml = MagicMock(side_effect=[GOOD_XML])


### PR DESCRIPTION
JIRA: EOS-8396

This is a hotfix for #1063. It turns out that there are no 'target_role'
shown in the Pacemaker status xml for the resources that are going to be
started. But what I can see is that their role is 'Starting'.

The only problem is that role == 'Starting' is true for those
resources that are starting at the moment. The ones that can't be
started at this point because of some unsatisfied dependencies have role
= 'Stopped' and they don't have any trace of being scheduled to start
soon.

It means that sometimes resources.statistics.awaiting_start can become 0
during the cluster startup but then it will show non-zero again.
Unfortunately pcs status doesn't provide a good clue how to work this
around easily.

cc @mandar.sawant, @ivan.poddubnyy 

Closes #1070 