### PR TITLE
Problem: new hax' dependency doesn't get installed

### DIFF
--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -6,3 +6,6 @@ pkgconfig
 python-consul
 setuptools
 wheel
+
+# this will work just because aiohttp is already specified in hax/setup.py
+aiohttp


### PR DESCRIPTION
Solution:
Duplicate aiohttp both in setup.py (already done) and in hax/requirements.txt. It turns out that this is the only correct way to specify hax' runtime dependencies.
