### PR TITLE
Problem: mk-consul-env fails during bootstrap for single node

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -268,12 +268,9 @@ EOF
 fi
 
 say 'Starting Consul server agent on this node...'
-join_peers_option="--join $join_peers"
-if [[ ! $join_peers ]]; then
-    join_peers_option=""
-fi
+join_peers_opt="${join_peers:+--join $join_peers}"
 # $join_ip is our bind_ip address
-mk-consul-env --mode server --bind $join_ip $join_peers_option\
+mk-consul-env --mode server --bind $join_ip $join_peers_opt \
               --extra-options '-ui -bootstrap-expect 1'
 
 sudo systemctl start hare-consul-agent


### PR DESCRIPTION
As part of node join command now the primary node (bootstrapping node)
joins its peer nodes. But in case of singlenode bootstrap `join_peers`
variable is empty and leads to parsing error in mk-consul-env script.
```
mk-consul-env: invalid option -- 'u'
mk-consul-env: invalid option -- 'i'
mk-consul-env: invalid option -- ' '
mk-consul-env: invalid option -- '-'
```

Solution:
Do not pass `join` option if `join_peers` is empty to mk-consul-env.