### PR TITLE
Problem: Hare wiki is difficult to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,4 @@ Solution: `git submodule update --init --recursive`.
 ## See also
 
 * [Hare RFCs](rfc/README.md)
+* [Hare wiki](https://github.com/Seagate/cortx-hare/wiki)


### PR DESCRIPTION
Contributors may be unaware of the existence of the wiki.

Solution: add 'Hare wiki' reference to the `README.md`.