### PR TITLE
EOS-8579: s3backgroundproducer does not failover

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -528,6 +528,23 @@ echo 'Adding rabbit-mq resources and constraints...'
 sudo pcs resource create rabbitmq systemd:rabbitmq-server clone op \
     monitor interval=30s meta failure-timeout=20s
 
+# Add and update node attribute for s3backgroundconsumer resource on both the
+# nodes. This will be used to define constraints for the resources depending
+# on s3backgroundconsumer resource on a node.
+sudo sed \
+ -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n s3backcons-running' \
+ -e '/ExecStop=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n s3backcons-running' \
+ -i /usr/lib/systemd/system/s3backgroundconsumer.service
+sudo systemctl daemon-reload
+
+cmd="
+sudo sed
+ -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n s3backcons-running' \
+ -e '/ExecStop=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n s3backcons-running' \
+ -i /usr/lib/systemd/system/s3backgroundconsumer.service &&
+sudo systemctl daemon-reload"
+ssh $rnode $cmd
+
 echo 'Adding s3background services...'
 sudo pcs cluster cib s3bcfg
 sudo pcs -f s3bcfg resource create s3backcons-c1 systemd:s3backgroundconsumer
@@ -541,6 +558,10 @@ sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backcons-c2
 sudo pcs -f s3bcfg resource create s3backprod systemd:s3backgroundproducer op \
     monitor interval=30s
 sudo pcs -f s3bcfg constraint order rabbitmq-clone then s3backprod
+sudo pcs -f s3bcfg constraint location s3backprod rule score=-INFINITY '#uname' \
+    eq $lnode and s3backcons-running eq 0
+sudo pcs -f s3bcfg constraint location s3backprod rule score=-INFINITY '#uname' \
+    eq $rnode and s3backcons-running eq 0
 sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c1 \
     score=50000
 sudo pcs -f s3bcfg constraint colocation add s3backprod with s3backcons-c2 \


### PR DESCRIPTION
As s3backgroundconsumer is an active/active resource which depends on the
s3servers running on that node, it is created as a single resource and not
a cloned pacemaker resource. This simplifies adding dependency constraints
for the s3backgroundconsumer resource on the node's local s3server resources.
However, s3backgroundproducer is an active/passive resource and runs only on
one node at a time and has dependency on its local s3backgroundconsumer
and s3server resources. Present dependency constraints between s3 producer and
consumer resource work fine in case of consumer or node failure. Producer
sucessfully fails over to the peer node. But this does not work if consumer
stops because corresponding s3servers stopped due some 3rd level dependency
failure (e.g. ioservice failure).
Having consumer resources cloned would simplify things but complicates its
dependency contraints on local s3servers.

Solution:
- Update a node attribute using attrd_updater corresponding to s3background
  consumer resource as it starts and stops.
- Use the node attribute to define s3background producer location constraints.