### PR TITLE
Problem: Primary consul node does not join the cluster on restart

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -256,6 +256,7 @@ abort_if_RC_leader_election_is_impossible
 
 # Get my IP address (the one that the other agents will join to).
 read _ join_ip <<< $(get_server_nodes | grep -w $(node-name))
+read _ join_peers <<< $(get_server_nodes | grep -vw $(node-name))
 
 if [[ -z $join_ip ]]; then
     cat <<'EOF' >&2
@@ -269,7 +270,7 @@ fi
 
 say 'Starting Consul server agent on this node...'
 # $join_ip is our bind_ip address
-mk-consul-env --mode server --bind $join_ip \
+mk-consul-env --mode server --bind $join_ip --join $join_peers \
               --extra-options '-ui -bootstrap-expect 1'
 
 sudo systemctl start hare-consul-agent

--- a/utils/hare-node-join
+++ b/utils/hare-node-join
@@ -101,7 +101,8 @@ get_session_checks_nr() {
 }
 
 get_leader() {
-    curl -sX GET http://$CONSUL_ADDR:$CONSUL_PORT/v1/leader
+    curl -sX GET http://$CONSUL_ADDR:$CONSUL_PORT/v1/kv/leader |
+        jq -r '.[].Value' | base64 -d
 }
 
 wait4() {
@@ -158,8 +159,8 @@ while true; do
     case "$1" in
         -h|--help)      usage; exit ;;
         -c|--conf-dir)  conf_dir=$2; shift 2 ;;
-        --consul-addr)  CONSUL_ADDR=$2 shift 2 ;;
-        --consul-port)  CONSUL_PORT=$2 shift 2 ;;
+        --consul-addr)  CONSUL_ADDR=$2; shift 2 ;;
+        --consul-port)  CONSUL_PORT=$2; shift 2 ;;
         --mkfs)         opt_mkfs=--mkfs; shift ;;
         --conf-create)  conf_create=true; shift ;;
         --)             shift; break ;;
@@ -242,7 +243,7 @@ sudo systemctl start hare-consul-agent
 # Here we are checking if any of the peer nodes is already elected as the
 # leader. This is required in case of node reboots and starting services
 # only on a given node.
-while ! $(get_leader); do
+while [[ ! $(get_leader) ]]; do
     sleep 1
     echo -n '.'
 done


### PR DESCRIPTION
On primary node which runs Consul agent in bootstrap mode does not set
the endpoints of its peer nodes to join. This works during bootstrap but the
node fails to join the cluster if restarted alone when cluster is running.

Solution:
- Provide peer node ipaddresses to consul agent running in bootstrap mode
  inorder for the node to re-join the cluster on restart.
- Fix typos.