### PR TITLE
Problem: ha update script is not integrated with provisioner

### DIFF
--- a/provisioning/setup-ha.yaml
+++ b/provisioning/setup-ha.yaml
@@ -16,3 +16,9 @@ hare:
   reset:
     script: /opt/seagate/eos/hare/libexec/prov-ha-reset
     args: null
+  post_update:
+    script: /opt/seagate/eos/hare/libexec/build-ees-ha-update
+    args:
+      - /var/lib/hare/cluster.yaml
+      - /var/lib/hare/build-ees-ha-args.yaml
+      - /var/lib/hare/build-ees-ha-csm-args.yaml


### PR DESCRIPTION
Presently ha update script is not part of the provisioner's framework
implemented through setup.yaml interface.

Solution:
Add a post_update section to setup.yaml and invoke ha update script
from the same. Add relevant list of arguments to the update script.
This section is invoked by the provisioner as part of the software
update process.

(cherry picked from commit 23693f58ed978e7f04e6a9d38e92a323b0323e63)