### PR TITLE
EOS-8257: improve the fix for mero-kernel restarts

### DIFF
--- a/pacemaker/lnet
+++ b/pacemaker/lnet
@@ -99,10 +99,6 @@ lnet_start() {
     if [ $? =  $OCF_SUCCESS ]; then
 	return $OCF_SUCCESS
     fi
-    # Make sure mero-kernel moule is stopped before we add the new
-    # endpoint address. This is workaround for EOS-8257 issue, a bug
-    # in Pacemaker - https://bugs.clusterlabs.org/show_bug.cgi?id=5428.
-    systemctl stop mero-kernel
     lnetctl net add --net ${OCF_RESKEY_nettype} --if ${OCF_RESKEY_iface}
 }
 

--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -250,7 +250,7 @@ bootstrap() {
     done
 
     run_on_both 'sudo rm -f /etc/sysconfig/m0d-*'
-
+    run_on_both 'sudo systemctl reset-failed hare\* m0d\*'
     hctl bootstrap --conf-dir $hare_dir
     hctl shutdown
 
@@ -421,6 +421,17 @@ mero_kernel_rsc_add() {
     sudo pcs -f $cib_file resource create mero-kernel systemd:mero-kernel clone
     sudo pcs -f $cib_file constraint order lnet-c1 then mero-kernel-clone
     sudo pcs -f $cib_file constraint order lnet-c2 then mero-kernel-clone
+
+    # Make sure mero-kernel is always stopped before lnet-c1/2
+    # is started. Otherwise, some transition abort in between may
+    # prevent mero-kernel restart. This is a workaround suggested
+    # at https://bugs.clusterlabs.org/show_bug.cgi?id=5428#c5.
+    sudo pcs -f $cib_file constraint order stop mero-kernel-clone then \
+                                           start lnet-c1 \
+                                           kind=Optional symmetrical=false
+    sudo pcs -f $cib_file constraint order stop mero-kernel-clone then \
+                                           start lnet-c2 \
+                                           kind=Optional symmetrical=false
 }
 
 hax_systemd_prepare() {


### PR DESCRIPTION
The old solution was to explicitly stop mero-kernel from
lnet resource agent before adding the endpoint into lnet.
It was an awkward and bugs prone approach to workarond
the bug in Pacemaker.

Solution: use the special Pacemaker order constraint
suggested at https://bugs.clusterlabs.org/show_bug.cgi?id=5428#c5
which ensures that mero-kernel stops before lnet-c1/2
resource is started on the node.