### PR TITLE
Merge S3 and CSM failover fixes to Beta

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -299,6 +299,23 @@ sudo sed
 sudo systemctl daemon-reload"
 ssh $rnode $cmd
 
+# Add and update node attribute for consul resource on both the nodes.
+# This will be used to define constraints for the resources depending
+# on consul.
+sudo sed \
+ -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n consul-c1-running' \
+ -e '/ExecStartPost=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n consul-c1-running' \
+ -i /usr/lib/systemd/system/hare-consul-agent-c1.service
+sudo systemctl daemon-reload
+
+cmd="
+sudo sed
+ -e '/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n consul-c2-running' \
+ -e '/ExecStartPost=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n consul-c2-running' \
+ -i /usr/lib/systemd/system/hare-consul-agent-c2.service &&
+sudo systemctl daemon-reload"
+ssh $rnode $cmd
+
 unset consul_c1_cfg_dir consul_c2_cfg_dir
 
 sudo cp $hare_dir/consul-env $hare_dir/consul-env-c1

--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -150,9 +150,12 @@ sudo pcs -f csmcfg constraint order consul-c1 then csm-web
 sudo pcs -f csmcfg constraint order consul-c2 then csm-web
 sudo pcs -f csmcfg constraint order els-search-clone then csm-kibana
 
+sudo pcs -f csmcfg constraint location csm-kibana rule score=-INFINITY \
+    '#uname' eq $lnode and consul-c1-running eq 0
+sudo pcs -f csmcfg constraint location csm-kibana rule score=-INFINITY \
+    '#uname' eq $rnode and consul-c2-running eq 0
+
 sudo pcs -f csmcfg constraint colocation add csm-kibana with els-search-clone \
-    score=INFINITY
-sudo pcs -f csmcfg constraint colocation add csm-kibana with consul-c1 \
     score=INFINITY
 sudo pcs -f csmcfg constraint colocation add csm-kibana with rabbitmq-clone \
     score=INFINITY


### PR DESCRIPTION
## Problem: io stack can failover if CSM fails over

As CSM stack is colocated with consul-c1, if CSM fails over to
another node, due to colocation constraint consul-c1 would also
failover, thus leading entire io stack to failover along with
it. This is not desirable.
CSM accesses local Consul by default, thus if Consul fails over, CSM
on that node won't be able to access Consul.

Solution:
- Remove CSM colocation constraint with Consul.
- Update a node attribute corresponding to node's local consul resource
  which is set and unset as the local consul resource is started or
  stopped.
- Add a rule with location constraint for csm resource group based on
  the local consul's availability. According to the activeness of the
  local consul resource, the score of the location constraint for csm
  resource group is updated. This avoids restarting or failing over
  of the io stack due to csm stack failure.

(cherry picked from commit 371190039dd547ece942dc0c42bd0809a518e15b)

master MR: #1083

## EOS-8579: s3backgroundproducer does not failover

As s3backgroundconsumer is an active/active resource which depends on the
s3servers running on that node, it is created as a single resource and not
a cloned pacemaker resource. This simplifies adding dependency constraints
for the s3backgroundconsumer resource on the node's local s3server resources.
However, s3backgroundproducer is an active/passive resource and runs only on
one node at a time and has dependency on its local s3backgroundconsumer
and s3server resources. Present dependency constraints between s3 producer and
consumer resource work fine in case of consumer or node failure. Producer
sucessfully fails over to the peer node. But this does not work if consumer
stops because corresponding s3servers stopped due some 3rd level dependency
failure (e.g. ioservice failure).
Having consumer resources cloned would simplify things but complicates its
dependency contraints on local s3servers.

Solution:
- Update a node attribute using attrd_updater corresponding to s3background
  consumer resource as it starts and stops.
- Use the node attribute to define s3background producer location constraints.

(cherry picked from commit 8e70c0bdde71479b9e8cc844c89a07dd0b0314d7)

master MR: #1102
