### PR TITLE
Problem: Hare does not maintain disk HA state

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1377,6 +1377,39 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                                         stype=ProcT(proc_ep.portal).name,
                                         meta_data=None)
 
+    def sdevs() -> List:
+        node_sdevs = []
+        for node_id, node in m0conf.items():
+            if node_id.type is not ObjT.node:
+                continue
+            node_key = f'm0conf/nodes/{fid2str(node_id)}'
+            node_val = json.dumps(dict(name=node.name,
+                                       state='M0_NC_UNKNOWN'))
+            node_sdevs.append((node_key, node_val))
+            for proc_id in node.processes:
+                assert proc_id.type is ObjT.process
+                proc = m0conf[proc_id]
+                proc_key = f'{node_key}/processes/{fid2str(proc_id)}'
+                proc_name = ProcT(proc.endpoint.portal).name
+                proc_val = json.dumps(dict(name=proc_name,
+                                           state='M0_NC_UNKNOWN'))
+                node_sdevs.append((proc_key, proc_val))
+                for svc_id in m0conf[proc_id].services:
+                    stype = m0conf[svc_id].type.name[len('M0_CST_'):].lower()
+                    svc_key = f'{proc_key}/services/{fid2str(svc_id)}'
+                    svc_val = json.dumps(dict(name=stype,
+                                              state='M0_NC_UNKNOWN'))
+                    node_sdevs.append((svc_key, svc_val))
+                    for sdev_id in m0conf[svc_id].sdevs:
+                        assert sdev_id.type is ObjT.sdev
+                        sdev = m0conf[sdev_id]
+                        disk_key = f'{svc_key}/sdevs/{fid2str(sdev_id)}'
+                        disk_val = json.dumps(dict(path=sdev.filename,
+                                                   state='M0_NC_UNKNOWN'))
+                        node_sdevs.append((disk_key, disk_val))
+        return node_sdevs
+
+    node_sdevs = [dict(key=k, value=v) for k, v in sdevs()]
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
         ('eq-epoch', 1),
@@ -1391,7 +1424,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
           for x in processes() if x.stype == 'ios' and x.meta_data],
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/endpoint',
            str(x.ep))
-          for x in processes()])],
+          for x in processes()])] + node_sdevs,
                       indent=2) + '\n'
 
 

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -366,22 +366,28 @@ class ConsulUtil:
         keys = getattr(self,
                        'get_{}_keys'.format(obj_t.name.lower()))(node_items,
                                                                  fidk)
-        assert keys
-        node_name = keys[0].split('/', 3)[2]
+        assert len(keys) == 1
+        key = keys[0].split('/')
+        node_key = ('/'.join(key[:3]))
+        node_val = self.kv.kv_get(node_key)
+        data = node_val['Value']
+        node_name: str = json.loads(data)['name']
         return self.get_node_health(node_name)
 
     @staticmethod
     def get_process_keys(node_items: List[Any], fidk: int) -> List[Any]:
+        fid = mk_fid(ObjT.PROCESS, fidk)
         return [
             x['Key'] for x in node_items
-            if '/processes/' in x['Key'] and str(fidk) in x['Key']
+            if f'{fid}' == x['Key'].split('/')[-1]
         ]
 
     @staticmethod
     def get_service_keys(node_items: List[Any], fidk: int) -> List[Any]:
+        fid = mk_fid(ObjT.SERVICE, fidk)
         return [
             x['Key'] for x in node_items
-            if '/services/' in x['Key'] and int(x['Value']) == fidk
+            if f'{fid}' == x['Key'].split('/')[-1]
         ]
 
     def get_node_health(self, node: str) -> str:

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -21,6 +21,10 @@ Key | Value | Description
 `m0conf/nodes/<name>/processes/<process_fidk>/endpoint` | endpoint address | Endpoint address of the Motr process (Consul service) with fid key `<process_fidk>`.  Example: `192.168.180.162@tcp:12345:44:101`.
 `m0conf/nodes/<name>/processes/<process_fidk>/meta_data` | path to meta-data disk | `m0mkfs` uses this value to create meta-data pool.
 `m0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>` | Fid key | Fid key of the Motr service, specified by its type, parent process, and node.
+`m0conf/nodes/<node_fid>` | `{ "name": "Host name", "state": "<HA state>" }` | Node name and ha state.
+`m0conf/nodes/<node_fid>/processes/<process_fid>` | `{ "name": "Process name", "state": "<HA state>" }` | Process name and ha state.
+`m0conf/nodes/<node_fid>/processes/<process_fid>/services/<svc_fid>` | `{ "name": "Service name", "state": "<HA state>" }` | Service name and ha state.
+`m0conf/nodes/<node_fid>/processes/<process_fid>/services/<svc_fid>/sdevs/<sdev_fid>` | `{ "path": "Sdev Path", "state": "<HA state>" }` | Storage device path and ha state.
 `m0conf/profiles/<profile_fidk>` | `[ <pool_fidk> ]` | Array of fid keys of the SNS pools associated with this profile.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
 `profile` | fid | Profile fid in string format.  Example: `"0x7000000000000001:0x4"`.

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -19,12 +19,13 @@
 
 # :help: show cluster status
 
+import json
 import argparse
 import io
 import logging
 import sys
 from subprocess import PIPE, Popen
-from typing import Any, Dict, List, NamedTuple, Optional, Set
+from typing import Any, Dict, List, NamedTuple, Optional
 
 import simplejson as j
 from consul import Consul, ConsulException
@@ -97,9 +98,10 @@ def sns_pools(cns: Consul) -> List[str]:
     return get_kv_safe(cns, 'm0conf/profiles/pools').split(' ')
 
 
-def hosts(cns: Consul) -> Set[str]:
+def hosts(cns: Consul) -> List[str]:
     data = get_kv(cns, 'm0conf/nodes', recurse=True)
-    host_names = {(x['Key'].split('/'))[2] for x in data}
+    host_names = [json.loads(x['Value'])['name'] for x in data
+                  if len(x['Key'].split('/')) == 3]
     return host_names
 
 
@@ -128,18 +130,37 @@ def proc_id2name(cns: Consul, node: str, proc_id: int) -> str:
     return 'm0_client'
 
 
-def processes(cns: Consul, node_id: str) -> List[Process]:
+def fid_key(fid: str) -> int:
+    key = fid.split(':')[1]
+    return int(key, 16)
+
+
+def node_name2id(cns: Consul, node_name: str) -> Any:
+    data = get_kv(cns, 'm0conf/nodes/', recurse=True)
+    for x in data:
+        if len(x['Key'].split('/')) == 3 and \
+           json.loads(x['Value'])['name'] == node_name:
+            return x['Key'].split('/')[-1]
+
+    assert False
+    return ''
+
+
+def processes(cns: Consul, node_name: str) -> List[Process]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/...' entries
     # from the KV.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md).
+    node_id = node_name2id(cns, node_name)
     data = get_kv(cns, f'm0conf/nodes/{node_id}/processes', recurse=True)
-    fidk_list: List[int] = list({int(x['Key'].split('/')[4]) for x in data})
+    proc_ids = [x['Key'].split('/')[-1] for x in data
+                if len(x['Key'].split('/')) == 5]
+    fidk_list = list(map(fid_key, proc_ids))
     fidk_list.sort()
     return [
-        Process(name=proc_id2name(cns, node_id, k),
+        Process(name=proc_id2name(cns, node_name, k),
                 fid=Fid(0x7200000000000001, k),
                 ep=get_kv_safe(
-                    cns, f'm0conf/nodes/{node_id}/processes/{k}/endpoint'),
-                status=process_status(cns, node_id, k)) for k in fidk_list
+                    cns, f'm0conf/nodes/{node_name}/processes/{k}/endpoint'),
+                status=process_status(cns, node_name, k)) for k in fidk_list
     ]
 
 


### PR DESCRIPTION
Disk HA state is used by all Motr processes for all requests.
Motr rely on Hare for these disk states. These states are
received from IO service and H/W monitoring daemon (SSPL).

Solution:
Add node-disk hirarchy to consul kv to maintain disk states.

Ref. EOS-11983