### PR TITLE
EOS-11866: Implementation of bq-delivered

### DIFF
--- a/hax/hax/ffi.py
+++ b/hax/hax/ffi.py
@@ -86,6 +86,7 @@ class HaxFFI:
             c.POINTER(HaNoteStruct),  # struct m0_ha_note *notes
             c.c_uint32  # uint32_t nr_notes
         ]
+        lib.m0_ha_notify.restype = c.py_object
         self.ha_broadcast = lib.m0_ha_notify
 
         lib.m0_ha_nvec_reply_send.argtypes = [

--- a/hax/hax/halink.py
+++ b/hax/hax/halink.py
@@ -169,8 +169,11 @@ class HaLink:
             notes.append(note)
             notes += self._generate_sub_services(note, cns)
 
-        self._ffi.ha_broadcast(self._ha_ctx, make_array(HaNoteStruct, notes),
-                               len(notes))
+        tags: List[int] = self._ffi.ha_broadcast(self._ha_ctx,
+                                                 make_array(HaNoteStruct,
+                                                            notes),
+                                                 len(notes))
+        logging.debug('Broadcast HA state complete with tag = %s', tags)
 
     def _process_event_cb(self, fid, chp_event, chp_type, chp_pid):
         logging.info('fid=%s, chp_event=%s', fid, chp_event)
@@ -191,6 +194,12 @@ class HaLink:
         self.queue.put(
             StobIoqError(fid, sie_conf_sdev, sie_stob_id, sie_fd, sie_opcode,
                          sie_rc, sie_offset, sie_size, sie_bshift))
+
+    def _msg_delivered_cb(self, proc_fid, proc_endpoint: str, tag: int):
+        logging.info('Delivered to endpoint'
+                     "'{}', process fid = {}".format(proc_endpoint,
+                                                     str(proc_fid)) +
+                     'tag= %d', tag)
 
     @log_exception
     def ha_nvec_get(self, hax_msg: int, nvec: List[HaNote]) -> None:

--- a/hax/hax/hax.h
+++ b/hax/hax/hax.h
@@ -87,7 +87,7 @@ void m0_ha_entrypoint_reply_send(unsigned long long epr,
 void m0_ha_failvec_reply_send(unsigned long long hm, struct m0_fid *pool_fid,
 			      uint32_t nr_notes);
 void m0_ha_nvec_reply_send(unsigned long long hm, struct m0_ha_note *notes, uint32_t nr_notes);
-void m0_ha_notify(unsigned long long ctx, struct m0_ha_note *notes, uint32_t nr_notes);
+PyObject *m0_ha_notify(unsigned long long ctx, struct m0_ha_note *notes, uint32_t nr_notes);
 void m0_ha_broadcast_test(unsigned long long ctx);
 
 /*


### PR DESCRIPTION
Hax does not implement motr halink interface callback for message delivered.
This is required to mark the last successfully delivered message to motr fro Hax
in case of node failures or restarts.

Solution:
- Implement motr halink interface message delivered call back.
- Escalate the message to Python land to update the last successfully delivered
  message.