### PR TITLE
Problem: wrong code for permanent branch checkout in Hare CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,10 +61,8 @@ pipeline {
                             def remote = getTestMachine(VM_FQDN)
                             def commandResult = sshCommand remote: remote, command: """
                             rm -rf $REPO_NAME
-                            mkdir $REPO_NAME
-                            cd $REPO_NAME
-                            git init
                             git clone --recursive https://$GITHUB_TOKEN@github.com/Seagate/'$REPO_NAME'.git
+                            cd $REPO_NAME
                             git checkout $BRANCH_NAME
                             git log -1
                             ls -la


### PR DESCRIPTION
Not all redundand git commands were removed in "Download cortx-hare
repo" stage.

Solution: remove redundand commands