### PR TITLE
EOS-8691: fix CSM failure during sanity test regression

### DIFF
--- a/utils/build-ees-ha-csm
+++ b/utils/build-ees-ha-csm
@@ -150,6 +150,8 @@ sudo pcs -f csmcfg constraint order consul-c1 then csm-web
 sudo pcs -f csmcfg constraint order consul-c2 then csm-web
 sudo pcs -f csmcfg constraint order els-search-clone then csm-kibana
 
+sudo pcs -f csmcfg constraint location csm-kibana prefers $lnode
+
 sudo pcs -f csmcfg constraint location csm-kibana rule score=-INFINITY \
     '#uname' eq $lnode and consul-c1-running eq 0
 sudo pcs -f csmcfg constraint location csm-kibana rule score=-INFINITY \


### PR DESCRIPTION
CSM failure was causing side effect to io stack due to csm_web's colocation
constraint with consul-c1. This was fixed as part of EOS-8535.
But the earlier constraint advised pacemaker to always start CSM on node-0
when cluster would start. As starting CSM on node-0 always during cluster
start was not identified as a mandatoy requirement and due to side effect
that the colocation constraint was causing, the constraint was replaced by
a new location constraint. But this left the node-0 selection for CSM start
to pacemaker's descretion and now CSM can be started on node-0 or node-1.
As it is mandatory from CSM perspective to start CSM on node-0 initially
during cluster start, this needs to be fixed.

Solution:
Add an advisory location constraint for CSM in-order to advise pacemaker
to always start CSM on node-0 during cluster start.