### PR TITLE
Problem: logrotate config uses mutually exclusive options

### DIFF
--- a/provisioning/hare-logrotate
+++ b/provisioning/hare-logrotate
@@ -1,7 +1,9 @@
 /var/log/hare/*.log
 {
     rotate 10
-    size 10M
+    maxsize 50M
     weekly
     compress
+    missingok
+    copytruncate
 }


### PR DESCRIPTION
Solution: replace 'size' with 'maxsize', which doesn't comflict with
'weekly' time interval option of lograte.

Additionally, increase max size of a log file to 50MB. Rotated logs are
compressed, with an avg ratio around 10:1 to 50:1, so total size of the
logs should not exceed 100MB, given that 10 last rotations are stored.

'copytruncate' option ensures that Hare applications can continue
logging information w/o needing to re-open the log file after each
rotation.