### PR TITLE
Problem: device-state-set is not exercised by CI

### DIFF
--- a/jenkins/test-rules
+++ b/jenkins/test-rules
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -e -o pipefail
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+# set -x
+
+PROG=${0##*/}
+
+die() {
+    echo "$PROG: ERROR: $*" >&2
+    exit 1
+}
+
+cd /opt/seagate/cortx/hare
+
+hctl bootstrap --mkfs share/cfgen/examples/singlenode.yaml
+hctl status
+
+../rules/device-state-set \
+    '{ "obj_type": "drive", "obj_name": "vdb", "obj_state": "Failed" }' ||
+    die "$0 rule execution failed"
+
+hctl status --json | jq -r '.nodes[] | .svcs[] | .status' | {
+    if ! grep -qE 'started|unknown'; then
+        die 'One or more process is offline'
+    fi
+}


### PR DESCRIPTION
Solution: call `device-state-set` from Hare CI.

Jira: [EOS-11865](https://jts.seagate.com/browse/EOS-11865)