### PR TITLE
Problem: CSM can't invoke pcswrap after repository splitting

### DIFF
--- a/hctl
+++ b/hctl
@@ -10,6 +10,10 @@ PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
 M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
 
+# Quick fix for EOS-10650
+CORTX_HA_BIN=/opt/seagate/cortx/ha/bin/
+CORTX_HA_PY_INCLUDES=/opt/seagate/cortx/ha/lib64/python3.6/site-packages:/opt/seagate/cortx/ha/lib/python3.6/site-packages
+
 die() {
     local LightRed="$(tput bold ; tput setaf 1)"
     local NC="$(tput sgr0)" # No Color
@@ -91,7 +95,7 @@ done
 # process commands
 case $cmd in
     help) usage; exit ;;
-    bootstrap|node|reportbug|shutdown|status)
+    bootstrap|reportbug|shutdown|status)
         if [[ -d $M0_SRC_DIR/utils ]]; then
             PATH="$M0_SRC_DIR/utils:$PATH"
         fi
@@ -102,6 +106,26 @@ case $cmd in
         # TODO: python3.6 version can be different
         PYTHONPATH="$HARE_BASE_DIR/lib/python3.6/site-packages"
         PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
+        export PYTHONPATH
+
+        systemd-cat --identifier $PROG <<< "$PROG $cmd $@"
+        exec $HARE_BASE_DIR/libexec/hare-$cmd "$@"
+        ;;
+    node)
+        # This is a temporary solution. Will be removed by the results of https://github.com/Seagate/cortx-hare/pull/1160
+        # After that the whole case block is TO BE REMOVED
+        if [[ -d $M0_SRC_DIR/utils ]]; then
+            PATH="$M0_SRC_DIR/utils:$PATH"
+        fi
+        PATH="$CORTX_HA_BIN:$PATH"
+        PATH="$HARE_BASE_DIR/libexec:$PATH"
+        PATH="$HARE_BASE_DIR/bin:$PATH"
+        export PATH
+
+        # TODO: python3.6 version can be different
+        PYTHONPATH="$HARE_BASE_DIR/lib/python3.6/site-packages"
+        PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
+        PYTHONPATH="$PYTHONPATH:$CORTX_HA_PY_INCLUDES"
         export PYTHONPATH
 
         systemd-cat --identifier $PROG <<< "$PROG $cmd $@"


### PR DESCRIPTION
Solution: make sure that `hctl` can invoke `pcswrap` at the new location — `/opt/seagate/cortx/ha/bin/`.

Relates to [EOS-10650](https://jts.seagate.com/browse/EOS-10650).