### PR TITLE
Problem: "Error! No key exists" in bootstrap output

### DIFF
--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -28,6 +28,7 @@ nodes:
         io_disks:
           data: []
       - io_disks:
+          #meta_data: /path/to/meta-data/drive
           data:
             - /dev/loop0
             - /dev/loop1

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -52,7 +52,9 @@ get_service_ep() {
 
 get_ios_meta_data() {
     local process_fidk=$1
-    consul kv get m0conf/nodes/$(node-name)/processes/$process_fidk/meta_data
+    consul kv export \
+           m0conf/nodes/$(node-name)/processes/$process_fidk/meta_data |
+        jq -r '.[].value | @base64d'
 }
 
 get_service_addr() {


### PR DESCRIPTION
```
[root@ssc-vm-0378 cortx-hare]# hctl bootstrap --mkfs singlenode.yaml
2020-08-12 12:53:20: Generating cluster configuration... OK
2020-08-12 12:53:21: Starting Consul server agent on this node........... OK
2020-08-12 12:53:30: Importing configuration into the KV store... OK
2020-08-12 12:53:30: Starting Consul agents on other cluster nodes... OK
2020-08-12 12:53:30: Updating Consul agents configs from the KV store...Error! No key exists at: m0conf/nodes/ssc-vm-0378.colo.seagate.com/processes/12/meta_data
 OK
2020-08-12 12:53:31: Installing Motr configuration files... OK
2020-08-12 12:53:31: Waiting for the RC Leader to get elected............ OK
2020-08-12 12:53:40: Starting Motr (phase1, mkfs)... OK
2020-08-12 12:53:46: Starting Motr (phase1, m0d)... OK
2020-08-12 12:53:47: Starting Motr (phase2, mkfs)... OK
2020-08-12 12:53:56: Starting Motr (phase2, m0d)... OK
2020-08-12 12:53:59: Checking health of services... OK
```

'meta_data' keys may not exist in the Consul KV store.

Solution: don't show error if '*/meta_data' key is not available.

Closes #1208.