### PR TITLE
Problem: S3 resources do not stop when motr stack migrated to another node

### DIFF
--- a/utils/build-ees-ha
+++ b/utils/build-ees-ha
@@ -442,12 +442,16 @@ hax_systemd_update() {
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
              -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero || /bin/mount $lvolume /var/mero'" \
              -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero || while ! /bin/umount /var/mero; do lsof +D /var/mero; sleep 1; done'" \
+             -e "/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running" \
+             -e "/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running" \
              -i /usr/lib/systemd/system/hare-hax-c1.service
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
              -e 's;ExecStart.*cd /var/mero;&2;' \
              -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
              -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero2 || /bin/mount $rvolume /var/mero2'" \
              -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero2 || while ! /bin/umount /var/mero2; do lsof +D /var/mero2; sleep 1; done'" \
+             -e "/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running" \
+             -e "/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running" \
              -i /usr/lib/systemd/system/hare-hax-c2.service
     echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
@@ -459,12 +463,16 @@ hax_systemd_update() {
              -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
              -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero1 || /bin/mount $lvolume /var/mero1'\"
              -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero1 || while ! /bin/umount /var/mero1; do lsof +D /var/mero1; sleep 1; done'\"
+             -e \"/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running\"
+             -e \"/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running\"
              -i /usr/lib/systemd/system/hare-hax-c1.service &&
     sudo cp -f /usr/lib/systemd/system/hare-hax.service
             /usr/lib/systemd/system/hare-hax-c2.service &&
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
              -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/mero || /bin/mount $rvolume /var/mero'\"
              -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/mero || while ! /bin/umount /var/mero; do lsof +D /var/mero; sleep 1; done'\"
+             -e \"/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running\"
+             -e \"/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running\"
              -i /usr/lib/systemd/system/hare-hax-c2.service &&
     echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
     ssh $rnode $cmd
@@ -543,6 +551,12 @@ clusterip_rsc_add() {
         echo 'Configuring ClusterIP constrains in Pacemaker...'
         sudo pcs -f $cib_file constraint order c1 then ClusterIP-clone
         sudo pcs -f $cib_file constraint order c2 then ClusterIP-clone
+        # Make ClusterIP to run only on nodes where motr and S3 stack are
+        # present. S3 stack shall follow the same constraint.
+        sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
+            score=-INFINITY '#uname' eq $lnode and hax-running eq 0
+        sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
+            score=-INFINITY '#uname' eq $rnode and hax-running eq 0
     fi
 }
 
@@ -574,6 +588,12 @@ s3auth_rsc_add() {
     sudo pcs -f $cib_file constraint order ldap-clone then s3auth-clone
     sudo pcs -f $cib_file constraint order mero-ios-c1 then s3auth-clone
     sudo pcs -f $cib_file constraint order mero-ios-c2 then s3auth-clone
+    # Make s3auth resource to run only on nodes where motr and hax are present.
+    # All s3server resources shall follow s3auth due to colocation constraint.
+    sudo pcs -f $cib_file constraint location s3auth-clone rule score=-INFINITY '#uname' \
+        eq $lnode and hax-running eq 0
+    sudo pcs -f $cib_file constraint location s3auth-clone rule score=-INFINITY '#uname' \
+        eq $rnode and hax-running eq 0
 }
 
 elastic_search_rsc_add() {


### PR DESCRIPTION
This makes s3server to fail and produce a lot of traces which consume
disk space on shared partition affecting another node.
ClusterIP resource shall also migrate after motr-stack since "failed"
node can't serve requests anymore.

Solution:
* Add hax-running attribute which is set to 1 when hax is
  started on current node and set to 0 when hax is stopped (Exec Post-hooks
  in systemd file).
* Add location constrains for ClusterIP-clone and s3auth-clone resources
  to make them migrate/stop when hax (i.e. motr-stack) is not running on
  current node. Since s3server-cN resources are colocated with s3auth
  and can't work on opposite nodes - they will be stopped on "failed"
  node.

Signed-off-by: Andrei Zheregelia <andrei.zheregelia@seagate.com>