### PR TITLE
Problem: HaX exit fs-stats-updater on failure of ios

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -34,7 +34,6 @@ class FsStatsUpdater(StoppableThread):
             while not self.stopped:
                 started = self._ioservices_running()
                 if not all(started):
-                    self.stopped = True
                     continue
                 stats = halink.get_filesystem_stats()
                 logging.debug('FS stats are as follows: %s', stats)


### PR DESCRIPTION
Due to some reasons, ios can failed and may not come back within
30 second (stats fetch interval), in that case stats updater thread
should not exit.

Solution:
fs-stat-updater try to fetch stats till HaX service stops.

Ref: EOS-10064