### PR TITLE
Problem: while loop check for services status may fail

### DIFF
--- a/utils/prov-m0-reset
+++ b/utils/prov-m0-reset
@@ -118,9 +118,9 @@ sudo pcs resource disable consul-c2
 
 # Wait until consul, hax and m0d are stopped.
 echo 'Waiting for Consul, hax and m0d services to stop on both the nodes...'
-while [ `pgrep consul` ] || [ `pgrep hax` ] || [ `pgrep m0d` ] ||
-      [ `ssh $rnode 'pgrep consul'` ] || [ `ssh $rnode 'pgrep hax'` ] ||
-      [ `ssh $rnode 'pgrep m0d'` ]; do
+while [[ `pgrep consul` ]] || [[ `pgrep hax` ]] || [[ `pgrep m0d` ]] ||
+      [[ `ssh $rnode 'pgrep consul'` ]] || [[ `ssh $rnode 'pgrep hax'` ]] ||
+      [[ `ssh $rnode 'pgrep m0d'` ]]; do
     sleep 5
 done
 


### PR DESCRIPTION
Using single brackets for the while loop condition may fail with
`line 122: [: 131746: unary operator expected` error.

Solution:
Replace single brackets with double brackets.

[ci skip]