### PR TITLE
Problem: bootstrap failed to create `$conf_dir/node-name` on remote node

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -219,7 +219,9 @@ EOF
         if is_localhost $node; then
             echo $node > $conf_dir/node-name
         else
-            ssh $node "echo $node > $conf_dir/node-name"
+            # Redirect stdin to /dev/null (`-n`) to prevent
+            # accidental stealing of `get_all_nodes` output.
+	    ssh -n $node "echo $node > $conf_dir/node-name"
         fi
     done < <(get_all_nodes)
 


### PR DESCRIPTION
While iterating through all the nodes, after ssh command for 1st
remote node it failed to get next node name from list. As a result
multi-node bootstrap fails.

Problem is ssh reads stdin and consume node name from list.

Solution:
Use ssh -n to redirects stdin from /dev/null

Closes #1133