### PR TITLE
EOS-8763: m0 reset script fails if m0d systemd unit is failed

### DIFF
--- a/utils/prov-m0-reset
+++ b/utils/prov-m0-reset
@@ -116,13 +116,17 @@ echo 'Disabling Consul resources...'
 sudo pcs resource disable consul-c1
 sudo pcs resource disable consul-c2
 
-# Wait until consul, hax and m0d are stopped.
-echo 'Waiting for Consul, hax and m0d services to stop on both the nodes...'
-while [[ `pgrep consul` ]] || [[ `pgrep hax` ]] || [[ `pgrep m0d` ]] ||
-      [[ `ssh $rnode 'pgrep consul'` ]] || [[ `ssh $rnode 'pgrep hax'` ]] ||
-      [[ `ssh $rnode 'pgrep m0d'` ]]; do
+echo 'Waiting for Consul agents, hax and m0d services to stop on both the nodes...'
+while [[ `pgrep -a consul | grep 'consul agent'` ]] || [[ `pgrep hax` ]] ||
+      [[ `pgrep m0d` ]] ||
+      [[ `ssh $rnode 'pgrep -a consul | grep "consul agent"'` ]] ||
+      [[ `ssh $rnode 'pgrep hax'` ]] || [[ `ssh $rnode 'pgrep m0d'` ]]; do
     sleep 5
 done
+
+# Killing any remaining consul watcher processes.
+sudo pkill consul || true
+ssh $rnode 'sudo pkill consul' || true
 
 ip a | grep -qF $ip1 ||
   die "IP address $ip1 doesn't appear to be configured at $lnode"
@@ -136,7 +140,7 @@ sudo lctl list_nids | grep -qF $ip1 ||
 ssh $rnode "sudo lctl list_nids | grep -qF $ip2" ||
   die "LNet endpoint $ip2 doesn't appear to be configured at $rnode"
 
-echo "Conforming if /var/mero on both the nodes is unmounted..."
+echo 'Conforming if /var/mero on both the nodes is unmounted...'
 while mountpoint /var/mero && ! umount /var/mero; do sleep 1; done
 while ssh $rnode 'mountpoint /var/mero && ! umount /var/mero'; do sleep 1; done
 
@@ -144,11 +148,15 @@ echo "Formatting volumes $lvolume and $rvolume ..."
 mkfs.ext4 $lvolume
 mkfs.ext4 $rvolume
 
-echo "Mounting /var/mero on both the nodes..."
+echo 'Mounting /var/mero on both the nodes...'
 mkdir -p /var/mero &&
   ! mountpoint -q /var/mero && sudo mount $lvolume /var/mero
 ssh $rnode "mkdir -p /var/mero &&
   ! mountpoint -q /var/mero && sudo mount $rvolume /var/mero"
+
+echo 'Resetting failed systemd units on both the nodes...'
+sudo systemctl reset-failed hare\* m0d\*
+ssh $rnode 'sudo systemctl reset-failed hare\* m0d\*'
 
 echo 'Running hctl bootstrap..'
 hctl bootstrap --mkfs -c /var/lib/hare
@@ -176,16 +184,19 @@ sudo pcs resource enable consul-c2
 # Reset failcount once after reset
 sudo pcs resource cleanup
 
-echo 'Wait until Consul, hax and m0d services start on both the nodes...'
+echo 'Waiting for Consul agents, hax and m0ds to start on both the nodes...'
 while true; do
-    if [[ `pgrep consul` && `pgrep hax` && `pgrep m0d` &&
-          `ssh $rnode 'pgrep consul'` && `ssh $rnode 'pgrep hax'` &&
-          `ssh $rnode 'pgrep m0d'` ]]; then
+    if [[ `pgrep -a consul | grep 'consul agent'` &&
+          `pgrep hax` && `pgrep m0d` &&
+          `ssh $rnode 'pgrep -a consul | grep "consul agent"'` &&
+          `ssh $rnode 'pgrep hax'` && `ssh $rnode 'pgrep m0d'` ]]; then
             break
     fi
     sleep 5
 done
 
-echo 'Import /var/lib/hare/consul-conf-exported.json...'
-/opt/seagate/eos/hare/bin/consul kv import \
-    @/var/lib/hare/consul-conf-exported.json
+echo 'Importing /var/lib/hare/consul-conf-exported.json...'
+for i in {1..10}; do
+    /opt/seagate/eos/hare/bin/consul kv import \
+        @/var/lib/hare/consul-conf-exported.json && break || sleep 5
+done


### PR DESCRIPTION
As Consul resources are temporary disabled for motr reset procedure, hax,
m0d and other dependant resources are stopped as well. There's a possibility
that m0d resources may fail to stop and eventually may get kiled after a
systemd timeout. This sets their corresponding systemd status as failed.
As part of the reset procedure `hctl bootstrap` is invoked which also
starts hax and m0d services. Starting of hax and m0d services fails during
hctl bootstrap if their corresponding systemd unit is in failed state.
Furthermore, this fails the reset process as well.

Solution:
- Invoke `systemctl reset-failed` before `hctl bootstrap` to reset
  the failed systemd units.
- Check only consul agent process while waiting for consul processes to
  stop instead of `pgrep consul` which may hang if Consul watch process
  of RC-leader that monitors the Events Queue is not stopped. Stop this
  process after all the Consul agents are stopped.

(cherry picked from commit f9cf7bcef3b60c25e296ae155ea6a57eac91aeb9)

"master" MR: #1118