### PR TITLE
EOS-11487: Rename references to `mero` to `motr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ on every machine in the cluster:
       if ! sudo yum install -y cortx-hare cortx-s3server; then
           for x in 'integration/centos-7.7.1908/last_successful' 's3server_uploads'
           do
-              repo="ci-storage.mero.colo.seagate.com/releases/eos/$x"
+              repo="cortx-storage.colo.seagate.com/releases/eos/$x"
               sudo yum-config-manager --add-repo="http://$repo"
               sudo tee -a /etc/yum.repos.d/${repo//\//_}.repo <<< 'gpgcheck=0'
           done

--- a/cfgen/Makefile
+++ b/cfgen/Makefile
@@ -3,7 +3,7 @@ SHELL = bash
 PYTHON_SCRIPTS = cfgen
 
 M0CONFGEN := $(if\
- $(shell which m0confgen 2>/dev/null),m0confgen,../../mero/utils/m0confgen)
+ $(shell which m0confgen 2>/dev/null),m0confgen,../../motr/utils/m0confgen)
 
 dhall-lang-version := $(shell readlink ../vendor/dhall-prelude/current)
 dhall-lang-dir := dhall/dhall-lang-$(dhall-lang-version)

--- a/ci/build
+++ b/ci/build
@@ -6,7 +6,7 @@ set -x
 . ci/functions.sh  # ci_vm_name_prefix, die
 
 # Make sure that the build image is up to date.
-docker pull $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE
+docker pull $DOCKER_REGISTRY/Seagate/cortx-hare:$CENTOS_RELEASE
 
 [[ -d $WORKSPACE_DIR ]] &&
     die "${FUNCNAME[0]}: \$WORKSPACE_DIR is not expected to exist"
@@ -20,7 +20,7 @@ if [[ $CI_PROJECT_NAME != hare && ! -d hare ]]; then
 fi
 
 cat >hare/ci/_env <<EOF
-MERO_COMMIT_REF=${MERO_COMMIT_REF:-}
+MOTR_COMMIT_REF=${MOTR_COMMIT_REF:-}
 RPMSYNC_DIR=$RPMSYNC_DIR
 WORKSPACE_NAME=$WORKSPACE_NAME
 
@@ -36,10 +36,10 @@ set -\$_orig_set_flags
 unset _orig_set_flags
 EOF
 
-[[ -z ${MERO_COMMIT_REF:-} ]] && exit
+[[ -z ${MOTR_COMMIT_REF:-} ]] && exit
 
 # --------------------------------------------------------------------
-# $MERO_COMMIT_REF is non-empty
+# $MOTR_COMMIT_REF is non-empty
 
 ci_docker() {
     (($# > 0)) || die "${FUNCNAME[0]}: Arguments expected"
@@ -48,17 +48,17 @@ ci_docker() {
         die "${FUNCNAME[0]}: Wrong working directory"
 
     _time docker run --rm --name $(ci_vm_name_prefix) -v $PWD:/data \
-        -w /data/hare $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE "$@"
+        -w /data/hare $DOCKER_REGISTRY/Seagate/cortx-hare:$CENTOS_RELEASE "$@"
 
     # Containers run commands as 'root' user.  Restore the ownership.
     sudo chown -R $(id -u):$(id -g) .
 }
 
-git clone --recursive http://gitlab.mero.colo.seagate.com/mero/mero.git cortx-motr
+git clone --recursive git@github.com:Seagate/cortx-motr.git cortx-motr
 cd cortx-motr
-git checkout $MERO_COMMIT_REF
+git checkout $MOTR_COMMIT_REF
 cd -
 
-ci_docker ci/docker/build-mero
+ci_docker ci/docker/build-motr
 #ci_docker ci/docker/build-s3server  # XXX-FIXME issue #216
 ci_docker make build  # build Hare

--- a/ci/collect-artifacts
+++ b/ci/collect-artifacts
@@ -27,7 +27,7 @@ for vm in $($M0VG status | awk '$2 == "running" {print $1}'); do
 
         say 'm0reportbug'
         $M0VG run --vm $vm \
-              sudo ${MERO_COMMIT_REF:+/data/mero/utils/}m0reportbug || true
+              sudo ${MOTR_COMMIT_REF:+/data/motr/utils/}m0reportbug || true
         $M0VG scp $vm:m0reportbug-\*.tar.xz $outdir/
     fi
     say

--- a/ci/docker/build-mero
+++ b/ci/docker/build-mero
@@ -5,7 +5,7 @@ set -x
 
 KERNEL=$(yum list installed kernel | tail -n1 | awk '{ print $2 }')
 
-cd /data/mero
+cd /data/motr
 ./autogen.sh
 ./configure --with-linux=/lib/modules/$KERNEL.x86_64/build
 make -j10

--- a/ci/docker/test-utils
+++ b/ci/docker/test-utils
@@ -3,10 +3,10 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-. ci/_env  # MERO_COMMIT_REF, RPMSYNC_DIR
+. ci/_env  # MOTR_COMMIT_REF, RPMSYNC_DIR
 
-if [[ -z ${MERO_COMMIT_REF:-} ]]; then
-    repo="ci-storage.mero.colo.seagate.com${RPMSYNC_DIR}"
+if [[ -z ${MOTR_COMMIT_REF:-} ]]; then
+    repo="cortx-storage.colo.seagate.com${RPMSYNC_DIR}"
     yum-config-manager --add-repo="http://$repo"
     tee -a /etc/yum.repos.d/${repo//\//_}.repo <<< 'gpgcheck=0'
 

--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -41,15 +41,15 @@ ci_init_m0vg() (
         # Get `m0vg` script.
         #
         # Notes:
-        # 1. We download the latest Motr, disregarding `MERO_COMMIT_REF`.
+        # 1. We download the latest Motr, disregarding `MOTR_COMMIT_REF`.
         # 2. We use no `--recursive`, because we don't need submodules.
-        git clone --depth 1 http://gitlab.mero.colo.seagate.com/mero/mero.git \
+        git clone --depth 1 git@github.com:Seagate/cortx-motr.git \
             ${M0VG%%/*}
     fi
 
     $M0VG env add <<EOF
 M0_VM_BOX=centos77/dev
-M0_VM_BOX_URL='http://ci-storage.mero.colo.seagate.com/vagrant/centos77/dev'
+M0_VM_BOX_URL='cortx-storage.colo.seagate.com/vagrant/centos77/dev'
 M0_VM_CMU_MEM_MB=4096
 M0_VM_NAME_PREFIX=$(ci_vm_name_prefix)
 M0_VM_HOSTNAME_PREFIX=$(ci_vm_name_prefix)
@@ -74,10 +74,10 @@ ci_success() {
 }
 
 XXX_with_s3server() {
-    if [[ -n ${MERO_COMMIT_REF:-} ]]; then
+    if [[ -n ${MOTR_COMMIT_REF:-} ]]; then
         cat >&2 <<'EOF'
 *WARNING* CI cannot test s3server with custom Motr.
-See http://gitlab.mero.colo.seagate.com/mero/hare/issues/216
+See https://github.com/Seagate/cortx-hare/issues/566
 EOF
         return 1
     else

--- a/ci/m0vg/init-node
+++ b/ci/m0vg/init-node
@@ -3,17 +3,17 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-. /data/hare/ci/_env  # MERO_COMMIT_REF, RPMSYNC_DIR
+. /data/hare/ci/_env  # MOTR_COMMIT_REF, RPMSYNC_DIR
 
-if [[ -n ${MERO_COMMIT_REF:-} ]]; then
+if [[ -n ${MOTR_COMMIT_REF:-} ]]; then
     # `systemctl start hare-hax` command, called by `bootstrap-node`,
     # will fail unless `motr-kernel` systemd service is installed.
-    sudo /data/mero/scripts/install-mero-service
+    sudo /data/motr/scripts/install-motr-service
 
     # `TERM=dumb` silences `tput: unknown terminal "unknown"` warnings.
     sudo make -C /data/hare TERM=dumb devinstall
 else
-    repo="ci-storage.mero.colo.seagate.com${RPMSYNC_DIR}"
+    repo="cortx-storage.colo.seagate.com${RPMSYNC_DIR}"
     if sudo yum-config-manager --add-repo="http://$repo"; then
         # `yum-config-manager` may fail with
         # "Cannot add repo from [...] a duplicate of an existing repo"

--- a/ci/m0vg/test-boot1
+++ b/ci/m0vg/test-boot1
@@ -3,18 +3,18 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 set -x
 
-. /data/hare/ci/_env  # MERO_COMMIT_REF
+. /data/hare/ci/_env  # MOTR_COMMIT_REF
 . /data/hare/ci/functions.sh  # _time
 
 # XXX `m0crate-io-conf` executes `consul`, which is /opt/seagate/cortx/hare/bin.
 # There should be a better way to add that directory to PATH; see
-# http://gitlab.mero.colo.seagate.com/mero/hare/merge_requests/248#note_16669
+# https://github.com/Seagate/cortx-hare/pull/382#issuecomment-661012209
 export PATH="/opt/seagate/cortx/hare/bin:$PATH"
 
 do_io() {
     utils/m0crate-io-conf >_m0crate-io.yaml
     dd if=/dev/urandom of=/tmp/128M bs=1M count=128
-    _time sudo ${MERO_COMMIT_REF:+/data/mero/clovis/m0crate/}m0crate \
+    _time sudo ${MOTR_COMMIT_REF:+/data/motr/clovis/m0crate/}m0crate \
           -S _m0crate-io.yaml
 }
 

--- a/ci/m0vg/test-boot1-s3
+++ b/ci/m0vg/test-boot1-s3
@@ -12,7 +12,7 @@ generate_s3cfg() {
     . update-consul-conf --dry-run  # import CONFD_IDs, IOS_IDs, id2fid()
     local id=${S3_IDs[0]}  # In absence of haproxy using 1st S3 server instance
     local ip_addr=$(get_service_ip_addr $(get_service_ep $id))
-    local port=$(awk -F= '$1 == "MERO_S3SERVER_PORT" {print $2}' \
+    local port=$(awk -F= '$1 == "MOTR_S3SERVER_PORT" {print $2}' \
                      /etc/sysconfig/s3server-$(id2fid $id))
     cat <<EOF
 [default]

--- a/ci/m0vg/test-boot2
+++ b/ci/m0vg/test-boot2
@@ -20,7 +20,7 @@ test_cluster ci/m0vg/_test-boot2.yaml
 test_cluster ci/m0vg/_test-boot2-1confd.yaml
 
 # XXX-TODO: Remove this block after
-# http://gitlab.mero.colo.seagate.com/mero/hare/issues/216 is resolved.
+# https://github.com/Seagate/cortx-hare/issues/566 is resolved.
 . ci/_env
 . ci/functions.sh
 XXX_with_s3server || exit 0

--- a/ci/m0vg/test-boot3
+++ b/ci/m0vg/test-boot3
@@ -17,7 +17,7 @@ cd /data/hare/
 test_cluster ci/m0vg/_test-boot3.yaml
 
 # XXX-TODO: Remove this block after
-# http://gitlab.mero.colo.seagate.com/mero/hare/issues/216 is resolved.
+# https://github.com/Seagate/cortx-hare/issues/566 is resolved.
 . ci/_env
 . ci/functions.sh
 XXX_with_s3server || exit 0

--- a/ci/rpmbuild
+++ b/ci/rpmbuild
@@ -5,8 +5,8 @@ set -x
 
 . ci/functions.sh  # _time, die
 
-[[ -z ${MERO_COMMIT_REF:-} ]] ||
-    die "$0 expects MERO_COMMIT_REF to be unset or empty"
+[[ -z ${MOTR_COMMIT_REF:-} ]] ||
+    die "$0 expects MOTR_COMMIT_REF to be unset or empty"
 
 # `BLATEST` is a symlink, which may be reset at any moment.
 # Store the path of its current target into a variable.
@@ -31,6 +31,6 @@ cd $RPMSYNC_DIR
 createrepo -v .  # see https://wiki.centos.org/HowTos/CreateLocalRepos
 
 ## The repository should have been created at
-## http://ci-storage.mero.colo.seagate.com${RPMSYNC_DIR}
+## http://cortx-storage.colo.seagate.com${RPMSYNC_DIR}
 ## e.g.
-## http://ci-storage.mero.colo.seagate.com/releases/dev/vvv/hare/ci-rpm/B63632/
+## http://cortx-storage.colo.seagate.com/releases/dev/vvv/hare/ci-rpm/B63632/

--- a/ci/test-utils
+++ b/ci/test-utils
@@ -8,4 +8,4 @@ set -x
 cd $WORKSPACE_DIR
 
 time docker run --rm --name $(ci_vm_name_prefix) -v $PWD:/data -w /data/hare \
-     $DOCKER_REGISTRY/mero/hare:$CENTOS_RELEASE ci/docker/test-utils
+     $DOCKER_REGISTRY/Seagate/cortx-hare:$CENTOS_RELEASE ci/docker/test-utils

--- a/hax/hax/hax.c
+++ b/hax/hax/hax.c
@@ -33,8 +33,8 @@
 #include "lib/thread.h"   /* m0_thread_{adopt, shun} */
 #include "lib/string.h"   /* m0_strdup */
 #include "lib/trace.h"    /* M0_LOG, M0_DEBUG */
-#include "mero/version.h" /* M0_VERSION_GIT_REV_ID */
-#include "mero/iem.h"
+#include "motr/version.h" /* M0_VERSION_GIT_REV_ID */
+#include "motr/iem.h"
 #include "ha/msg.h"
 #include "ha/link.h"
 #include "hax.h"
@@ -244,7 +244,7 @@ static void __ha_failvec_reply_send(const struct hax_msg *hm,
 	m0_free(repmsg);
 }
 
-/* Tests hax - mero nvec reply send. */
+/* Tests hax - motr nvec reply send. */
 static void handle_nvec(const struct hax_msg *hm)
 {
 	struct hax_msg *hmsg;

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -51,7 +51,7 @@ def main():
     _setup_logging()
 
     # [KN] The elements in the queue will appear if
-    # 1. A callback is invoked from ha_link (this will happen in a mero
+    # 1. A callback is invoked from ha_link (this will happen in a motr
     #    thread which must be free ASAP)
     # 2. A new HA notification has come form Consul via HTTP
     # [KN] The messages are consumed by Python thread created by

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -63,7 +63,7 @@ class HaNoteStruct(c.Structure):
     _fields_ = [("no_id", FidStruct), ("no_state", c.c_uint32)]
 
 
-# Mostly duplicates mero/conf/ha.h:m0_conf_ha_process
+# Mostly duplicates motr/conf/ha.h:m0_conf_ha_process
 class ConfHaProcess:
     def __init__(self, chp_event=0, chp_type=0, chp_pid=0, fid=None):
         self.chp_event = chp_event
@@ -72,7 +72,7 @@ class ConfHaProcess:
         self.fid = fid
 
 
-# Duplicates mero/fid/fid.h
+# Duplicates motr/fid/fid.h
 class Fid:
     def __init__(self, container: int, key: int):
         self.container = container

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -74,7 +74,7 @@ def get_motr_libs_dir():
         # the system
         pass
 
-    libs_dir = get_motr_dir() + '/mero/.libs'
+    libs_dir = get_motr_dir() + '/motr/.libs'
     libmotr = libs_dir + '/libmotr.so'
     assert P.isfile(libmotr), f'{libmotr}: No such file'
     return libs_dir

--- a/hctl
+++ b/hctl
@@ -8,7 +8,7 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 # constants
 PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
-M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/mero}
+M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/motr}
 
 # Quick fix for EOS-10650
 CORTX_HA_BIN=/opt/seagate/cortx/ha/bin/

--- a/rfc/10/README.md
+++ b/rfc/10/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 10/GLOSS
 name: Hare User's Glossary
 status: raw

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 11/HCTL
 name: Hare Controller CLI
 status: stable

--- a/rfc/12/README.md
+++ b/rfc/12/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 12/CHECK
 name: EES HA Health Checks
 status: raw

--- a/rfc/13/README.md
+++ b/rfc/13/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 13/HALC
 name: EES HA, Loosely Coupled
 status: draft

--- a/rfc/14/README.md
+++ b/rfc/14/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 14/HW
 name: EES Hardware
 status: raw

--- a/rfc/3/README.md
+++ b/rfc/3/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 3/CFGEN
 name: Configuration Generation
 status: stable

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 4/KV
 name: Consul KV Schema
 status: draft
@@ -95,4 +95,4 @@ Field | Description
 
 Corresponding Motr structure: [`struct m0_fs_stats`][spiel/m0_fs_stats]
 
-[spiel/m0_fs_stats]: http://gitlab.mero.colo.seagate.com/mero/mero/blob/3c6e1148ff5fb18b81236700396bd7881ad61c18/spiel/spiel.h#L1251
+[spiel/m0_fs_stats]: https://github.com/Seagate/cortx-motr/blob/dev/spiel/spiel.h#L1268

--- a/rfc/5/README.md
+++ b/rfc/5/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 5/HAX
 name: HAlink eXchange
 status: draft
@@ -43,7 +43,7 @@ M0_HA_MSG_EVENT_RPC | Ignore.
 M0_HA_MSG_BE_IO_ERR | `m0_panic()`
 M0_HA_MSG_SNS_ERR | `m0_panic()`
 
-[m0_ha_msg_type]: http://gitlab.mero.colo.seagate.com/mero/mero/blob/master/ha/msg.h#L70
+[m0_ha_msg_type]: https://github.com/Seagate/cortx-motr/blob/dev/ha/msg.h#L70
 
 ### Interaction Use Cases
 
@@ -176,7 +176,7 @@ Hax processes the following callbacks from `ha_link` (via `m0_ha_halon_interface
 **Notes:**
 
 1. Hax MUST NOT make any assumption whether the service is registered in Consul. Service registering and watching the KV with the service status is out of  hax' responsibilty.
-2. In the future we might want to support Motr service update events (namely, `M0_HA_MSG_EVENT_SERVICE` message with event type `M0_CONF_HA_SERVICE_FAILED`, `M0_CONF_HA_SERVICE_STOPPED` or `M0_CONF_HA_SERVICE_FAILED` - see `m0_conf_ha_service_event` enum in `mero/conf/ha.h`). For the current version this functionality more like an overkill.
+2. In the future we might want to support Motr service update events (namely, `M0_HA_MSG_EVENT_SERVICE` message with event type `M0_CONF_HA_SERVICE_FAILED`, `M0_CONF_HA_SERVICE_STOPPED` or `M0_CONF_HA_SERVICE_FAILED` - see `m0_conf_ha_service_event` enum in `motr/conf/ha.h`). For the current version this functionality more like an overkill.
 3. In the future versions process update events must be forwarded through Consul-based Event Queue.
 
 ### Storing process status in Consul KV

--- a/rfc/6/README.md
+++ b/rfc/6/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 6/BOOT
 name: Motr Cluster Bootstrap
 status: stable

--- a/rfc/8/README.md
+++ b/rfc/8/README.md
@@ -1,5 +1,5 @@
 ---
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 8/STYLE
 name: Coding Style Guidelines
 status: stable

--- a/rfc/9/README.md
+++ b/rfc/9/README.md
@@ -1,7 +1,7 @@
 ---
 original-author: Pieter Hintjens <ph@imatix.com>
 original-url: http://hintjens.com/blog:23
-domain: gitlab.mero.colo.seagate.com
+domain: github.com
 shortname: 9/PC3
 name: Pedantic Code Construction Contract
 status: stable

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -6,7 +6,7 @@ processes.
 * A specification is created and modified by pull requests according to
   [PC3](rfc/9/README.md).
 * Each specification has an editor who publishes the RFC to
-  http://gitlab.mero.colo.seagate.com as needed.
+  github.com as needed.
 * Specification lifecycle SHOULD follow the lifecycle defined in
   [COSS](http://rfc.unprotocols.org/spec:2/COSS).
 * Non-cosmetic changes are allowed only on Raw and Draft specifications.

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -78,7 +78,7 @@ Oftentimes this belief is contradicted by reality.
 EES developers need your help.
 
 Please add a comment to
-http://gitlab.mero.colo.seagate.com/mero/hare/issues/242
+https://github.com/Seagate/cortx-hare/issues/625
 with the following output:
 
 ----------BEGIN OUTPUT----------
@@ -98,8 +98,8 @@ fi
 
 if [[ $do_mkfs ]] && [[ ! -e /etc/sysconfig/motr-kernel ]]; then
     # Auto-start of `motr-kernel` systemd unit will cause kernel panic
-    # unless `MERO_NODE_UUID` configuration option is provided.
-    echo "MERO_NODE_UUID='$(uuidgen --time)'" |
+    # unless `MOTR_NODE_UUID` configuration option is provided.
+    echo "MOTR_NODE_UUID='$(uuidgen --time)'" |
         sudo tee /etc/sysconfig/motr-kernel >/dev/null
 fi
 

--- a/utils/m0crate-io-conf
+++ b/utils/m0crate-io-conf
@@ -42,11 +42,11 @@ m0crate_io_conf() {
     local process_fid=$3
 
     cat <<EOF
-CrateConfig_Sections: [MERO_CONFIG, WORKLOAD_SPEC]
+CrateConfig_Sections: [MOTR_CONFIG, WORKLOAD_SPEC]
 
-MERO_CONFIG:
-   MERO_LOCAL_ADDR: $local_ep
-   MERO_HA_ADDR:    $hax_ep
+MOTR_CONFIG:
+   MOTR_LOCAL_ADDR: $local_ep
+   MOTR_HA_ADDR:    $hax_ep
    CLOVIS_PROF: <$(profile_fid)>  # Profile fid
    LAYOUT_ID: 9                      # Defines the UNIT_SIZE (9: 1MB)
    IS_OOSTORE: 1                     # Is oostore-mode?

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -116,10 +116,10 @@ append_confd_svc() {
         ]
     }"
     cat <<EOF | sudo tee /etc/sysconfig/m0d-$fid > /dev/null
-MERO_M0D_EP='$ep'
-MERO_HA_EP='$HAX_EP'
-MERO_PROCESS_FID='$fid'
-MERO_CONF_XC='/etc/motr/confd.xc'
+MOTR_M0D_EP='$ep'
+MOTR_HA_EP='$HAX_EP'
+MOTR_PROCESS_FID='$fid'
+MOTR_CONF_XC='/etc/motr/confd.xc'
 EOF
 }
 
@@ -144,9 +144,9 @@ append_ios_svc() {
         ]
     }"
     cat <<EOF | sudo tee /etc/sysconfig/m0d-$fid > /dev/null
-MERO_M0D_EP='$ep'
-MERO_HA_EP='$HAX_EP'
-MERO_PROCESS_FID='$fid'
+MOTR_M0D_EP='$ep'
+MOTR_HA_EP='$HAX_EP'
+MOTR_PROCESS_FID='$fid'
 EOF
 }
 
@@ -173,11 +173,11 @@ append_s3_svc() {
         ]
     }"
     cat <<EOF | sudo tee /etc/sysconfig/s3server-$fid > /dev/null
-MERO_PROFILE_FID=`consul kv get m0conf/profiles`
-MERO_S3SERVER_EP='$ep'
-MERO_HA_EP='$HAX_EP'
-MERO_PROCESS_FID='$fid'
-MERO_S3SERVER_PORT=$s3port
+MOTR_PROFILE_FID=`consul kv get m0conf/profiles`
+MOTR_S3SERVER_EP='$ep'
+MOTR_HA_EP='$HAX_EP'
+MOTR_PROCESS_FID='$fid'
+MOTR_S3SERVER_PORT=$s3port
 EOF
 }
 


### PR DESCRIPTION
Mero is renamed to cortx-motr this requires all the occurences of
mero in the hare source to be renamed to motr.

Solution:
Rename all the Mero occurences in documentation and sources.

Note:
Occurences of mero in repo link http://ci-storage.mero.colo.seagate.com
are left out until we have a replacement repo url.