### PR TITLE
Problem: no Python FFI for SPIEL SNS API

### DIFF
--- a/hax/hax/exception.py
+++ b/hax/hax/exception.py
@@ -31,6 +31,10 @@ class ConfdQuorumException(HaxAPIException):
     pass
 
 
+class RepairRebalanceException(HaxAPIException):
+    pass
+
+
 class NotDelivered(RuntimeError):
     def __init__(self, message: str):
         super().__init__()

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -104,3 +104,43 @@ class HaxFFI:
         lib.m0_ha_filesystem_stats_fetch.argtypes = [c.c_void_p]
         lib.m0_ha_filesystem_stats_fetch.restype = c.py_object
         self.filesystem_stats_fetch = lib.m0_ha_filesystem_stats_fetch
+
+        lib.repair_status.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.repair_status.restype = c.py_object
+        self.repair_status = lib.repair_status
+
+        lib.rebalance_status.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.rebalance_status.restype = c.py_object
+        self.rebalance_status = lib.rebalance_status
+
+        lib.start_repair.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.start_repair.restype = c.c_int
+        self.start_repair = lib.start_repair
+
+        lib.start_rebalance.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.start_rebalance.restype = c.c_int
+        self.start_rebalance = lib.start_rebalance
+
+        lib.stop_repair.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.stop_repair.restype = c.c_int
+        self.stop_repair = lib.stop_repair
+
+        lib.stop_rebalance.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.stop_rebalance.restype = c.c_int
+        self.stop_rebalance = lib.stop_rebalance
+
+        lib.pause_repair.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.pause_repair.restype = c.c_int
+        self.pause_repair = lib.pause_repair
+
+        lib.pause_rebalance.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.pause_rebalance.restype = c.c_int
+        self.pause_rebalance = lib.pause_rebalance
+
+        lib.resume_repair.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.resume_repair.restype = c.c_int
+        self.resume_repair = lib.resume_repair
+
+        lib.resume_rebalance.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
+        lib.resume_rebalance.restype = c.c_int
+        self.resume_rebalance = lib.resume_rebalance

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -146,6 +146,19 @@ FsStatsWithTime = NamedTuple('FsStatsWithTime', [('stats', FsStats),
                                                  ('timestamp', float),
                                                  ('date', str)])
 
+
+class SnsCmStatus(Enum):
+    CM_STATUS_INVALID = 0
+    CM_STATUS_IDLE = 1
+    CM_STATUS_STARTED = 2
+    CM_STATUS_FAILED = 3
+    CM_STATUS_PAUSED = 4
+
+
+ReprebStatus = NamedTuple('ReprebStatus', [('srs_fid', Fid),
+                                           ('srs_state', SnsCmStatus),
+                                           ('srs_progress', c.c_uint32)])
+
 HaNote = NamedTuple('HaNote', [('obj_t', str), ('note', HaNoteStruct)])
 
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', str)])


### PR DESCRIPTION
Solution: add FFI for libmotr SPIEL SNS operations and data structures.                                                  
                                                                                                                         
* introduce 'ReprebStatus' struct in 'hax/types.py'                                                                      
* add new methods in HaLink class:                                                                                       
  - get_repair_status                                                                                                    
  - get_rebalance_status                                                                                                 
  - start_repair                                                                                                         
  - start_rebalance                                                                                                      
  - stop_repair                                                                                                          
  - stop_rebalance                                                                                                       
  - pause_repair                                                                                                         
  - pause_rebalance                                                                                                      
  - resume_repair                                                                                                        
  - resume_rebalance