### PR TITLE
Problem: Hare jenkins test fails due to `systemctl reset-failed`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,6 @@ pipeline {
                     def commandResult = sshCommand remote: remote, command: """
                         PATH=/opt/seagate/cortx/hare/bin/:\$PATH
                         hctl shutdown
-                        systemctl status hare-hax || systemctl reset-failed hare-hax
                         """
                     echo "Result: " + commandResult
                 }


### PR DESCRIPTION
Not all invocations of `systemctl reset-failed` were removed.

Solution: Remove remaining `systemctl reset-failed hare-hax` from
Jenkinsfile