### PR TITLE
Problem: hctl node-join outputs error when run without --conf-create

### DIFF
--- a/utils/hare-node-join
+++ b/utils/hare-node-join
@@ -231,7 +231,7 @@ make_consul_env() {
 
 say 'Starting Consul server agent on this node...'
 # Create Consul env only for this node.
-if [[ $conf_create ]]; then
+if $conf_create; then
     make_consul_env
 fi
 
@@ -274,7 +274,7 @@ while (( $(get_ready_agents | wc -l) != $agents_nr )); do
     (( count++ ))
 done
 
-if [[ $conf_create ]]; then
+if $conf_create; then
     say 'Updating Consul agents configs from the KV store...'
     update-consul-conf &
     pids=($!)


### PR DESCRIPTION
[root@ssc-vm-c-0553 cortx-hare]# hctl node-join -c /var/lib/hare --consul-addr 192.168.9.108 --consul-port 8500
2020-09-18 16:04:22: Starting Consul server agent on this node...jq: error: Could not open file /var/lib/hare/consul-agents.json: No such file or directory
jq: error: Could not open file /var/lib/hare/consul-agents.json: No such file or directory
jq: error: Could not open file /var/lib/hare/consul-agents.json: No such file or directory

Solution:
Check for conf_create flag (boolean) without square brackets.