### PR TITLE
Problem: I/O stack can failover if CSM fails over

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -303,6 +303,23 @@ sudo sed
 sudo systemctl daemon-reload"
 ssh $rnode $cmd
 
+# Add and update node attribute for consul resource on both the nodes.
+# This will be used to define constraints for the resources depending
+# on consul.
+sudo sed \
+ -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n consul-c1-running' \
+ -e '/ExecStartPost=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n consul-c1-running' \
+ -i /usr/lib/systemd/system/hare-consul-agent-c1.service
+sudo systemctl daemon-reload
+
+cmd="
+sudo sed
+ -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n consul-c2-running' \
+ -e '/ExecStartPost=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n consul-c2-running' \
+ -i /usr/lib/systemd/system/hare-consul-agent-c2.service &&
+sudo systemctl daemon-reload"
+ssh $rnode $cmd
+
 unset consul_c1_cfg_dir consul_c2_cfg_dir
 
 sudo cp $hare_dir/consul-env $hare_dir/consul-env-c1

--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -150,9 +150,12 @@ sudo pcs -f csmcfg constraint order consul-c1 then csm-web
 sudo pcs -f csmcfg constraint order consul-c2 then csm-web
 sudo pcs -f csmcfg constraint order els-search-clone then csm-kibana
 
+sudo pcs -f csmcfg constraint location csm-kibana rule score=-INFINITY \
+    '#uname' eq $lnode and consul-c1-running eq 0
+sudo pcs -f csmcfg constraint location csm-kibana rule score=-INFINITY \
+    '#uname' eq $rnode and consul-c2-running eq 0
+
 sudo pcs -f csmcfg constraint colocation add csm-kibana with els-search-clone \
-    score=INFINITY
-sudo pcs -f csmcfg constraint colocation add csm-kibana with consul-c1 \
     score=INFINITY
 sudo pcs -f csmcfg constraint colocation add csm-kibana with rabbitmq-clone \
     score=INFINITY


### PR DESCRIPTION
As CSM stack is colocated with consul-c1, if CSM fails over to
another node, due to colocation constraint consul-c1 would also
failover, thus leading entire io stack to failover along with
it. This is not desirable.
CSM accesses local Consul by default, thus if Consul fails over, CSM
on that node won't be able to access Consul.
 
Solution:
- Remove CSM colocation constraint with Consul.
- Update a node attribute corresponding to node's local consul resource
  which is set and unset as the local consul resource is started or
  stopped.
- Add a rule with location constraint for csm resource group based on
  the local consul's availability. According to the activeness of the
  local consul resource, the score of the location constraint for csm
  resource group is updated. This avoids restarting or failing over
  of the io stack due to csm stack failure.