### PR TITLE
Problem: make test-cfgen fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,9 +429,10 @@ mypy: $(PYTHON_SCRIPTS)
 test: test-cfgen
 
 .PHONY: test-cfgen
-test-cfgen: $(PY_VENV_DIR)
+test-cfgen: $(PY_VENV_DIR) unpack-dhall-bin unpack-dhall-prelude
 	@$(call _info,Testing cfgen)
-	@$(PY_VENV); $(MAKE) --quiet -C cfgen test-cfgen check-dhall
+	@$(PY_VENV); PATH=$$PWD/vendor/dhall-bin/current:$$PATH \
+		$(MAKE) --quiet -C cfgen test-cfgen check-dhall
 
 # RPM ------------------------------------------------- {{{1
 #

--- a/cfgen/Makefile
+++ b/cfgen/Makefile
@@ -25,9 +25,6 @@ M0CONFGEN := $(if\
 dhall-lang-version := $(shell readlink ../vendor/dhall-prelude/current)
 dhall-lang-dir := dhall/dhall-lang-$(dhall-lang-version)
 
-opt_mock := $(shell if ! which facter &>/dev/null ||\
- grep -q ':/docker/' /proc/1/cgroup 2>/dev/null; then echo '--mock'; fi)
-
 .PHONY: check
 check: flake8 typecheck test-cfgen check-dhall
 
@@ -43,8 +40,8 @@ typecheck: $(PYTHON_SCRIPTS)
 test-cfgen: unpack-dhall-prelude
 	set -eu -o pipefail;\
  out=$$(mktemp -d);\
- ./cfgen -D ./dhall $(opt_mock) --debug examples/singlenode.yaml >/dev/null;\
- ./cfgen -D ./dhall $(opt_mock) -o $$out examples/singlenode.yaml;\
+ ./cfgen -D ./dhall --mock --debug examples/singlenode.yaml >/dev/null;\
+ ./cfgen -D ./dhall --mock -o $$out examples/singlenode.yaml;\
  dhall text <$$out/confd.dhall | $(M0CONFGEN) >/dev/null;\
  jq . <$$out/consul-kv.json >/dev/null;\
  rm -r $$out


### PR DESCRIPTION
Solution: make sure Dhall and Dhall Prelude exist before running
cfgen test. Run cfgen with '--mock' in order not to fail if there
are no loop devices.