### PR TITLE
EOS-9694: shutdown attribute is misleading and should be removed

### DIFF
--- a/pcswrap/pcswrap/internal/connector.py
+++ b/pcswrap/pcswrap/internal/connector.py
@@ -127,7 +127,6 @@ class CliConnector(PcsConnector):
         def to_node(tag) -> Node:
             return Node(name=tag.attrib['name'],
                         online=b(tag.attrib['online']),
-                        shutdown=b(tag.attrib['shutdown']),
                         unclean=b(tag.attrib['unclean']),
                         standby=b(tag.attrib['standby']),
                         resources_running=int(tag.attrib['resources_running']))

--- a/pcswrap/pcswrap/types.py
+++ b/pcswrap/pcswrap/types.py
@@ -3,9 +3,8 @@ from typing import List, NamedTuple, Optional
 
 Credentials = NamedTuple('Credentials', [('username', str), ('password', str)])
 
-Node = NamedTuple('Node', [('name', str), ('online', bool), ('shutdown', bool),
-                           ('standby', bool), ('unclean', bool),
-                           ('resources_running', int)])
+Node = NamedTuple('Node', [('name', str), ('online', bool), ('standby', bool),
+                           ('unclean', bool), ('resources_running', int)])
 
 Resource = NamedTuple('Resource', [('id', str), ('resource_agent', str),
                                    ('role', str), ('target_role', str),

--- a/pcswrap/tests/test_connector.py
+++ b/pcswrap/tests/test_connector.py
@@ -162,7 +162,6 @@ class ClientTest(unittest.TestCase):
             side_effect=[[
                 Node(name='test',
                      online=True,
-                     shutdown=False,
                      standby=False,
                      unclean=False,
                      resources_running=2)
@@ -170,7 +169,6 @@ class ClientTest(unittest.TestCase):
                          [
                              Node(name='test',
                                   online=True,
-                                  shutdown=False,
                                   standby=False,
                                   unclean=False,
                                   resources_running=2)
@@ -178,7 +176,6 @@ class ClientTest(unittest.TestCase):
                          [
                              Node(name='test',
                                   online=True,
-                                  shutdown=False,
                                   standby=False,
                                   unclean=False,
                                   resources_running=0)
@@ -205,7 +202,6 @@ class ClientTest(unittest.TestCase):
         connector.get_nodes = MagicMock(return_value=[
             Node(name='test',
                  online=True,
-                 shutdown=False,
                  standby=False,
                  unclean=False,
                  resources_running=2)

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -40,7 +40,7 @@ Detailed list of commands can be seen below.
 |3|Stop all nodes in cluster ('standby all')|`hctl node standby --all`| |
 |4|Start all nodes in cluster ('unstandby all')|`hctl node unstandby --all`| |
 |5|Shutdown a node|`hctl node shutdown <node-id>`| |
-|6|Get the status of all nodes in the cluster|`hctl node status`| `[{"name": "srvnode-1", "online": false, "shutdown": false, "standby": true, "unclean": false, "resources_running": 0}]` |
+|6|Get the status of all nodes in the cluster|`hctl node status`| `[{"name": "srvnode-1", "online": false, "standby": true, "unclean": false, "resources_running": 0}]` |
 |7|Enable "smart maintenance" mode |`hctl node --verbose maintenance --all --timeout-sec=120`| |
 |8|Disable "smart maintenance" mode |`hctl node --verbose unmaintenance --all --timeout-sec=120`| |
 


### PR DESCRIPTION
Problem: JSON that "hctl node status" command emits contains "shutdown"
attribute which is not working well. Moreover, Pacemaker docs say
explicitly that the attribute is used by Pacemaker internally and must
not be used anywhere outside.

This commit removes shutdown field from the JSON layout to avoid
misleading.

Closes #1135