### PR TITLE
Problem: Hare CDF does not support device path to create BE segment

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -76,7 +76,10 @@ nodes:
                                # optional, defaults to "tcp"
     m0_servers:
       - runs_confd: <bool>  # optional, defaults to false
-        io_disks: [ <str> ] # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
+        io_disks:
+          be_seg: <str>     # device path for BE segment
+                            # optional, default path @ /var/motr/m0d-<FID>/
+          data: [ <str> ]   # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
                             # Empty list means no IO service.
     m0_clients:
         s3: <int>     # number of S3 servers to start
@@ -209,8 +212,11 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
 
         for m0d in node['m0_servers']:
             m0d.setdefault('runs_confd', False)
+            m0d.setdefault('_be_seg', None)
             m0d['_io_disks'] = get_disks(node['hostname'], mock_p,
-                                         m0d['io_disks'])
+                                         m0d['io_disks']['data'])
+        if 'be_seg' in m0d['io_disks']:
+            m0d['_be_seg'] = m0d['io_disks']['be_seg']
 
 
 def validate_cluster_desc(desc: Dict[str, Any]) -> None:
@@ -530,12 +536,13 @@ class ConfProcess(ToDhall):
     _downlinks = {Downlink('services', ObjT.service)}
 
     def __init__(self, nr_cpu: int, memsize_MB: int, endpoint: Endpoint,
-                 services: List[Oid]):
+                 be_seg: str, services: List[Oid]):
         assert nr_cpu > 0
         self.nr_cpu = nr_cpu
         assert memsize_MB > 0
         self.memsize_MB = memsize_MB
         self.endpoint = endpoint
+        self.be_seg = be_seg
         assert all(x.type is ObjT.service for x in services)
         self.services = services
 
@@ -572,9 +579,15 @@ class ConfProcess(ToDhall):
                       ipaddr=facts[ipaddr_key(node_desc['data_iface'])],
                       portal=proc_t.value)
         proc_id = new_oid(ObjT.process)
+        if proc_desc is not None and proc_t is ProcT.m0_server:
+            bs = proc_desc['_be_seg']
+        else:
+            bs = ''
+
         m0conf[proc_id] = cls(nr_cpu=facts['processorcount'],
                               memsize_MB=facts['_memsize_MB'],
                               endpoint=ep,
+                              be_seg=bs,
                               services=[])
         m0conf[parent].processes.append(proc_id)
 
@@ -1187,7 +1200,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
 
     ConsulService = NamedTuple('ConsulService', [
         ('node_name', str), ('proc_id', Oid), ('ep', Endpoint),
-        ('svc_id', Oid), ('stype', str)])
+        ('svc_id', Oid), ('stype', str), ('be_seg', str)])
 
     def profile() -> str:
         profiles = [x for x in m0conf.keys() if x.type is ObjT.profile]
@@ -1214,7 +1227,8 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                     yield ConsulService(node_name=node.name,
                                         proc_id=proc_id,
                                         ep=m0conf[proc_id].endpoint,
-                                        svc_id=svc_id, stype=stype)
+                                        svc_id=svc_id, stype=stype,
+                                        be_seg=m0conf[proc_id].be_seg)
                 # Add clovis clients to consul kv
                 if proc_id in cluster.m0_clients:
                     proc_ep = m0conf[proc_id].endpoint
@@ -1222,7 +1236,8 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                                         proc_id=proc_id,
                                         ep=m0conf[proc_id].endpoint,
                                         svc_id=cluster.m0_clients[proc_id],
-                                        stype=ProcT(proc_ep.portal).name)
+                                        stype=ProcT(proc_ep.portal).name,
+                                        be_seg='')
 
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
@@ -1232,6 +1247,8 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('m0conf/profiles/pools', sns_pools()),
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/services/'
            f'{x.stype}', x.svc_id.fidk) for x in processes()],
+        *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/'
+           f'be_seg', x.be_seg) for x in processes() if x.stype == 'ios'],
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/endpoint',
            str(x.ep))
           for x in processes()])],

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -1,7 +1,7 @@
 -- m0d process
 let M0Server =
   { runs_confd : Optional Bool
-  , io_disks : List Text
+  , io_disks : { be_seg: Optional Text, data : List Text }
   }
 
 let Node =

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -4,19 +4,22 @@ nodes:
     data_iface_type: tcp
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/loop0
-          - /dev/loop1
-          - /dev/loop2
-          - /dev/loop3
+          data:
+            - /dev/loop0
+            - /dev/loop1
+            - /dev/loop2
+            - /dev/loop3
       - io_disks:
-          - /dev/loop4
-          - /dev/loop5
-          - /dev/loop6
-          - /dev/loop7
-          - /dev/loop8
-          - /dev/loop9
+          data:
+            - /dev/loop4
+            - /dev/loop5
+            - /dev/loop6
+            - /dev/loop7
+            - /dev/loop8
+            - /dev/loop9
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -3,14 +3,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -18,12 +20,13 @@ nodes:
     data_iface: eth1
     m0_servers:
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -3,14 +3,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -18,14 +20,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -3,14 +3,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -18,14 +20,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -33,14 +37,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ees-cluster.yaml
+++ b/cfgen/examples/ees-cluster.yaml
@@ -8,12 +8,14 @@ nodes:
                             # supported values: "tcp" (default), "o2ib"
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/sdd
-          - /dev/sde
-          - /dev/sdf
-          - /dev/sdg
+          data:
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
     m0_clients:
         s3: 0           # number of S3 servers to start
         other: 2        # max quantity of other Motr clients this node may have
@@ -22,12 +24,14 @@ nodes:
     data_iface_type: o2ib
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/sdh
-          - /dev/sdi
-          - /dev/sdj
-          - /dev/sdk
+          data:
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -8,18 +8,20 @@ nodes:
                             # supported values: "tcp" (default), "o2ib"
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/loop0
-          - /dev/loop1
-          - /dev/loop2
-          - /dev/loop3
-          - /dev/loop4
-          - /dev/loop5
-          - /dev/loop6
-          - /dev/loop7
-          - /dev/loop8
-          - /dev/loop9
+          data:
+            - /dev/loop0
+            - /dev/loop1
+            - /dev/loop2
+            - /dev/loop3
+            - /dev/loop4
+            - /dev/loop5
+            - /dev/loop6
+            - /dev/loop7
+            - /dev/loop8
+            - /dev/loop9
     m0_clients:
       s3: 0         # number of S3 servers to start
       other: 2      # max quantity of other Motr clients this host may have

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -8,12 +8,18 @@ in
       , data_iface_type = None types.Protocol
       , m0_servers =
           [ { runs_confd = Some True
-            , io_disks = [] : List Text
+            , io_disks =
+                { be_seg = Text
+                , data = [] : List Text
+                }
             }
           , { runs_confd = None Bool
             , io_disks =
-                let mkPath = \(i : Natural) -> "/dev/loop" ++ Natural/show i
-                in Prelude.List.generate 10 Text mkPath
+                { be_seg = None
+                , data =
+                    let mkPath = \(i : Natural) -> "/dev/loop" ++ Natural/show i
+                    in Prelude.List.generate 10 Text mkPath
+                }
             }
           ]
       , m0_clients =

--- a/rfc/3/README.md
+++ b/rfc/3/README.md
@@ -38,8 +38,13 @@ nodes:
                                # optional, defaults to "tcp"
     m0_servers:
       - runs_confd: <bool>  # optional, defaults to false
-        io_disks: [ <str> ] # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
+        io_disks:
+          be_seg: <str>     # device path for BE segment
+                            # optional, default path @ /var/motr/m0d-<FID>/
+          data: [ <str> ]   # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
                             # Empty list means no IO service.
+                            # Empty list means no IO service.
+
     m0_clients:
         s3: <int>     # number of S3 servers to start
         other: <int>  # max quantity of other Motr clients this host may have

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -27,6 +27,7 @@ Key | Value | Description
 `sspl.SYSTEM_INFORMATION.log_level` | | This key is used by SSPL.
 `stats/filesystem` | JSON object | See ['stats/filesystem' value](#statsfilesystem-value) below.
 `timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.
+`m0conf/nodes/<name>/processes/<process_fidk>/be_seg` | BE seg path | BE segment path, it is used to create BE segment wile m0mkfs.
 
 **Note:** Fid keys are non-negative integers, base 10.
 

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -48,6 +48,11 @@ id2fid() {
     printf '0x7200000000000001:%#x\n' $1
 }
 
+get_ios_be_seg() {
+    local id=$1
+    consul kv get m0conf/nodes/$(node-name)/processes/$id/be_seg
+}
+
 HAX_ID=$(get_service_ids 'grep -iw ha')
 [[ $HAX_ID ]] || {
     cat >&2 <<.
@@ -58,9 +63,10 @@ Please verify that the host name matches the one stored in the Consul KV.
     exit 1
 }
 CONFD_IDs=$(get_service_ids 'grep -iw confd')
-IOS_IDs=$(get_service_ids 'grep -iw ios | grep -iwv confd')
+IOS_IDs=$(get_service_ids 'grep -iw ios | grep -iwv be_seg | grep -iwv confd')
 S3_IDs=$(get_service_ids 'grep -iw m0_client_s3')
 HAX_EP=$(get_service_ep $HAX_ID)
+
 
 if $dry_run; then
     return 0  # we must not `exit`, because the script is sourced
@@ -129,6 +135,7 @@ append_ios_svc() {
     local ep=$(get_service_ep $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
+    local be_seg=$(get_ios_be_seg $id)
     SVCS_CONF+="${SVCS_CONF:+,}{
       \"id\": \"$id\",
       \"name\": \"ios\",
@@ -147,6 +154,7 @@ append_ios_svc() {
 MERO_M0D_EP='$ep'
 MERO_HA_EP='$HAX_EP'
 MERO_PROCESS_FID='$fid'
+MERO_BE_SEG_PATH='$be_seg'
 EOF
 }
 


### PR DESCRIPTION
One of the requirement for EES data recovery is to use some external
device to create BE segment, currently Motr create these BE segments
at its default location `/var/motr/m0d-<FID>/db/o`.

Motr use BE segments paths from `/etc/sysconfig/m0d-<FID>`. Since
`hctl bootstrap` configure Mote processes (m0d), paths for these
segments are required to mention in CDF. Bootstrap process parse
BE segment paths and sueuse use it to generate Motr configuration
(/etc/sysconfig/m0d-<FID>).

Solution:
- Update CDF format to accommodate BE segment path for each Motr process
- Add segment path to consul-kv for each Motr process
- Update script `update-consul-conf` to configure BE segment path to
  "/var/motr/m0d-*"

Ref:
EOS-11427  (Hare )
EOS-10457) (Motr )

Closes: #1174 
