### PR TITLE
EOS-9258: uds is not colocated with csm-agent

### DIFF
--- a/utils/build-ees-ha-uds
+++ b/utils/build-ees-ha-uds
@@ -13,7 +13,7 @@ Configures UDS HA by adding resources to Pacemaker.
 
 Caveats:
 
-* The script expects that 'csm-web' resource is added to Pacemaker.
+* The script expects that 'csm-agent' resource is added to Pacemaker.
   Check with 'pcs status'.
 
 Optional parameters:
@@ -45,14 +45,17 @@ while true; do
 done
 
 precheck() {
-    # Abort (set -e) if `csm-web` resource does not exist.
-    sudo pcs resource show csm-web >/dev/null
+    # Abort (set -e) if `csm-agent` resource does not exist.
+    sudo pcs resource show csm-agent >/dev/null
 }
 
 uds_rsc_add() {
     echo 'Adding UDS resource and constraints...'
     sudo pcs -f $cib_file resource create uds systemd:uds op monitor interval=30s
-    sudo pcs -f $cib_file constraint colocation add uds with csm-web score=INFINITY
+    sudo pcs -f $cib_file constraint colocation add uds with csm-agent score=INFINITY
+
+    # According to EOS-9258, there is a bug which requires UDS to be started after csm_agent
+    sudo pcs -f $cib_file constraint order csm-agent then uds
 }
 
 cib_init() {


### PR DESCRIPTION
Solution: change colocation rule in build-ees-ha-uds script.

[ci skip]