### PR TITLE
EOS-12233: ees_ha deployment fails

### DIFF
--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -1,5 +1,6 @@
 {
   "server": true,
+  "leave_on_terminate": true,
   "watches": [
     {
       "type": "key",

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -122,10 +122,16 @@ abort_if_RC_leader_election_is_impossible() {
 
         for svc in hare-hax $confd_id; do
             if $ssh sudo systemctl --quiet --state=failed is-failed $svc; then
-                ok=false
-                status_commands+=(
-                    "${ssh:+$ssh }sudo systemctl status $svc"
-                )
+                # hare-hax service fails during stop which blocks the further
+                # deployment of the cluster. Remove this explicit reset-failed
+                # and enable code after this statement once the stop failure is
+                # resolved.
+                sudo systemctl reset-failed $svc
+
+                #ok=false
+                #status_commands+=(
+                #    "${ssh:+$ssh }sudo systemctl status $svc"
+                #)
             fi
         done
         if $ok; then


### PR DESCRIPTION
HA script build-ees-ha invokes hctl bootstrap multiple times, after the first
bootstrap, during shutdown, hare-consul-agent and hare-hax services fail to
stop gracefully. As consul agent parameter, leave_on_terminate value is false
by default, leads to server failure while stopping.
see https://www.consul.io/docs/agent#stopping-an-agent
Hax service also fails to stop as it tries to disconnect halink links with motr
processes which are already stopped before hax.

Solution:
- Setting leave_on_terminate value to true as part of consul server configuration
  allows server to gracefully shutdown.
- Hax shutdown failure during bootstrap is worked around by resetting the corresponding
  systemd unit to unblock and the actual fix must be handled separately.

Closes #1207