### PR TITLE
Problem: there is grounding script to setup PYTHONPATH for queue tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ install: install-dirs install-cfgen install-hax install-systemd install-vendor
 	@$(call _log,linking hctl -> $(DESTDIR)/usr/bin)
 	@install --verbose --directory $(DESTDIR)/usr/bin
 	@ln -sf /$(PREFIX)/bin/hctl $(DESTDIR)/usr/bin
+	@$(call _log,copying h0q -> $(DESTDIR)/$(PREFIX)/bin)
+	@install utils/h0q $(DESTDIR)/$(PREFIX)/bin
+	@$(call _log,linking h0q -> $(DESTDIR)/usr/bin)
+	@ln -sf /$(PREFIX)/bin/h0q $(DESTDIR)/usr/bin
 
 .PHONY: install-dirs
 install-dirs:
@@ -235,6 +239,8 @@ devinstall: install-dirs devinstall-cfgen devinstall-hax devinstall-systemd devi
 	@$(call _log,linking hctl -> $(DESTDIR)/usr/bin)
 	@install --verbose --directory $(DESTDIR)/usr/bin
 	@ln -sf $(TOP_SRC_DIR)hctl $(DESTDIR)/usr/bin
+	@$(call _log,linking h0q -> $(DESTDIR)/usr/bin)
+	@ln -sf $(TOP_SRC_DIR)/utils/h0q $(DESTDIR)/usr/bin
 	@$(call _log,creating hare group)
 	@groupadd --force hare
 	@$(call _log,changing permission of $(DESTDIR)/var/lib/hare)

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -129,7 +129,7 @@ setup(
         'python-consul>=1.1.0', 'simplejson', 'aiohttp', 'click',
     ],
     entry_points={
-        'console_scripts': ['hax=hax.hax:main', 'h0q=hax.queue.cli:main']
+        'console_scripts': ['hax=hax.hax:main', 'q=hax.queue.cli:main']
     },
     ext_modules=[
         Extension(

--- a/utils/h0q
+++ b/utils/h0q
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -e -o pipefail
+# set -x
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+
+HARE_BASE_DIR=/opt/seagate/cortx/hare
+PYTHONPATH="$HARE_BASE_DIR/lib/python3.6/site-packages"
+PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
+export PYTHONPATH
+
+exec $HARE_BASE_DIR/bin/q "$@"

--- a/utils/proto-rc
+++ b/utils/proto-rc
@@ -46,11 +46,6 @@ RULES_DIR=${CURR_DIR%/*}/rules
 RULES_DEFAULT_TIMEOUT_SEC=4
 RULES_CRITICAL_TIMEOUT_SEC=6
 
-HARE_BASE_DIR=/opt/seagate/cortx/hare
-PYTHONPATH="$HARE_BASE_DIR/lib/python3.6/site-packages"
-export PYTHONPATH="$HARE_BASE_DIR/lib64/python3.6/site-packages:$PYTHONPATH"
-export PATH="$HARE_BASE_DIR/bin:$PATH"
-
 STOP=0
 sig_handler() {
     echo 'Signal caught! Exiting...'


### PR DESCRIPTION
Python scrips on hare are launched with customized PYTHONPATH to point
to correct place with site-packages.
Without this queue tool python script can't resolve dependencies during
start.

Solution: implement grounding script h0q which exports PYTHONPATH
variable and executes queue tool