### PR TITLE
Problem: RC rules directory is not included to cortx-hare RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ uninstall:
 	@$(call _info,Un-installing)
 	@for d in $(CFGEN_EXE) $(CFGEN_SHARE) \
 	          $(HARE_CONF) \
-			  $(HARE_RULES) \
+	          $(HARE_RULES) \
 	          $(HAX_EXE) $(HAX_EGG_LINK) $(HAX_EGG) $(HAX_MODULE) \
 	          $(EASY_INST_PTH) \
 	          $(CONSUL_LIBEXEC) $(CONSUL_SHARE) \


### PR DESCRIPTION
Solution: add missing commands to install, install-dirs, devinstall,
uninstall targets in Makefile