### PR TITLE
Problem: Hax service stuck while stopping rconfc

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -98,13 +98,10 @@ def main():
                    ha_service=cfg.ha_fid,
                    rm_service=cfg.rm_fid)
         logging.info('Motr API has been started')
-        # FIXME XXX
-        # We are disabling filesystem stats fetch till we have
-        # clean fix for EOS-12405
-        # stats_updater = _run_stats_updater_thread(motr)
+        stats_updater = _run_stats_updater_thread(motr)
         # [KN] This is a blocking call. It will work until the program is
         # terminated by signal
-        run_server(q, herald, threads_to_wait=[consumer])
+        run_server(q, herald, threads_to_wait=[consumer, stats_updater])
     except Exception:
         logging.exception('Exiting due to an exception')
     finally:


### PR DESCRIPTION
While shutting down cluster, Hax service stops after IOS & CONFD
stops. In this case when Hax tried to stop rconfc, it stuck in
confd election, since confds already shutdown it should not go
for election and mark as rconfc_failed instead.

Solution:
Currently rconfc only used to fetch filesystem stats, and it only
fetch stats if all Motr services are running. fs-stats-updater thread
start rconfc only when all Motr services are running. So whenever it
it finds that all services are not running it stops rconfc and again
start when all services up and running again.