### PR TITLE
Problem: STOB errors are not broadcast

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -109,7 +109,7 @@ class ConsumerThread(StoppableThread):
                         logging.info('Stob IOQ: %s', item.fid)
                         payload = dump_json(item)
                         logging.debug('Stob IOQ JSON: %s', payload)
-                        offset = self.eq_publisher.publish('STOB_IOQ', payload)
+                        offset = self.eq_publisher.publish('stob-ioq', payload)
                         logging.debug('Written to epoch: %s', offset)
                     elif isinstance(item, SnsRepairStatus):
                         logging.info('Requesting SNS repair status')

--- a/hax/hax/queue/__init__.py
+++ b/hax/hax/queue/__init__.py
@@ -1,12 +1,12 @@
 import json
 import logging
 from queue import Queue
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from hax.message import BroadcastHAStates
 from hax.motr.delivery import DeliveryHerald
 from hax.queue.confobjutil import ConfObjUtil
-from hax.types import HaLinkMessagePromise, HAState, MessageId
+from hax.types import Fid, HaLinkMessagePromise, HAState, MessageId
 from hax.util import create_drive_fid
 
 
@@ -24,28 +24,59 @@ class BQProcessor:
         (i, msg) = message
         logging.debug('Message #%d received: %s (type: %s)', i, msg,
                       type(msg).__name__)
-        self.payload_process(msg)
+        try:
+            self.payload_process(msg)
+        except Exception:
+            logging.exception(
+                'Failed to process a message #%d.'
+                ' The message is skipped.', i)
         logging.debug('Message #%d processed', i)
 
     def payload_process(self, msg: str) -> None:
-        hastates = []
+        data = None
         try:
-            msg_load = json.loads(msg)
-            payload = msg_load['payload']
+            data = json.loads(msg)
         except json.JSONDecodeError:
             logging.error('Cannot parse payload, invalid json')
             return
+
+        payload = data['payload']
+        msg_type = data['message_type']
+
+        handlers: Dict[str, Callable[[Dict[str, Any]], None]] = {
+            'M0_HA_MSG_NVEC': self.handle_device_state_set,
+            'STOB_IOQ_ERROR': self.handle_ioq_stob_error,
+        }
+        if msg_type not in handlers:
+            logging.warn(
+                'Unsupported message type given: %s. Message skipped.',
+                msg_type)
+            return
+        handlers[msg_type](payload)
+
+    def handle_device_state_set(self, payload: Dict[str, Any]) -> None:
         # To add check for multiple object entries in a payload.
         # for objinfo in payload:
         hastate: Optional[HAState] = self.to_ha_state(payload)
-        if hastate:
-            hastates.append(hastate)
-        if not hastates:
-            logging.debug('No ha states to broadcast')
+        if not hastate:
+            logging.debug('No ha states to broadcast.')
             return
 
         q: Queue = Queue(1)
-        self.queue.put(BroadcastHAStates(states=hastates, reply_to=q))
+        self.queue.put(BroadcastHAStates(states=[hastate], reply_to=q))
+        ids: List[MessageId] = q.get()
+        self.herald.wait_for_any(HaLinkMessagePromise(ids))
+
+    def handle_ioq_stob_error(self, payload: Dict[str, Any]) -> None:
+        fid = Fid.parse(payload['conf_sdev'])
+        if fid.is_null():
+            logging.debug('Fid is 0:0. Skipping the message.')
+            return
+
+        q: Queue = Queue(1)
+        self.queue.put(
+            BroadcastHAStates(states=[HAState(fid, status='offline')],
+                              reply_to=q))
         ids: List[MessageId] = q.get()
         self.herald.wait_for_any(HaLinkMessagePromise(ids))
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -99,7 +99,7 @@ class Fid:
         self.key = key
 
     @staticmethod
-    def parse(val: str):
+    def parse(val: str) -> 'Fid':
         cont, key = tuple(int(s, 16) for s in val.split(':', 1))
         return Fid(cont, key)
 
@@ -107,11 +107,14 @@ class Fid:
     def from_struct(val: FidStruct):
         return Fid(val.f_container, val.f_key)
 
-    def to_c(self):
+    def to_c(self) -> FidStruct:
         return FidStruct(self.container, self.key)
 
-    def get_copy(self):
+    def get_copy(self) -> 'Fid':
         return Fid(self.container, self.key)
+
+    def is_null(self) -> bool:
+        return self.container == 0 and self.key == 0
 
     def __repr__(self):
         return f'{self.container:#x}:{self.key:#x}'
@@ -166,15 +169,14 @@ HaNote = NamedTuple('HaNote', [('obj_t', str), ('note', HaNoteStruct)])
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', str)])
 
 # struct m0_stob_id
-StobId = NamedTuple('StobId', [('si_domain_fid', Fid), ('si_fid', Fid)])
+StobId = NamedTuple('StobId', [('domain_fid', Fid), ('fid', Fid)])
 
 # struct m0_stob_ioq_error
-StobIoqError = NamedTuple('StobIoqError',
-                          [('fid', Fid), ('sie_conf_sdev', Fid),
-                           ('sie_stob_id', StobId), ('sie_fd', int),
-                           ('sie_opcode', int), ('sie_rc', int),
-                           ('sie_offset', int), ('sie_size', int),
-                           ('sie_bshift', int)])
+StobIoqError = NamedTuple('StobIoqError', [('fid', Fid), ('conf_sdev', Fid),
+                                           ('stob_id', StobId), ('fd', int),
+                                           ('opcode', int), ('rc', int),
+                                           ('offset', int), ('size', int),
+                                           ('bshift', int)])
 
 # SnsRepairStatusItem = NamedTuple('SnsRepairStatusItem', [('fid', Fid),
 #                                                          ('status', str),

--- a/rules/stob-ioq
+++ b/rules/stob-ioq
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Broadcast IOQ_STOB error to all motr processes.
+# Sample payload: {"fid": "0x1:0x4", "conf_sdev": "0x1:0x4", "stob_id": {"domain_fid": "0x1:0x2", "fid": "0x1:0x3"}, "fd": 1, "opcode": 2, "rc": 3, "offset": 4, "size": 1024, "bshift": 1}
+
+h0q bq STOB_IOQ_ERROR "$HARE_RC_EVENT_PAYLOAD"


### PR DESCRIPTION
Solution:
1. Add EQ rule that expects ioq_stob message type (with StobIoqError
dumped as JSON)
2. That rule forwards the StobIoqError to BQ with message type IOQ_STOB_ERROR
3. Add BQ handler for IOQ_STOB_ERROR that takes conf_sdev Fid and sends
HAState with it as 'offline' (M0_NC_FAILED).

JIRA: EOS-13031