### PR TITLE
Problem: status of 11/HCTL is wrong

### DIFF
--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -2,7 +2,7 @@
 domain: gitlab.mero.colo.seagate.com
 shortname: 11/HCTL
 name: Hare Controller CLI
-status: raw
+status: stable
 editor: Konstantin Nekrasov <konstantin.nekrasov@seagate.com>
 ---
 

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -15,7 +15,6 @@ processes.
 
 * Raw
   * [10/GLOSS](10/README.md) — Hare User's Glossary
-  * [11/HCTL](11/README.md) - Hare Controller CLI
   * [12/CHECK](12/README.md) - EES HA Health Checks
   * [13/HALC](13/README.md) — EES HA, Loosely Coupled
   * [14/HW](14/README.md) — EES Hardware
@@ -27,3 +26,4 @@ processes.
   * [6/BOOT](6/README.md) — Motr Cluster Bootstrap
   * [8/STYLE](8/README.md) — Coding Style Guidelines
   * [9/PC3](9/README.md) — Pedantic Code Construction Contract
+  * [11/HCTL](11/README.md) - Hare Controller CLI


### PR DESCRIPTION
[11/HCTL][] documents `hctl node status` interface, which CSM team
relies on.  Accordingly to [2/COSS], this makes this specification
'stable'.

> When draft specifications are used by third parties, they become
> **stable** specifications. Changes to stable specifications should be
> restricted to cosmetic ones, errata and clarifications. Stable
> specifications are contracts between editors, implementers, and
> end-users.

Solution: upgrade the status of 11/HCTL to 'stable'.

[11/HCTL]: rfc/11/README.md
[2/COSS]: https://rfc.unprotocols.org/spec:2/COSS/#stable-specifications