### PR TITLE
EOS-8592: hax crashes when rconfc quorum is lost

### DIFF
--- a/hax/hax/exception.py
+++ b/hax/hax/exception.py
@@ -6,3 +6,7 @@ class HaxAPIException(RuntimeError):
 
 class HAConsistencyException(HaxAPIException):
     pass
+
+
+class ConfdQuorumException(HaxAPIException):
+    pass

--- a/hax/hax/halink.py
+++ b/hax/hax/halink.py
@@ -3,6 +3,7 @@ import logging
 from errno import EAGAIN
 from typing import Any, List
 
+from hax.exception import ConfdQuorumException
 from hax.ffi import HaxFFI, make_array, make_c_str
 from hax.message import EntrypointRequest, HaNvecGetEvent, ProcessEvent
 from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats, HaNote,
@@ -201,4 +202,7 @@ class HaLink:
 
     def get_filesystem_stats(self) -> FsStats:
         stats: FsStats = self._ffi.filesystem_stats_fetch(self._ha_ctx)
+        if stats is None:
+            raise ConfdQuorumException(
+                'Confd quorum lost, filesystem statistics is unavailable')
         return stats

--- a/hax/hax/hax.c
+++ b/hax/hax/hax.c
@@ -177,10 +177,17 @@ PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx)
 	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
 
 	struct m0_fs_stats stats;
-	Py_BEGIN_ALLOW_THREADS int rc =
+	int rc;
+	Py_BEGIN_ALLOW_THREADS rc =
 	    m0_spiel_filesystem_stats_fetch(spiel, &stats);
-	M0_ASSERT(rc == 0);
-	Py_END_ALLOW_THREADS PyObject *hax_mod = getModule("hax.types");
+	Py_END_ALLOW_THREADS if (rc != 0)
+	{
+		PyGILState_Release(gstate);
+		// This returns None python object (which is a singleton)
+		// properly with respect to reference counters.
+		Py_RETURN_NONE;
+	}
+	PyObject *hax_mod = getModule("hax.types");
 	PyObject *fs_stats = PyObject_CallMethod(
 	    hax_mod, "FsStats", "(KKKKKII)", stats.fs_free_seg,
 	    stats.fs_total_seg, stats.fs_free_disk, stats.fs_avail_disk,


### PR DESCRIPTION
Solution:
1. Force hax to handle failed invocation of m0_spiel_filesystem_stats_fetch gracefully.
2. [mero side] make sure that m0_spiel_filesystem_stats_fetch doesn't
trigger unrecoverable M0_ASSERT when confd quorum is lost.

This patch includes part [1] only.

Closes #1095