### PR TITLE
Problem: sleeps in filestats.py can make hax hang

### DIFF
--- a/hax/hax/exception.py
+++ b/hax/hax/exception.py
@@ -39,3 +39,10 @@ class NotDelivered(RuntimeError):
     def __init__(self, message: str):
         super().__init__()
         self.message = message
+
+
+class InterruptedException(RuntimeError):
+    """
+    Marker exception that is used in HaX to control thread lifecycle.
+    """
+    pass


### PR DESCRIPTION
Solution: don't use time.sleep(). Instead, use [threading.Event](https://docs.python.org/3/library/threading.html#event-objects) that can be canceled from another thread (and the waiting thread will react immediately).

Relates to [EOS-13393](https://jts.seagate.com/browse/EOS-13393).