### PR TITLE
Problem: 'main' branch is not synced

### DIFF
--- a/.github/workflows/dispatch_submodule_update.yml
+++ b/.github/workflows/dispatch_submodule_update.yml
@@ -1,7 +1,7 @@
 name: Dispatch event for cortx submodule
 on:
   push:
-    branches: [ release ]
+    branches: [ main ]
 jobs:
   dispatch:
     strategy:


### PR DESCRIPTION
For the open source release `main` branch will be front-facing: it will be set as the default branch, and community members will raise PRs against it.  Hence we need to sync `main` branch with cortx repository.

Solution: change event trigger branch from `release` to `main`.