### PR TITLE
Problem: fid values in hctl status --json are not parseable

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -28,7 +28,7 @@ class Fid:
 class FidEncoder(j.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Fid):
-            return obj.__repr__()
+            return str(obj)
         return super().default(obj)
 
 


### PR DESCRIPTION
Solution: correct JSON encoder for Fid type so that it doesn't invoke
`__repr__` function.

Closes #1081