### PR TITLE
EOS-8640: fix permanent s3backcons resources stop

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -641,11 +641,11 @@ s3_systemd_update() {
 
 s3back_rsc_add() {
     echo 'Adding s3background services...'
-    sudo pcs -f $cib_file resource create s3backcons-c1 systemd:s3backgroundconsumer
-    sudo pcs -f $cib_file resource create s3backcons-c2 systemd:s3backgroundconsumer
-    sudo pcs -f $cib_file constraint location s3backcons-c1 prefers $lnode=INFINITY
+    sudo pcs -f $cib_file resource create s3backcons-c1 \
+                          systemd:s3backgroundconsumer meta failure-timeout=300s
+    sudo pcs -f $cib_file resource create s3backcons-c2 \
+                          systemd:s3backgroundconsumer meta failure-timeout=300s
     sudo pcs -f $cib_file constraint location s3backcons-c1 avoids $rnode=INFINITY
-    sudo pcs -f $cib_file constraint location s3backcons-c2 prefers $rnode=INFINITY
     sudo pcs -f $cib_file constraint location s3backcons-c2 avoids $lnode=INFINITY
     sudo pcs -f $cib_file constraint order rabbitmq-clone then s3backcons-c1
     sudo pcs -f $cib_file constraint order rabbitmq-clone then s3backcons-c2


### PR DESCRIPTION
It might happens sometimes that s3backcons resource fails
to start due to some issue with dependent resource or some
other reason. And since s3backcons-c1/2 resources are bind
to the specific node only and not allowed to migrate -
Pacemaker would not try to restart them again leaving in
a stopped state forever.

Solution: set failure-timeout=300s meta attribute to these
resources so that Pacemaker would try to restart them in
a 5 minutes.

Note: s3backcons-c1/2 resources are not critical for the
system work, they just delete a stale objects from Mero
(the ones that had failed to be written successfully for
some reason, for example, m0d crash). Still, it is better
to keep them running.