### PR TITLE
Problem: hctl does not provide start command

### DIFF
--- a/hctl
+++ b/hctl
@@ -113,7 +113,7 @@ done
 # process commands
 case $cmd in
     help) usage; exit ;;
-    bootstrap|reportbug|shutdown|status|drive-state)
+    bootstrap|start|reportbug|shutdown|status|drive-state)
         if [[ -d $M0_SRC_DIR/utils ]]; then
             PATH="$M0_SRC_DIR/utils:$PATH"
         fi

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -22,6 +22,7 @@ Commands:
     node        manage the cluster nodes
     reportbug   gather Hare forensic data
     shutdown    stop the cluster
+    start       start cluster
     status      show cluster status
 
     help        Show this help and exit.
@@ -85,6 +86,21 @@ Stopping hare-consul-agent at ssc-vm-c-0553.colo.seagate.com...
 Stopped hare-consul-agent at ssc-vm-c-0552.colo.seagate.com
 Stopped hare-consul-agent at ssc-vm-c-0553.colo.seagate.com
 Killing RC Leader at ssc-vm-c-0552.colo.seagate.com... **ERROR**
+```
+
+## Cluster start
+
+```
+$ hctl start
+2020-09-18 06:59:59: Starting Consul server agent on this node............ OK
+2020-09-18 07:00:09: Importing configuration into the KV store... OK
+2020-09-18 07:00:09: Starting Consul agents on other cluster nodes... OK
+2020-09-18 07:00:09: Updating Consul agents configs from the KV store... OK
+2020-09-18 07:00:10: Installing Motr configuration files... OK
+2020-09-18 07:00:10: Waiting for the RC Leader to get elected..... OK
+2020-09-18 07:00:12: Starting Motr (phase1, m0d)... OK
+2020-09-18 07:00:15: Starting Motr (phase2, m0d)... OK
+2020-09-18 07:00:18: Checking health of services... OK
 ```
 
 ## Cluster status

--- a/utils/hare-start
+++ b/utils/hare-start
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -eu -o pipefail
+# set -x
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+
+# :help: start cluster
+
+PROG=${0##*/}
+
+die() {
+    echo "$PROG: $*" >&2
+    exit 1
+}
+
+conf_dir=/var/lib/hare
+
+if ! [[ -d $conf_dir ]]; then
+    die 'Cluster is not configured on this node.'
+fi
+
+if  hctl status > /dev/null 2>&1; then
+    die 'Cluster is up and running.'
+fi
+
+hctl bootstrap -c $conf_dir


### PR DESCRIPTION
User may need to start cluster and not required to generate
configuration. `hctl bootstrap` already has option to skip
config generation. And there is one requirement for opensource
to have `hctl start`.

Solution:
Add start command to hctl