### PR TITLE
Problem: 40 minutes is not enough for pipeline to finish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     agent { label 'docker-nightly-node' }
 
     options {
-        timeout(40)  // abort the build after that many minutes
+        timeout(50)  // abort the build after that many minutes
         disableConcurrentBuilds()
         timestamps()
         ansiColor('xterm')  // XXX Delete if not useful.


### PR DESCRIPTION
Jenkins job is interrupted in the middle of I/O test which is the last
stage in pipeline.

Solution: increase timeout to 50 minutes