### PR TITLE
Problem: hctl drive-state command is broken

### DIFF
--- a/hctl
+++ b/hctl
@@ -113,7 +113,7 @@ done
 # process commands
 case $cmd in
     help) usage; exit ;;
-    bootstrap|reportbug|shutdown|status|drive|rebalance|repair)
+    bootstrap|reportbug|shutdown|status|drive-state|rebalance|repair)
         if [[ -d $M0_SRC_DIR/utils ]]; then
             PATH="$M0_SRC_DIR/utils:$PATH"
         fi


### PR DESCRIPTION
hctl --help displays `drive-state` command but internally was still referring to
`drive`, this was failing the drive-state command.

Solution:
Replace `drive` with `drive-state`