### PR TITLE
EOS-8506: fsstats is polled too often

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -2,15 +2,15 @@
 
 import logging
 from queue import Queue
+from typing import NamedTuple
 
 from hax.ffi import HaxFFI
+from hax.filestats import FsStatsUpdater
 from hax.halink import HaLink
 from hax.handler import ConsumerThread
 from hax.server import run_server
-from hax.filestats import FsStatsUpdater
 from hax.types import Fid
 from hax.util import ConsulUtil, repeat_if_fails
-from typing import NamedTuple
 
 __all__ = ['main']
 
@@ -31,7 +31,7 @@ def _run_qconsumer_thread(queue: Queue, ffi: HaxFFI) -> ConsumerThread:
 
 
 def _run_stats_updater_thread(halink: HaLink) -> FsStatsUpdater:
-    thread = FsStatsUpdater(halink)
+    thread = FsStatsUpdater(halink, interval_sec=30)
     thread.start()
     return thread
 


### PR DESCRIPTION
This issue relates to EOS-7167, there is a chance that
m0_spiel_filesystem_stats_fetch invocations made with Spiel instance
initialized under the hood of m0_halon_interface cause too many
connection close messages.

Solution: increase the delay between
m0_spiel_filesystem_stats_fetch invocations from 5 up to 30 seconds.

(cherry picked from commit 3c8b79fd0654b5f9eae40efe50c18058cafa303c)