### PR TITLE
Problem: no HTTP endpoint for getting SNS progress

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -22,10 +22,11 @@ from queue import Empty, Queue
 from typing import List
 
 from hax.message import (BroadcastHAStates, EntrypointRequest, HaNvecGetEvent,
-                         ProcessEvent)
+                         ProcessEvent, SnsRepairStatus)
 from hax.motr.ffi import HaxFFI
 from hax.queue.publish import EQPublisher
-from hax.types import MessageId, StobIoqError, StoppableThread
+from hax.types import (Fid, MessageId, SnsRepairStatusItem, StobIoqError,
+                       StoppableThread)
 from hax.util import ConsulUtil, dump_json, repeat_if_fails
 
 
@@ -108,6 +109,18 @@ class ConsumerThread(StoppableThread):
                         logging.debug('Stob IOQ JSON: %s', payload)
                         offset = self.eq_publisher.publish('STOB_IOQ', payload)
                         logging.debug('Written to epoch: %s', offset)
+                    elif isinstance(item, SnsRepairStatus):
+                        logging.info('Requesting SNS status')
+                        time.sleep(5)
+                        # FIXME implement a real logic here
+                        logging.info('SNS status is received')
+                        item.reply_to.put([
+                            SnsRepairStatusItem(
+                                progress=25,
+                                status='M0_CMS_ACTIVE',
+                                fid=Fid.parse('0x7200000000000001:deadbeef'))
+                        ])
+
                     else:
                         logging.warning('Unsupported event type received: %s',
                                         item)

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -16,6 +16,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+import queue as q
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -26,11 +27,6 @@ from queue import Queue
 
 class BaseMessage:
     pass
-
-
-@dataclass
-class Message(BaseMessage):
-    s: str
 
 
 @dataclass
@@ -106,6 +102,11 @@ class SnsDiskAttach(SnsOperation):
 
 class SnsDiskDetach(SnsOperation):
     pass
+
+
+@dataclass
+class SnsRepairStatus:
+    reply_to: q.Queue
 
 
 class Die(BaseMessage):

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -174,6 +174,10 @@ StobIoqError = NamedTuple('StobIoqError',
                            ('sie_offset', int), ('sie_size', int),
                            ('sie_bshift', int)])
 
+SnsRepairStatusItem = NamedTuple('SnsRepairStatusItem', [('fid', Fid),
+                                                         ('status', str),
+                                                         ('progress', int)])
+
 
 class StoppableThread(Thread):
     def stop(self) -> None:


### PR DESCRIPTION
Solution:
Implement the endpoint and stub code within Motr-aware thread (so that it is easy to integrate with Motr API).

Sample response:

```
$ curl -i -X GET 192.168.6.214:8008/api/v1/sns/rebalance-progress
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 85
Date: Fri, 04 Sep 2020 15:54:49 GMT
Server: Python/3.6 aiohttp/3.6.2

[{"fid": "0x7200000000000001:0xdeadbeef", "status": "M0_CMS_ACTIVE", "progress": 25}]
```