### PR TITLE
Problem: hare-reportbug tool saves system logs only for current boot

### DIFF
--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -76,7 +76,7 @@ cd "$dest_dir/hare/$HOSTNAME"
 exec 5>&2
 exec 2> >(tee _reportbug.stderr >&2)
 
-sudo journalctl --no-pager --full --utc --boot --output short-precise \
+sudo journalctl --no-pager --full --utc --output short-precise \
      > syslog.txt || true
 
 sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \


### PR DESCRIPTION
The problem makes logs analysis harder since previous boots are needed as well.
This may increase logfile size, but it is partially mitigated since
everything is archived.

Solution: remove --boot option from journalctl command

Signed-off-by: Andrei Zheregelia <andrei.zheregelia@seagate.com>