### PR TITLE
Problem: hctl drive-state-set command fails

### DIFF
--- a/hax/hax/queue/confobjutil.py
+++ b/hax/hax/queue/confobjutil.py
@@ -5,8 +5,5 @@ class ConfObjUtil:
     def __init__(self):
         self.consul = ConsulUtil()
 
-    def obj_name_to_id(self, objtype: str, objname: str) -> str:
-        # This depends on consul kv schema for storing drive configuration.
-        # Presently returning a random value, must be replaced with a proper
-        # function per object type.
-        return '16'
+    def drive_to_sdev_fid(self, node: str, drive: str):
+        return self.consul.node_to_drive_fid(node, drive)

--- a/rules/device-state-set
+++ b/rules/device-state-set
@@ -18,10 +18,5 @@
 #
 
 # Broadcast disk failure event to motr processes.
-# Sample payload: {"obj_type": "drive", "obj_name": "vdb", "obj_state": "failed"}
 
-HARE_BIN=/opt/seagate/cortx/hare/bin
-
-payload=$1
-
-$HARE_BIN/h0q bq M0_HA_MSG_NVEC $payload
+h0q bq M0_HA_MSG_NVEC "$HARE_RC_EVENT_PAYLOAD"

--- a/utils/hare-drive-state
+++ b/utils/hare-drive-state
@@ -31,40 +31,41 @@ Usage: $PROG [<option>]
 
 Post drive events to Motr
 
-Positional arguments:
-  <drive name> Universal drive name
-
 Options:
-  -s, --state <drive state> Drive state to notify Motr
-  -h, --help   Show this help and exit.
+  --json <json-payload> Payload to set device state.
+                        payload format:
+                        {
+                          "node" : "ssc-vm-c-0553.colo.seagate.com",
+                          "source_type" : "drive",
+                          "device" : "/dev/vdb"
+                          "state" : "FAILED",
+                        }
+  -h, --help            Show this help and exit.
 EOF
 }
 
-TEMP=$(getopt --options hs: \
-              --longoptions help,state: \
+TEMP=$(getopt --options h: \
+              --longoptions help,json: \
               --name "$PROG" -- "$@" || true)
+
+echo $?
 
 (($? == 0)) || { usage >&2; exit 1; }
 
 eval set -- "$TEMP"
 
-state=
+payload=
 
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
-        -s|--state)          state=$2; shift 2 ;;
+        --json)              payload=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
 done
 
-drive=${1:-}
-
-[[ $drive ]] || {
-    usage >&2
-    exit 1
-}
+[[ $payload ]] || { usage >&2; exit 1; }
 
 die() {
     echo "$PROG: $*" >&2
@@ -72,12 +73,7 @@ die() {
 }
 
 state_set() {
-    payload=$(jq --null-input --compact-output \
-            --arg obj_type "drive" \
-            --arg obj_name "$drive" \
-            --arg obj_state "$state" \
-            '{ obj_type: $obj_type, obj_name: $obj_name, obj_state: $obj_state }')
-    h0q eq 'device-state-set' $payload
+    h0q eq 'device-state-set' "$payload"
 }
 
 state_get() {
@@ -85,7 +81,7 @@ state_get() {
     :
 }
 
-if [[ $state ]]; then
+if [[ $payload ]]; then
     state_set
 else
     state_get

--- a/utils/proto-rc
+++ b/utils/proto-rc
@@ -129,9 +129,6 @@ sed '/^null$/d' | jq --compact-output '.[]' | {
           debug_RC)
             exec_with_timeout $RULES_DIR/_debug
             ;;
-          device-state-set)
-            exec_with_timeout $RULES_DIR/device-state-set $HARE_RC_EVENT_PAYLOAD
-            ;;
           # Run rule script with the name equal to incoming event type.
           # Recommended option for new rule scripts and event types.
           *)


### PR DESCRIPTION
Rule device-state-set did not construct json payload properly
to send an event to bq. Hax was thus failing to parse the payload
and failing to broadcast.

Solution:
Construct json payload received from eq event processin before the
broadcast.