### PR TITLE
Problem: outdated information in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hare
+# Hare User Guide
 
 ## Welcome
 
@@ -8,14 +8,15 @@ disguised as a software project.
 
 ## What Hare does?
 
-1. Configures components of the distributed Motr object store.
-2. Makes arrangements to ensure that Motr system remains available even
-   if some of its components fail.
-3. Provides CLI for starting/stopping Motr system.
+1. Configures components of Motr object store system.
+2. Provides CLI for starting/stopping Motr system.
+3. Makes arrangements to ensure that Motr system remains available even
+   when some of its components fail.
 
-Hare implementation leverages the key-value store and health-checking
-mechanisms of [Consul](https://www.consul.io) service networking
-solution.
+Hare implementation uses [Consul](https://www.consul.io) key-value store
+and health-checking mechanisms.
+
+<!------------------------------------------------------------------->
 
 ## Prerequisites
 
@@ -28,12 +29,12 @@ ensure that
 --- | --- | ---
 1 | passwordless `sudo` works for \<user\> | all machines
 2 | \<user\> can `ssh` from \<origin\> to other machines | \<origin\>
-3 | `cortx-hare` and `cortx-s3server` rpms are installed | all machines
+3 | `cortx-hare` and `cortx-s3server` RPMs are installed | all machines
 4 | `/opt/seagate/cortx/hare/bin` is in \<user\>'s PATH | all machines
 5 | \<user\> is a member of `hare` group | all machines
-6 | CDF exists and reflects actual cluster configuration | \<origin\>
+6 | CDF exists and corresponds to the actual cluster configuration | \<origin\>
 
-### Install rpm packages
+### Install RPM packages
 
 * Install `cortx-hare` and `cortx-s3server` packages by running these commands
   on every machine of the cluster:
@@ -67,28 +68,6 @@ ensure that
   ```
   Log out and log back in.
 
-### Check motr-kernel service
-
-Motr processes require Motr kernel module to be inserted.
-Make sure Motr kernel service is running:
-```sh
-[[ $(systemctl is-active motr-kernel) == active ]] ||
-    sudo systemctl start motr-kernel
-```
-
-### Check LNet network ids
-
-Check if LNet network ids are configured:
-```sh
-sudo lctl list_nids
-```
-
-If not configured, run
-```sh
-sudo modprobe lnet
-sudo lctl network configure
-```
-
 ### Prepare a CDF
 
 To start the cluster for the first time you will need a cluster
@@ -116,6 +95,8 @@ See `cfgen --help-schema` for the description of CDF format.
 ```sh
 /opt/seagate/cortx/hare/libexec/s3auth-disable
 ```
+
+<!------------------------------------------------------------------->
 
 ## Hare we go
 
@@ -151,11 +132,29 @@ See `cfgen --help-schema` for the description of CDF format.
   hctl shutdown
   ```
 
+<!------------------------------------------------------------------->
+
 ## Troubleshooting
+
+### Ensure that LNet is configured
+
+<!-- XXX When does one have to check this? -->
+
+Run this command:
+```sh
+sudo lctl list_nids
+```
+
+If LNet (Lustre network) is not configured, run
+```sh
+sudo modprobe lnet
+sudo lctl network configure
+```
 
 ### RC Leader cannot be elected
 
-If `hctl bootstrap` cannot complete and keeps printing dots similarly to the output below,
+If `hctl bootstrap` cannot complete and keeps printing dots similarly
+to the output below,
 ```
 2020-01-14 10:57:25: Generating cluster configuration... Ok.
 2020-01-14 10:57:26: Starting Consul server agent on this node.......... Ok.
@@ -171,11 +170,3 @@ hctl shutdown
 sudo systemctl reset-failed hare-hax
 ```
 and bootstrap again.
-
-## Contributing
-
-This project uses
-[PC3 (Pedantic Code Construction Contract)](rfc/9/README.md)
-process for contributions.
-
-To build from sources, see the README_developers.md file.

--- a/README_developers.md
+++ b/README_developers.md
@@ -1,32 +1,44 @@
-# Hare - Halon replacement
+# Hare Developer Guide
 
-The scripts in this repository constitute a middleware layer between [Consul](https://www.consul.io/) and [Mero](http://gitlab.mero.colo.seagate.com/mero/mero) services.  Their responsibilities:
+The scripts in this repository form a middleware layer between
+[Consul](https://www.consul.io/) and
+[Motr](https://github.com/seagate/cortx-motr) services.
 
-- generate initial configuration of Motr cluster;
-- mediate communications between Motr services and Consul agents.
+Hare responsibilities:
+
+- Generate initial configuration of Motr cluster.
+- Mediate communication between Motr processes and Consul agents.
 
 ## 0. Prerequisites
 
-* Python &geq; 3.6 and the corresponding header files.
+* Python &geq; 3.6 and the header files.
 
-  To install them on CentOS 7.6, run
+  To install on CentOS 7, run
   ```sh
   sudo yum install python3 python3-devel
   ```
 
-* Ensure that Motr is built and its systemd services are installed.
-  ```sh
-  M0_SRC_DIR=/data/mero  # YMMV
+* Ensure that [Motr](https://github.com/seagate/cortx-motr) is installed.
 
-  $M0_SRC_DIR/scripts/m0 make
-  sudo $M0_SRC_DIR/scripts/install-mero-service --link
-  ```
+  * To install Motr from RPMs:
+    ```sh
+    sudo yum install cortx-motr cortx-motr-devel
+    ```
+
+  * Alternatively, Motr can be compiled and installed from sources:
+    ```sh
+    git clone --recursive https://github.com/Seagate/cortx-motr.git motr
+    M0_SRC_DIR=$PWD/motr
+
+    $M0_SRC_DIR/scripts/m0 make
+    sudo $M0_SRC_DIR/scripts/install-motr-service --link
+    ```
 
 ## 1. Single-node setup
 
 1. Build and install Hare:
    ```sh
-   git clone --recursive http://gitlab.mero.colo.seagate.com/mero/hare.git
+   git clone --recursive https://github.com/Seagate/cortx-hare.git hare
    cd hare
    make
    sudo make devinstall
@@ -66,12 +78,16 @@ dd if=/dev/urandom of=/tmp/128M bs=1M count=128
 sudo $M0_SRC_DIR/clovis/m0crate/m0crate -S /tmp/m0crate-io.yaml
 ```
 
-## 3. 3-node VM setup
+## 3. 3-node SSC VM setup
+
+<!-- XXX Why do we need this section at all?
+  -- Is section '4. Multi-node setup' not enough?
+  -->
 
 ### 3.1. Create VMs
 
 * Login to [Red Hat CloudForms](https://ssc-cloud.colo.seagate.com)
-  using your Seagate GID and password.
+  (aka SSC) using your Seagate GID and password.
 
 * Open
   [Service Catalogs](https://ssc-cloud.colo.seagate.com/catalog/explorer#/).
@@ -83,7 +99,7 @@ sudo $M0_SRC_DIR/clovis/m0crate/m0crate -S /tmp/m0crate-io.yaml
   [Active Services](https://ssc-cloud.colo.seagate.com/service/explorer#/)
   page.
 
-### 3.2. Install Cortx RPM packages
+### 3.2. Install RPMs
 
   Run the following code snippet on each of the nodes (VMs):
 
@@ -190,8 +206,8 @@ pools:
     data_units: 2
     parity_units: 1
 EOF
-   )
-   ```
+)
+```
 
 ### 3.7. Disable S3 authentication
 
@@ -334,8 +350,3 @@ has been elected.
 
   The timeout resets automatically (for demo purposes), so you will
   see it in the log file every other minute.
-
-## 7. Links
-
-- [Halon replacement: a simpler, better HA subsystem for EOS](https://docs.google.com/presentation/d/17Pn61WBbTHpeR4NxGtaDfmmHxgoLW9BnQHRW7WJO0gM/view) (slides)
-- [Halon replacement: Consul, design highlights](https://docs.google.com/document/d/1cR-BbxtMjGuZPj8NOc95RyFjqmeFsYf4JJ5Hw_tL1zA/view)


### PR DESCRIPTION
Solution:
- Use GitHub links instead of GitLab.
- Simplify `Prerequisites` section of README.md — move motr-kernel and LNet commands to the `Troubleshooting` section.
- Remove obsolete `Links` section.