### PR TITLE
Problem: Hare doesn't build against cortx-motr

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -50,8 +50,8 @@ ci_docker() {
     sudo chown -R $(id -u):$(id -g) .
 }
 
-git clone --recursive http://gitlab.mero.colo.seagate.com/mero/mero.git
-cd mero
+git clone --recursive http://gitlab.mero.colo.seagate.com/mero/mero.git cortx-motr
+cd cortx-motr
 git checkout $MERO_COMMIT_REF
 cd -
 

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -61,7 +61,7 @@ def get_motr_dir():
     d = os.environ.get('M0_SRC_DIR')
     if d:
         return d
-    return P.normpath(P.dirname(P.abspath(__file__)) + '/../../mero')
+    return P.normpath(P.dirname(P.abspath(__file__)) + '/../../cortx-motr')
 
 
 def get_motr_libs_dir():


### PR DESCRIPTION
At GitHub Mero repository is now called cortx-motr. This means that in
normal scenario the developer will not be able to build Hare even though
both Hare and Mero were checked out from the correct repositories.
That's basically a UX issue for the end developer.

Solution: always assume that default Mero source folder name is the same
to the corresponding git repository.