### PR TITLE
Problem: filesytems stats updater thread checks ioservices in a loop

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -50,6 +50,7 @@ class FsStatsUpdater(StoppableThread):
             while not self.stopped:
                 started = self._ioservices_running()
                 if not all(started):
+                    time.sleep(self.interval_sec)
                     continue
                 result: int = motr.start_rconfc()
                 if result == 0:
@@ -85,6 +86,8 @@ class FsStatsUpdater(StoppableThread):
 
     def _ensure_motr_all_started(self):
         while True:
+            if self.stopped:
+                return
             started = self._ioservices_running()
             if all(started):
                 logging.debug(


### PR DESCRIPTION
Before fetching filesystems stats from motr, FsStatsUpdater thread checks
if all the ioservices are running or not. Only if all the ioservices are
running file systems stats are queried from motr. Presently if all the
motr ioservices are not started fs stats updater thread spins in a loop
to check for all ioservices without a delay. The thread does wait for the
given time interval between subsequent fs stats queries though.

Solution:
Use the given time interval to wait between subsequent ioservices running
checks as well.