### PR TITLE
'h0q bq' publishes JSON as an escaped string which breaks the BQ watcher

### DIFF
--- a/hax/hax/queue/__init__.py
+++ b/hax/hax/queue/__init__.py
@@ -36,7 +36,7 @@ class BQProcessor:
         hastates = []
         try:
             msg_load = json.loads(msg)
-            payload = json.loads(msg_load['payload'])
+            payload = msg_load['payload']
         except json.JSONDecodeError:
             logging.error('Cannot parse payload, invalid json')
             return

--- a/hax/hax/queue/publish.py
+++ b/hax/hax/queue/publish.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 import simplejson
 from hax.util import ConsulKVBasic, TxPutKV, repeat_if_fails
@@ -6,7 +6,8 @@ from hax.util import ConsulKVBasic, TxPutKV, repeat_if_fails
 # XXX do we want to make payload definition more strict?
 # E.g. there could be a type hierarchy for payload objects that depends
 # on the type name.
-Message = NamedTuple('Message', [('message_type', str), ('payload', str)])
+Message = NamedTuple('Message', [('message_type', str),
+                                 ('payload', Dict[str, Any])])
 
 
 class Publisher:
@@ -25,7 +26,8 @@ class Publisher:
         """
         Publishes the given message to the queue.
         """
-        message = Message(message_type=message_type, payload=payload)
+        data = simplejson.loads(payload)
+        message = Message(message_type=message_type, payload=data)
         data = simplejson.dumps(message)
 
         while True:


### PR DESCRIPTION
Solution: always assume the message payload as a JSON.

Closes https://github.com/Seagate/cortx-hare/issues/1274