### PR TITLE
EOS-11864: Rule implementations for the supported event types

### DIFF
--- a/hax/hax/queue/__init__.py
+++ b/hax/hax/queue/__init__.py
@@ -1,5 +1,10 @@
+import json
 import logging
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Optional
+from hax.types import HAState
+from hax.util import create_drive_fid
+from hax.queue.confobjutil import ConfObjUtil
+from queue import Queue
 
 
 class BQProcessor:
@@ -7,7 +12,50 @@ class BQProcessor:
     This is the place where a real processing logic should be located.
     Currently it is effectively a no-op.
     """
+    def __init__(self, queue: Queue):
+        self.queue = queue
+        self.confobjutil = ConfObjUtil()
+
     def process(self, messages: List[Tuple[int, Any]]) -> None:
         for i, msg in messages:
-            logging.debug('Message #%s received: %s (type: %s)', i, msg,
-                          type(msg).__name__)
+            logging.debug('Message #%s received: %s (type: %s)',
+                          i, msg, type(msg).__name__)
+            self.payload_process(msg)
+
+    def payload_process(self, msg: str) -> None:
+        #
+        # XXX:
+        # differing import temporarily due to following runtime error suspected
+        # due to
+        # import dependency,
+        # from hax.message import EntrypointRequest, HaNvecGetEvent,
+        # ProcessEvent
+        # ImportError: cannot import name 'EntrypointRequest'
+        #
+        from hax.message import BroadcastHAStates
+        hastates = []
+        try:
+            msg_load = json.loads(msg)
+            payload = json.loads(msg_load['payload'])
+        except json.JSONDecodeError:
+            logging.error('Cannot parse payload, invalid json')
+            return
+        # To add check for multiple object entries in a payload.
+        # for objinfo in payload:
+        hastate: Optional[HAState] = self.to_ha_state(payload)
+        if hastate:
+            hastates.append(hastate)
+        if not hastates:
+            logging.debug('No ha states to broadcast')
+            return
+        self.queue.put(BroadcastHAStates(hastates))
+
+    def to_ha_state(self, objinfo: dict) -> Optional[HAState]:
+        try:
+            drive_id = self.confobjutil.obj_name_to_id(objinfo['obj_type'],
+                                                       objinfo['obj_name'])
+        except KeyError as error:
+            logging.error('Invalid json payload, no key (%s) present', error)
+            return None
+        return HAState(fid=create_drive_fid(int(drive_id)),
+                       status=objinfo['obj_state'])

--- a/hax/hax/queue/confobjutil.py
+++ b/hax/hax/queue/confobjutil.py
@@ -1,0 +1,12 @@
+from hax.util import ConsulUtil
+
+
+class ConfObjUtil:
+    def __init__(self):
+        self.consul = ConsulUtil()
+
+    def obj_name_to_id(self, objtype: str, objname: str) -> str:
+        # This depends on consul kv schema for storing drive configuration.
+        # Presently returning a random value, must be replaced with a proper
+        # function per object type.
+        return '16'

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -101,7 +101,8 @@ def run_server(
     app.add_routes([
         web.get('/', hello_reply),
         web.post('/', process_ha_states(queue)),
-        web.post('/watcher/bq', process_bq_update(inbox_filter, BQProcessor()))
+        web.post('/watcher/bq', process_bq_update(inbox_filter,
+                                                  BQProcessor(queue)))
     ])
     logging.info(f'Starting HTTP server at {addr}:{port} ...')
     try:

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -35,7 +35,9 @@ ObjT = Enum(
     [
         # These are the only conf object types we care about.
         ('PROCESS', 0x7200000000000001),
-        ('SERVICE', 0x7300000000000001)
+        ('SERVICE', 0x7300000000000001),
+        ('SDEV', 0x6400000000000001),
+        ('DRIVE', 0x6b00000000000001),
     ])
 ObjT.__doc__ = 'Motr conf object types and their m0_fid.f_container values'
 

--- a/rules/rule-drive-failed
+++ b/rules/rule-drive-failed
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Broadcast disk failure event to motr processes.
+# Sample payload: {"obj_type": "drive", "obj_name": "vdb", "obj_state": "failed"}
+
+HARE_BIN=/opt/seagate/cortx/hare/bin
+
+payload=$1
+
+$HARE_BIN/h0q bq M0_HA_MSG_NVEC $payload


### PR DESCRIPTION
Rule to broadcast drive failure event is missing.

Solution:
- Create a rule script to handle drive failure event and broadcasts the same to
  motr services.
- Drive event comprises of universal drive name (uuid or serial number) passed to
  it through EQ interface. Rule converts the universal drive name to motr specific
  identifier with help of Consul and posts event to BQ (broadcast queue).