### PR TITLE
"Problem:" prefix constricts subject line by 20%

### DIFF
--- a/rfc/9/README.md
+++ b/rfc/9/README.md
@@ -104,9 +104,9 @@ specific goals:
 5. A patch MUST compile cleanly and pass project self-tests on at least
    the principal target platform.
 
-6. A patch commit message MUST consist of a single short (less than 50
-   characters) line stating the problem ("Problem: ...") being solved,
-   followed by a blank line and then the proposed solution
+6. A patch commit message SHOULD consist of a single short (less than
+   50 characters) line stating the problem ("Problem: ...") being
+   solved, followed by a blank line and then the proposed solution
    ("Solution: ...").
 
 <!--


### PR DESCRIPTION
Solution: make "Problem:" prefix a recommendation, not a strict
requirement.  s/MUST/SHOULD/

[RFC 2119](https://tools.ietf.org/html/rfc2119):

> 3. SHOULD   This word, or the adjective "RECOMMENDED", mean that there
>    may exist valid reasons in particular circumstances to ignore a
>    particular item, but the full implications must be understood and
>    carefully weighed before choosing a different course.

See also https://github.com/zeromq/rfc/issues/117

Closes #959.