### PR TITLE
CONTRIBUTING.md updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,7 @@ and describe the problem you are facing.
    ```
 
 4. [Create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+
+## See also
+
+* [CORTX Contributing Guide](https://github.com/Seagate/cortx/blob/main/CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,6 @@ Thank you for your interest in contributing to Hare!
 This project uses [PC3 (Pedantic Code Construction Contract)](rfc/9/README.md)
 process for contributions.
 
-## Authenticating with SSO
-
-<!-- XXX-DELETEME Remove this section as soon as Seagate ditches SSO. -->
-
-'Seagate' organization at GitHub uses SAML single sign-on (SSO).
-To authenticate with the API or Git on the command line, you must
-[authorize your SSH key or personal access token](https://docs.github.com/en/github/authenticating-to-github/authenticating-with-saml-single-sign-on).
-
 ## Requesting changes
 
 To request changes,


### PR DESCRIPTION
# Problem: CORTX contributing guide is not mentioned

Solution: add 'CORTX Contributing Guide' reference to the end of `CONTRIBUTING.md`.

# Problem: CONTRIBUTING.md still mentions SSO

SAML single sign-on (SSO) is not needed any more.  Phew!

Solution: remove SSO instructions from `CONTRIBUTING.md`.