### PR TITLE
Problem: README.md refers to wrong Consul version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and health-checking mechanisms.
   ```sh
   sudo yum -y install yum-utils
   sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
-  sudo yum -y install consul-1.7.2
+  sudo yum -y install consul-1.7.8
   ```
 
 * Install Motr.


### PR DESCRIPTION
Solution: use `consul-1.7.8` — the same version as in `hare.spec`.