### PR TITLE
Problem: README files greet readers with garbage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,9 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 # Contributing
 
 ## The process
 This project uses
 [PC3 (Pedantic Code Construction Contract)](rfc/9/README.md)
-process for contributions.  
+process for contributions.
 Read it to learn contribution requirements and
 process details.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 # Hare User Guide
 
 ## Welcome
@@ -47,9 +28,9 @@ cotrx-motr must be installed for proper operation. cotrx-motr can be either
 installed from packages of build from sources.
 
 Available options:
-* Install RPMs from CI build.  
+* Install RPMs from CI build.
   _The easiest way to get Hare + Motr instances up and running._
-* Build and install from source code.  
+* Build and install from source code.
   _Works for contribution process._
 
 ### Get source code
@@ -94,11 +75,11 @@ on every machine in the cluster:
 
 ### Choose a configuration to setup
 
-* Single node with Hare + Motr up and running.  
+* Single node with Hare + Motr up and running.
   _Recommended for fast proof of concept check to get familiar with software._
-* Cluster setup  
+* Cluster setup
   _Intended mode of operation. Several nodes/VM is required. RPM installation
-  is recommended._  
+  is recommended._
   **WARNING: will be available once public CI is operational.**
 
 The difference is obviously a number or nodes to configure and the content of
@@ -247,7 +228,7 @@ This is caused by missing `/etc/modprobe.d/lnet.conf` file. Check [Configure lne
 ### hctl reportbug
 
 hctl provides command which gathers all required logs from consul, hax and motr
-services.  
+services.
 Those logs can be attached to GitHub issue.
 ```
 hctl reportbug

--- a/README_developers.md
+++ b/README_developers.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 # Hare Developer Guide
 
 Current document covers building from sources and detailed configuration of Hare service.
@@ -25,7 +6,7 @@ Topics described here may require access to Seagate infrastructure.
 
 ## 0. Prerequisites
 
-* Repository is cloned along with all submodules. [Link to readme.](README.md#get-source-code)  
+* Repository is cloned along with all submodules. [Link to readme.](README.md#get-source-code)
   Quick clone from Seagate repo: `git clone --recursive https://github.com/Seagate/cortx-hare.git`
 
 * Python &geq; 3.6 and the corresponding header files.
@@ -35,7 +16,7 @@ Topics described here may require access to Seagate infrastructure.
   sudo yum install python3 python3-devel
   ```
 
-* Ensure that [Motr](https://github.com/seagate/cortx-motr) is built and its systemd services are installed.  
+* Ensure that [Motr](https://github.com/seagate/cortx-motr) is built and its systemd services are installed.
   _Note: check [cortx-motr](https://github.com/Seagate/cortx-motr/blob/dev/README.md) repo for more details_
   ```sh
   M0_SRC_DIR=/data/mero  # YMMV
@@ -373,7 +354,7 @@ make[1]: Leaving directory `/tmp/cortx-hare'
 make: *** [rpm] Error 2
 ```
 This caused by missing submodules. It happens when repository is cloned without
-`--recursive` flag.  
+`--recursive` flag.
 Solution: initialize following submodules
 * cortx-hare/vendor/consul-bin/
 * cortx-hare/vendor/dhall-bin/

--- a/cfgen/dhall/Prelude.dhall
+++ b/cfgen/dhall/Prelude.dhall
@@ -1,23 +1,3 @@
-{-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
-
--}
-
 {- This file provides a central `Prelude` import for the rest of the library to
    use so that the integrity check only needs to be updated in one place
    whenever upgrading the interpreter.

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 nodes:
   - hostname: localhost
     data_iface: eth1

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 nodes:
   - hostname: ssu1
     data_iface: eth1

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 nodes:
   - hostname: ssu1
     data_iface: eth1

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 nodes:
   - hostname: ssu1
     data_iface: eth1

--- a/cfgen/examples/ees-cluster.yaml
+++ b/cfgen/examples/ees-cluster.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 # Cluster Description File (CDF).
 # See `cfgen --help-schema` for the format description.
 

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 # Cluster Description File (CDF).
 # See `cfgen --help-schema` for the format description.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,42 +1,4 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 # GitLab CI scripts
-<!--
- Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-
- For any questions about this software or licensing,
- please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 
 `.gitlab-ci.yml` [configures CI pipelines](https://docs.gitlab.com/ee/ci/yaml/).
 To improve readability and maintainability of `.gitlab-ci.yml`, most

--- a/ci/expect-timeout
+++ b/ci/expect-timeout
@@ -18,7 +18,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-
 set usage "Usage: $argv0 <timeout (seconds)> <program> \[<arguments>\]"
 
 proc die {msg {rc 1}} {

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 hare:
   post_install:
     script: null

--- a/rfc/10/README.md
+++ b/rfc/10/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 10/GLOSS

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 11/HCTL

--- a/rfc/12/README.md
+++ b/rfc/12/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 12/CHECK

--- a/rfc/13/README.md
+++ b/rfc/13/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 13/HALC

--- a/rfc/14/README.md
+++ b/rfc/14/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 14/HW

--- a/rfc/3/README.md
+++ b/rfc/3/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 3/CFGEN

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 4/KV

--- a/rfc/5/README.md
+++ b/rfc/5/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 5/HAX

--- a/rfc/6/README.md
+++ b/rfc/6/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 6/BOOT

--- a/rfc/8/README.md
+++ b/rfc/8/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 domain: github.com
 shortname: 8/STYLE

--- a/rfc/9/README.md
+++ b/rfc/9/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 ---
 original-author: Pieter Hintjens <ph@imatix.com>
 original-url: http://hintjens.com/blog:23

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 # Hare RFC
 
 We collect specifications for APIs, file formats, wire protocols, and

--- a/systemd/consul-env.in
+++ b/systemd/consul-env.in
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 # mandatory:
 NODE=
 NODE_ID=

--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -27,6 +27,11 @@ PATH="$HARE_BASE_DIR/bin:$PATH"
 export PATH
 
 # TODO: should it be `consul` and PATH=/opt/seagate/cortx/hare/bin:$PATH ?
-exec consul agent -node $NODE -node-id $NODE_ID -bind $BIND -client "$CLIENT" $JOIN \
+exec consul agent \
+     -node $NODE \
+     -node-id $NODE_ID \
+     -bind $BIND \
+     -client "$CLIENT" \
+     $JOIN \
      -config-dir=/var/lib/hare/consul-$MODE-conf \
      -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS

--- a/systemd/hare-consul-agent.service
+++ b/systemd/hare-consul-agent.service
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 [Unit]
 Description=Consul agent for Hare
 Requires=network-online.target

--- a/systemd/hare-hax.service
+++ b/systemd/hare-hax.service
@@ -1,20 +1,3 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# For any questions about this software or licensing,
-# please email opensource@seagate.com or cortx-questions@seagate.com.
-
 [Unit]
 Description=HAX daemon for Hare
 Requires=hare-consul-agent.service motr-kernel.service

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,22 +1,3 @@
-<!--
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
-  For any questions about this software or licensing,
-  please email opensource@seagate.com or cortx-questions@seagate.com.
--->
-
 # Hare utilities
 
 - `build-ees-ha*` are [Pacemaker][] HA scripts.

--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -17,7 +17,6 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-
 # :help: stop the cluster
 
 import logging

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -17,7 +17,6 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-
 # :help: show cluster status
 
 import argparse


### PR DESCRIPTION
Copyright information is the first thing one expects to see in README file.

Solution:
- `:common-sense on`
- Remove copyright headers from Markdown and YAML files.
- Add `LICENSE` file.