### PR TITLE
Problem: hctl-node points to non-existent pcswrap

### DIFF
--- a/hctl
+++ b/hctl
@@ -91,7 +91,7 @@ done
 # process commands
 case $cmd in
     help) usage; exit ;;
-    bootstrap|node|reportbug|shutdown|status)
+    bootstrap|reportbug|shutdown|status)
         if [[ -d $M0_SRC_DIR/utils ]]; then
             PATH="$M0_SRC_DIR/utils:$PATH"
         fi

--- a/utils/hare-node
+++ b/utils/hare-node
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
-# set -x
-export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
-
-# :help: manage the cluster nodes
-PCSCLI_PROG_NAME='hctl node' pcswrap "$@"


### PR DESCRIPTION
`pcswrap` tool was moved to another repository, it is no more a part of
Hare. Thus hctl can't be used to interact with `pcswrap`. This means that
hctl 'grounding' scripts for pcswrap must be removed.

Closes #1158 