### PR TITLE
Change event trigger branch to open source facing branch main

### DIFF
--- a/.github/workflows/dispatch_submodule_update.yml
+++ b/.github/workflows/dispatch_submodule_update.yml
@@ -1,7 +1,7 @@
 name: Dispatch event for cortx submodule
 on:
   push:
-    branches: [ release ]
+    branches: [ main ]
 jobs:
   dispatch:
     strategy:


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

For the opensource `main` branch will be front-facing. This means the `main` branch will be set as the default branch and community members will raise PR against the `main` branch. Hence we need to sync the main branch with [cortx ](https://github.com/Seagate/cortx) repository.