### PR TITLE
EOS-7834: Beta RC2: RMQ failed to start post reboot

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -526,7 +526,7 @@ get_s3_svc() {
 
 echo 'Adding rabbit-mq resources and constraints...'
 sudo pcs resource create rabbitmq systemd:rabbitmq-server clone op \
-    monitor interval=30s
+    monitor interval=30s meta failure-timeout=20s
 
 echo 'Adding s3background services...'
 sudo pcs cluster cib s3bcfg


### PR DESCRIPTION
During subsequent node reboots, rabbitmq may fail to start if it
is not able to connect to its peer node.

```
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: DIAGNOSTICS
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: ===========
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: attempted to contact: ['rabbit@smc22-m10']
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: rabbit@smc22-m10:
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: * unable to connect to epmd (port 4369) on smc22-m10: address (cannot connect to host/port)
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: current node details:
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: - node name: 'rabbit@smc21-m10'
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: - home dir: /var/lib/rabbitmq
May 27 15:05:16 smc21-m10.colo.seagate.com rabbitmq-server[5042]: - cookie hash: hm+QVBEGFinAC8jWQSBarg==
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: BOOT FAILED
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: ===========
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: Error description:
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {could_not_start,rabbit,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {bad_return,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {{rabbit,start,[normal,[]]},
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {'EXIT',
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {rabbit,failure_during_boot,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {error,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {timeout_waiting_for_tables,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: [rabbit_user,rabbit_user_permission,rabbit_vhost,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: rabbit_durable_route,rabbit_durable_exchange,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: rabbit_runtime_parameters,
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: rabbit_durable_queue]}}}}}}}
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: Log files (may contain more information):
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: /var/log/rabbitmq/rabbit@smc21-m10.log
May 27 15:05:17 smc21-m10.colo.seagate.com rabbitmq-server[5042]: /var/log/rabbitmq/rabbit@smc21-m10-sasl.log
May 27 15:05:18 smc21-m10.colo.seagate.com rabbitmq-server[5042]: {"init terminating in do_boot",{rabbit,failure_during_boot,{could_not_start,rabbit,{bad_return,{{rabbit,staMay 27 15:05:20 smc21-m10.colo.seagate.com rabbitmq-server[5042]: Crash dump was written to: erl_crash.dump
May 27 15:05:20 smc21-m10.colo.seagate.com systemd[1]: rabbitmq-server.service: main process exited, code=exited, status=1/FAILURE
May 27 15:05:20 smc21-m10.colo.seagate.com rabbitmqctl[6985]: Stopping and halting node 'rabbit@smc21-m10' ...
May 27 15:05:20 smc21-m10.colo.seagate.com rabbitmqctl[6985]: Error: unable to connect to node 'rabbit@smc21-m10': nodedown
May 27 15:05:20 smc21-m10.colo.seagate.com rabbitmqctl[6985]: DIAGNOSTICS
May 27 15:05:20 smc21-m10.colo.seagate.com rabbitmqctl[6985]: ===========
May 27 15:05:20 smc21-m10.colo.seagate.com rabbitmqctl[6985]: attempted to contact: ['rabbit@smc21-m10']
May 27 15:05:20 smc21-m10.colo.seagate.com rabbitmqctl[6985]: rabbit@smc21-m10:
May 27 15:05:20 smc21-m10.colo.seagate.com systemd[1]: rabbitmq-server.service: control process exited, code=exited status=2
```
Solution:
If pacemaker fails to start rabbitmq it sets its failcount to -INFINITY which can
be cleared explicitly by `pcs resource cleanup`. Another way to automatically
reset the failcount in such case is by adding a failure-timeout meta parameter to
the rabbitmq pacemaker resource. Pacemaker resets the failcount of the resource
after the timeout expires and tries to start the resource again.