### PR TITLE
Problem: Consul rpm is outdated

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -45,7 +45,7 @@ BuildRequires: python36-devel
 BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
-Requires: consul = 1.7.2
+Requires: consul = 1.7.8
 Requires: facter
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}


### PR DESCRIPTION
Solution: update Consul rpm version to the lasted patch-fix release
from 1.7.x branch. It includes all the recent bugfixes and also matches
the version of Consul rpm provided by the Provisioner.