### PR TITLE
Add workflow file for submodule update in cortx repo

### DIFF
--- a/.github/workflows/dispatch_submodule_update.yml
+++ b/.github/workflows/dispatch_submodule_update.yml
@@ -1,0 +1,17 @@
+name: Dispatch event for cortx submodule
+on:
+  push:
+    branches: [ release ]
+jobs:
+  dispatch:
+    strategy:
+      matrix:
+        repo: ['Seagate/cortx']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: submodule-update-event


### PR DESCRIPTION
Added workflow to update cortx-motr submodule present in [cortx repository](https://github.com/Seagate/cortx) to the latest commits on the `release` branch of [cortx-hare repository](https://github.com/Seagate/cortx-hare).
This workflow would get triggered by a commit on the `release` branch and generates a dispatch event named `submodule-update-event` which would, in turn, trigger [workflow](https://github.com/Seagate/cortx/blob/master/.github/workflows/update-submodules.yml) in cortx repository and updates cortx-hare submodule remote to the latest commit.