### PR TITLE
Problem: get-process-state returns multiple states

### DIFF
--- a/utils/get-process-state
+++ b/utils/get-process-state
@@ -32,4 +32,4 @@ case $1 in
 esac
 
 fid=$1
-consul kv export processes/$fid | jq -r '.[].value | @base64d' | jq -r '.state'
+consul kv get processes/$fid 2> /dev/null | jq -r '.state'


### PR DESCRIPTION
If processes has fids like 0x7200000000000001:0x9, 0x7200000000000001:0x94,
for `consul kv export processes/0x7200000000000001:0x9` return multiple
process states for each match.

```
[root@ssc-vm-0688 520422]# /opt/seagate/eos/hare/bin/consul kv export processes/0x7200000000000001:0x9 | grep key
                "key": "processes/0x7200000000000001:0x9",
                "key": "processes/0x7200000000000001:0x96",
[root@ssc-vm-0688 520422]#
```

Solution:
Use `consul kv get` instead of `consul kv export`.