### PR TITLE
Problem: mero-free-space-mon resource is not colocated with Mero

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -607,6 +607,11 @@ sudo pcs cluster cib-push s3cfg --config
 
 echo 'Adding mero-free-space-monitor to pacemaker...'
 sudo pcs resource create mero-free-space-mon systemd:mero-free-space-monitor \
-     op monitor interval=30s
+     op monitor interval=30s meta failure-timeout=300s
 sudo pcs constraint order mero-ios-c1 then mero-free-space-mon
 sudo pcs constraint order mero-ios-c2 then mero-free-space-mon
+sudo pcs constraint colocation add mero-free-space-mon with mero-ios-c1 \
+     score=1000
+sudo pcs constraint colocation add mero-free-space-mon with mero-ios-c2 \
+     score=1000
+


### PR DESCRIPTION
Colocation constraint is missing which leads to situation when
mero-free-space-mon does not participate in failover. This resource
can't work without Mero running on the same node.
Since this resource is just a monitor, it should not cause failover of
entire data stack, so mandatory colocation does not work here.

Solution:

* Apply advisory colocation (with finite score) to make
  mero-free-space-mon resource follow mero-ios resources.
  Colocation is applied to both mero-ios-c1 and mero-ios-c2 resources
  to avoid unnecessary migration -- any mero-ios instance is enough
  for free-space-monitor.

* Introduce failure-timeout attribute to mitigate scenario when
  failover happens due to data stack problems, and then
  mero-free-space-mon resource fails on current node. This will cause
  monitor resource to migrate to another node, where no Mero stack is
  present. failure-timeout allows to try again the only survived node.
  The value was chosen to not affect the slowest failover.

  The only currently visible downside introduced by failure-timeout is
  that mero-free-space-monitor will never fail forever. So in case of
  misbehaviour it will repeat attempts to start on alive node with
  active Mero stack again and again.

Closes EOS-8532

