### PR TITLE
Problem: no proper teardown for ip-c{1,2} resources

### DIFF
--- a/utils/prov-ha-reset
+++ b/utils/prov-ha-reset
@@ -35,6 +35,7 @@ resources=(
     c{2,1}
     motr-kernel
     lnet
+    ip-c{2,1}
 )
 for r in ${resources[@]}; do
     pcs resource delete $r || true


### PR DESCRIPTION
The problem apprears when components.ha.ees_ha.teardown is explicitly
called. prov-ha-reset script does not remove ip-c{1,2} resources.

Solution: improve prov-ha-reset script adding missing resources

[ci skip]