### PR TITLE
Problem: BE segment device path is not configurable

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -158,12 +158,14 @@ node_desc() {
     data_iface: $iface
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/loop1
-          - /dev/loop2
-          - /dev/loop3
-          - /dev/loop4
+          data:
+            - /dev/loop1
+            - /dev/loop2
+            - /dev/loop3
+            - /dev/loop4
     m0_clients:
         s3: 1
         other: 2

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional, \
 import yaml
 
 
-__version__ = '0.9.1'
+__version__ = '0.10'
 
 
 def parse_opts(argv):
@@ -76,7 +76,11 @@ nodes:
                                # optional, defaults to "tcp"
     m0_servers:
       - runs_confd: <bool>  # optional, defaults to false
-        io_disks: [ <str> ] # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
+        io_disks:
+          meta_data: <str>  # device path for meta-data;
+                            # optional, Motr will use "/var/motr/m0d-<FID>/"
+                            # by default
+          data: [ <str> ]   # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
                             # Empty list means no IO service.
     m0_clients:
         s3: <int>     # number of S3 servers to start
@@ -212,7 +216,7 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
         for m0d in node['m0_servers']:
             m0d.setdefault('runs_confd', False)
             m0d['_io_disks'] = get_disks(node['hostname'], mock_p,
-                                         m0d['io_disks'])
+                                         m0d['io_disks']['data'])
 
 
 def validate_cluster_desc(desc: Dict[str, Any]) -> None:
@@ -243,8 +247,16 @@ Make sure the value of data_iface in the CDF is correct."""
         total_nr_confds += nr_confds
 
         for m0d in node['m0_servers']:
-            assert m0d['runs_confd'] or m0d['io_disks'], \
-                f"{name}: Either 'runs_confd' or 'io_disks' must be set"
+            d = m0d['io_disks']
+            assert m0d['runs_confd'] or d['data'], \
+                f"{name}: Either 'runs_confd' or 'io_disks.data' must be set"
+            assert '' not in d['data'], \
+                f"{name}: Empty strings in 'io_disks.data' are not allowed"
+            if 'meta_data' in d:
+                assert d['meta_data'], \
+                    f"{name}: 'io_disks.meta_data' must not be an empty string"
+                assert d['meta_data'] not in d['data'], \
+                    f"{name}: Meta-data disk must not belong io_disks.data"
 
         disks: List[Disk] = []
         for m0d in node['m0_servers']:
@@ -532,12 +544,13 @@ class ConfProcess(ToDhall):
     _downlinks = {Downlink('services', ObjT.service)}
 
     def __init__(self, nr_cpu: int, memsize_MB: int, endpoint: Endpoint,
-                 services: List[Oid]):
+                 services: List[Oid], meta_data: str = None):
         assert nr_cpu > 0
         self.nr_cpu = nr_cpu
         assert memsize_MB > 0
         self.memsize_MB = memsize_MB
         self.endpoint = endpoint
+        self.meta_data = meta_data
         assert all(x.type is ObjT.service for x in services)
         self.services = services
 
@@ -574,9 +587,15 @@ class ConfProcess(ToDhall):
                       ipaddr=facts[ipaddr_key(node_desc['data_iface'])],
                       portal=proc_t.value)
         proc_id = new_oid(ObjT.process)
+
+        meta_data = None
+        if proc_desc is not None and proc_t is ProcT.m0_server:
+            meta_data = proc_desc['io_disks'].get('meta_data')
+
         m0conf[proc_id] = cls(nr_cpu=facts['processorcount'],
                               memsize_MB=facts['_memsize_MB'],
                               endpoint=ep,
+                              meta_data=meta_data,
                               services=[])
         m0conf[parent].processes.append(proc_id)
 
@@ -1207,7 +1226,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
 
     ConsulService = NamedTuple('ConsulService', [
         ('node_name', str), ('proc_id', Oid), ('ep', Endpoint),
-        ('svc_id', Oid), ('stype', str)])
+        ('svc_id', Oid), ('stype', str), ('meta_data', Optional[str])])
 
     def profile() -> str:
         profiles = [x for x in m0conf.keys() if x.type is ObjT.profile]
@@ -1231,18 +1250,22 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                 assert proc_id.type is ObjT.process
                 for svc_id in m0conf[proc_id].services:
                     stype = m0conf[svc_id].type.name[len('M0_CST_'):].lower()
+                    proc = m0conf[proc_id]
                     yield ConsulService(node_name=node.name,
                                         proc_id=proc_id,
-                                        ep=m0conf[proc_id].endpoint,
-                                        svc_id=svc_id, stype=stype)
+                                        ep=proc.endpoint,
+                                        svc_id=svc_id,
+                                        stype=stype,
+                                        meta_data=proc.meta_data)
                 # Add clovis clients to consul kv
                 if proc_id in cluster.m0_clients:
                     proc_ep = m0conf[proc_id].endpoint
                     yield ConsulService(node_name=node.name,
                                         proc_id=proc_id,
-                                        ep=m0conf[proc_id].endpoint,
+                                        ep=proc.endpoint,
                                         svc_id=cluster.m0_clients[proc_id],
-                                        stype=ProcT(proc_ep.portal).name)
+                                        stype=ProcT(proc_ep.portal).name,
+                                        meta_data=None)
 
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
@@ -1252,6 +1275,9 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('m0conf/profiles/pools', sns_pools()),
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/services/'
            f'{x.stype}', x.svc_id.fidk) for x in processes()],
+        *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/'
+           f'meta_data', x.meta_data)
+          for x in processes() if x.stype == 'ios' and x.meta_data],
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/endpoint',
            str(x.ep))
           for x in processes()])],

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -1,7 +1,7 @@
 -- m0d process
 let M0Server =
   { runs_confd : Optional Bool
-  , io_disks : List Text
+  , io_disks : { meta_data: Optional Text, data : List Text }
   }
 
 let Node =

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -4,19 +4,22 @@ nodes:
     data_iface_type: tcp
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/loop0
-          - /dev/loop1
-          - /dev/loop2
-          - /dev/loop3
+          data:
+            - /dev/loop0
+            - /dev/loop1
+            - /dev/loop2
+            - /dev/loop3
       - io_disks:
-          - /dev/loop4
-          - /dev/loop5
-          - /dev/loop6
-          - /dev/loop7
-          - /dev/loop8
-          - /dev/loop9
+          data:
+            - /dev/loop4
+            - /dev/loop5
+            - /dev/loop6
+            - /dev/loop7
+            - /dev/loop8
+            - /dev/loop9
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -3,14 +3,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -18,12 +20,13 @@ nodes:
     data_iface: eth1
     m0_servers:
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -3,14 +3,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -18,14 +20,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -3,14 +3,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -18,14 +20,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -33,14 +37,16 @@ nodes:
     data_iface: eth1
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/vdb
-          - /dev/vdc
-          - /dev/vdd
-          - /dev/vde
-          - /dev/vdf
-          - /dev/vdg
+          data:
+            - /dev/vdb
+            - /dev/vdc
+            - /dev/vdd
+            - /dev/vde
+            - /dev/vdf
+            - /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ees-cluster.yaml
+++ b/cfgen/examples/ees-cluster.yaml
@@ -8,12 +8,14 @@ nodes:
                             # supported values: "tcp" (default), "o2ib"
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/sdd
-          - /dev/sde
-          - /dev/sdf
-          - /dev/sdg
+          data:
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
     m0_clients:
         s3: 0           # number of S3 servers to start
         other: 2        # max quantity of other Motr clients this node may have
@@ -22,12 +24,14 @@ nodes:
     data_iface_type: o2ib
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/sdh
-          - /dev/sdi
-          - /dev/sdj
-          - /dev/sdk
+          data:
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -8,18 +8,20 @@ nodes:
                             # supported values: "tcp" (default), "o2ib"
     m0_servers:
       - runs_confd: true
-        io_disks: []
+        io_disks:
+          data: []
       - io_disks:
-          - /dev/loop0
-          - /dev/loop1
-          - /dev/loop2
-          - /dev/loop3
-          - /dev/loop4
-          - /dev/loop5
-          - /dev/loop6
-          - /dev/loop7
-          - /dev/loop8
-          - /dev/loop9
+          data:
+            - /dev/loop0
+            - /dev/loop1
+            - /dev/loop2
+            - /dev/loop3
+            - /dev/loop4
+            - /dev/loop5
+            - /dev/loop6
+            - /dev/loop7
+            - /dev/loop8
+            - /dev/loop9
     m0_clients:
       s3: 0         # number of S3 servers to start
       other: 2      # max quantity of other Motr clients this host may have

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -8,12 +8,18 @@ in
       , data_iface_type = None types.Protocol
       , m0_servers =
           [ { runs_confd = Some True
-            , io_disks = [] : List Text
+            , io_disks =
+                { meta_data = None Text
+                , data = [] : List Text
+                }
             }
           , { runs_confd = None Bool
             , io_disks =
-                let mkPath = \(i : Natural) -> "/dev/loop" ++ Natural/show i
-                in Prelude.List.generate 10 Text mkPath
+                { meta_data = None Text
+                , data =
+                    let mkPath = \(i : Natural) -> "/dev/loop" ++ Natural/show i
+                    in Prelude.List.generate 10 Text mkPath
+                }
             }
           ]
       , m0_clients =

--- a/rfc/3/README.md
+++ b/rfc/3/README.md
@@ -38,7 +38,11 @@ nodes:
                                # optional, defaults to "tcp"
     m0_servers:
       - runs_confd: <bool>  # optional, defaults to false
-        io_disks: [ <str> ] # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
+        io_disks:
+          meta_data: <str>  # device path for meta-data;
+                            # optional, Motr will use "/var/motr/m0d-<FID>/"
+                            # by default
+          data: [ <str> ]   # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
                             # Empty list means no IO service.
     m0_clients:
         s3: <int>     # number of S3 servers to start

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -19,6 +19,7 @@ Key | Value | Description
 `last_fidk` | last generated fid key | Atomically incremented counter that is used to generate fids.
 `leader` | node name | This key is used for RC leader election.  Created with [`consul lock`](https://www.consul.io/docs/commands/lock.html) command.
 `m0conf/nodes/<name>/processes/<process_fidk>/endpoint` | endpoint address | Endpoint address of the Motr process (Consul service) with fid key `<process_fidk>`.  Example: `192.168.180.162@tcp:12345:44:101`.
+`m0conf/nodes/<name>/processes/<process_fidk>/meta_data` | path to meta-data disk | `m0mkfs` uses this value to create meta-data pool.
 `m0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>` | Fid key | Fid key of the Motr service, specified by its type, parent process, and node.
 `m0conf/profiles/<profile_fidk>` | `[ <pool_fidk> ]` | Array of fid keys of the SNS pools associated with this profile.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -32,6 +32,11 @@ get_service_ep() {
     consul kv get m0conf/nodes/$(node-name)/processes/$process_fidk/endpoint
 }
 
+get_ios_meta_data() {
+    local process_fidk=$1
+    consul kv get m0conf/nodes/$(node-name)/processes/$process_fidk/meta_data
+}
+
 get_service_addr() {
     echo ${1%:*}
 }
@@ -58,7 +63,7 @@ Please verify that the host name matches the one stored in the Consul KV.
     exit 1
 }
 CONFD_IDs=$(get_service_ids 'grep -iw confd')
-IOS_IDs=$(get_service_ids 'grep -iw ios | grep -iwv confd')
+IOS_IDs=$(get_service_ids 'grep -iw ios')
 S3_IDs=$(get_service_ids 'grep -iw m0_client_s3')
 HAX_EP=$(get_service_ep $HAX_ID)
 
@@ -129,6 +134,7 @@ append_ios_svc() {
     local ep=$(get_service_ep $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
+    local meta_data=$(get_ios_meta_data $id)
     SVCS_CONF+="${SVCS_CONF:+,}{
       \"id\": \"$id\",
       \"name\": \"ios\",
@@ -148,6 +154,11 @@ MOTR_M0D_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 EOF
+    if [[ $meta_data ]]; then
+        cat <<EOF | sudo tee -a /etc/sysconfig/m0d-$fid > /dev/null
+MOTR_BE_SEG_PATH='$meta_data'
+EOF
+    fi
 }
 
 append_s3_svc() {


### PR DESCRIPTION
One of the requirements for EES data recovery is to use some external
device to create BE segment. Currently Motr creates BE segments
at `/var/motr/m0d-<FID>/db/o` and this path is not configurable.

Motr takes BE segments paths from `/etc/sysconfig/m0d-<FID>`. Since
`hctl bootstrap` configures Mote processes (m0d), it is convenient to
specify BE segment path in the CDF and have `hctl bootstrap` put it
into Motr configuration files (`/etc/sysconfig/m0d-<FID>`).

Solution:
- Update CDF format to accommodate BE segment path for each Motr process.
- Add segment path to the Consul KV for each Motr process.
- Modify `update-consul-conf` script to configure BE segment path to
  `/var/motr/m0d-*`.

References:
* [EOS-11427](https://jts.seagate.com/browse/EOS-11427) (Hare)
* [EOS-10457](https://jts.seagate.com/browse/EOS-10457) (Motr)