### PR TITLE
EOS-13678: Consul doesn't always invoke service watcher (cortx-1.0)

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -28,7 +28,7 @@ from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats, HaNote,
                        HaNoteStruct, HAState, MessageId, ObjT, ReprebStatus,
-                       StobIoqError)
+                       ServiceHealth, StobIoqError)
 from hax.util import ConsulUtil
 
 
@@ -169,7 +169,7 @@ class Motr:
         cns = ConsulUtil()
 
         def ha_obj_state(st):
-            return HaNoteStruct.M0_NC_ONLINE if st.status == 'online' \
+            return HaNoteStruct.M0_NC_ONLINE if st.status == ServiceHealth.OK \
                 else HaNoteStruct.M0_NC_FAILED
 
         notes = []
@@ -195,8 +195,9 @@ class Motr:
                               fid=fid)))
         if chp_event == 3:
             self.queue.put(
-                BroadcastHAStates(states=[HAState(fid=fid, status='offline')],
-                                  reply_to=None))
+                BroadcastHAStates(
+                    states=[HAState(fid=fid, status=ServiceHealth.FAILED)],
+                    reply_to=None))
 
     def _stob_ioq_event_cb(self, fid, sie_conf_sdev, sie_stob_id, sie_fd,
                            sie_opcode, sie_rc, sie_offset, sie_size,

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -23,6 +23,8 @@ from typing import Dict
 from hax.exception import NotDelivered
 from hax.types import HaLinkMessagePromise, MessageId
 
+LOG = logging.getLogger('hax')
+
 
 class DeliveryHerald:
     """
@@ -55,7 +57,7 @@ class DeliveryHerald:
             self.waiting_clients[promise] = condition
 
         with condition:
-            logging.debug('Blocking until %s is confirmed', promise)
+            LOG.debug('Blocking until %s is confirmed', promise)
             condition.wait(timeout=timeout_sec)
         with self.lock:
             del self.waiting_clients[promise]
@@ -63,8 +65,8 @@ class DeliveryHerald:
                 raise NotDelivered('None of message tags =' + str(promise) +
                                    '  were delivered to Motr within ' +
                                    str(timeout_sec) + ' seconds timeout')
-            logging.debug('Thread unblocked - %s has just been received',
-                          self.recently_delivered[promise])
+            LOG.debug('Thread unblocked - %s has just been received',
+                      self.recently_delivered[promise])
             del self.recently_delivered[promise]
 
     def notify_delivered(self, message_id: MessageId):
@@ -72,8 +74,8 @@ class DeliveryHerald:
         with self.lock:
             for promise, client in self.waiting_clients.items():
                 if message_id in promise:
-                    logging.debug('Found a waiting client for %s: %s',
-                                  message_id, promise)
+                    LOG.debug('Found a waiting client for %s: %s', message_id,
+                              promise)
                     with client:
                         client.notify()
                     self.recently_delivered[promise] = message_id

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -22,6 +22,8 @@ import os
 
 from hax.types import FidStruct, HaNoteStruct, Uint128Struct
 
+LOG = logging.getLogger('hax')
+
 py_func_proto = c.PYFUNCTYPE(None, c.c_void_p)
 
 
@@ -43,7 +45,7 @@ class HaxFFI:
     def __init__(self):
         dirname = os.path.dirname(os.path.abspath(__file__))
         lib_path = f'{dirname}/../../libhax.cpython-36m-x86_64-linux-gnu.so'
-        logging.debug('Loading library from path: %s', lib_path)
+        LOG.debug('Loading library from path: %s', lib_path)
         lib = c.cdll.LoadLibrary(lib_path)
         lib.init_motr_api.argtypes = [c.py_object, c.c_char_p]
         lib.init_motr_api.restype = c.c_void_p

--- a/hax/hax/queue/offset.py
+++ b/hax/hax/queue/offset.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from hax.util import ConsulKVBasic, repeat_if_fails
 
+LOG = logging.getLogger('hax')
+
 
 def get_key_by_node(prefix: str, node_name: str):
     return f'{prefix}/{node_name}'
@@ -26,7 +28,7 @@ class OffsetStorage:
     @repeat_if_fails()
     def mark_last_read(self, message_epoch: int) -> None:
         key = get_key_by_node(self.key_prefix, self.node_name)
-        logging.debug('Marking epoch %s as read', str(message_epoch))
+        LOG.debug('Marking epoch %s as read', str(message_epoch))
         self.kv.kv_put(key, str(message_epoch))
 
     @repeat_if_fails()
@@ -67,7 +69,7 @@ class InboxFilter:
             return (key, b_value.decode())
 
         offset = self.offset_mgr.get_last_read_epoch()
-        logging.debug('Last read epoch: %s', offset)
+        LOG.debug('Last read epoch: %s', offset)
         messages = [to_tuple(item) for item in raw_input]
         messages.sort(key=lambda x: x[0])
         return [x for x in messages if x[0] > offset]

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -26,54 +26,20 @@ from aiohttp import web
 from aiohttp.web import HTTPError, HTTPNotFound
 from aiohttp.web_response import json_response
 
-from hax.message import (BaseMessage, BroadcastHAStates, SnsDiskAttach,
-                         SnsDiskDetach, SnsRebalanceStop, SnsRebalancePause,
-                         SnsRebalanceResume, SnsRebalanceStart, SnsRepairStop,
-                         SnsRepairPause, SnsRepairResume, SnsRepairStart,
-                         SnsRebalanceStatus, SnsRepairStatus)
+from hax.message import (BaseMessage, SnsDiskAttach, SnsDiskDetach,
+                         SnsRebalancePause, SnsRebalanceResume,
+                         SnsRebalanceStart, SnsRebalanceStatus,
+                         SnsRebalanceStop, SnsRepairPause, SnsRepairResume,
+                         SnsRepairStart, SnsRepairStatus, SnsRepairStop)
 from hax.motr.delivery import DeliveryHerald
 from hax.queue import BQProcessor
 from hax.queue.offset import InboxFilter, OffsetStorage
-from hax.types import Fid, HAState, StoppableThread
-from hax.util import create_process_fid, dump_json, ConsulUtil
+from hax.types import Fid, StoppableThread
+from hax.util import ConsulUtil, dump_json
 
 
 async def hello_reply(request):
     return json_response(text="I'm alive! Sincerely, HaX")
-
-
-def to_ha_states(data: Any) -> List[HAState]:
-    """Converts a dictionary, obtained from JSON data, into a list of
-    HA states.
-
-    Format of an HA state: HAState(fid= <service fid>, status= <state>),
-    where <state> is either 'online' or 'offline'.
-    """
-    if not data:
-        return []
-
-    def get_status(checks: List[Dict[str, Any]]) -> str:
-        ok = all(x.get('Status') == 'passing' for x in checks)
-        return 'online' if ok else 'offline'
-
-    return [
-        HAState(fid=create_process_fid(int(t['Service']['ID'])),
-                status=get_status(t['Checks'])) for t in data
-    ]
-
-
-def process_ha_states(queue: Queue):
-    async def _process(request):
-        data = await request.json()
-
-        loop = asyncio.get_event_loop()
-        # Note that queue.put is potentially a blocking call
-        await loop.run_in_executor(
-            None, lambda: queue.put(
-                BroadcastHAStates(states=to_ha_states(data), reply_to=None)))
-        return web.Response()
-
-    return _process
 
 
 def process_sns_operation(queue: Queue):
@@ -120,8 +86,9 @@ def get_sns_status(motr_queue: Queue,
                                       Type[SnsRebalanceStatus]]):
     def fn(request):
         queue = Queue(1)
-        motr_queue.put(status_type(reply_to=queue,
-                                   fid=Fid.parse(request.query['pool_fid'])))
+        motr_queue.put(
+            status_type(reply_to=queue,
+                        fid=Fid.parse(request.query['pool_fid'])))
         return queue.get(timeout=10)
 
     async def _process(request):
@@ -200,7 +167,6 @@ def run_server(
     app = web.Application(middlewares=[encode_exception])
     app.add_routes([
         web.get('/', hello_reply),
-        web.post('/', process_ha_states(queue)),
         web.post('/watcher/bq',
                  process_bq_update(inbox_filter, BQProcessor(queue, herald))),
         web.post('/api/v1/sns/{operation}', process_sns_operation(queue)),

--- a/hax/hax/servicemon.py
+++ b/hax/hax/servicemon.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+from queue import Queue
+from threading import Event
+from typing import Dict, List
+
+from hax.exception import HAConsistencyException
+from hax.message import BroadcastHAStates
+from hax.types import HAState, ServiceHealth, StoppableThread
+from hax.util import ConsulUtil
+
+
+class ServiceMonitor(StoppableThread):
+    def __init__(self, queue: Queue, interval_sec=1):
+        super().__init__(target=self._execute, name='service-monitor')
+        self.stopped = False
+        self.consul = ConsulUtil()
+        self.interval_sec = interval_sec
+        self.event = Event()
+        self.q = queue
+
+    def stop(self) -> None:
+        logging.debug('Stop signal received')
+        self.stopped = True
+        self.event.set()
+
+    def _sleep(self, interval_sec) -> bool:
+        interrupted = self.event.wait(timeout=interval_sec)
+        return interrupted
+
+    def _get_services(self) -> List[str]:
+        services = self.consul.catalog_service_names()
+        excluded = {'consul'}
+        return [s for s in services if s not in excluded]
+
+    def _broadcast(self, state_list: List[HAState]) -> None:
+        if not state_list:
+            return
+        logging.debug('Changes in statuses: %s', state_list)
+        self.q.put(BroadcastHAStates(states=state_list, reply_to=None))
+
+    def _execute(self):
+        service_names: List[str] = self._get_services()
+        logging.debug('The following services will be monitored %s',
+                      service_names)
+        known_statuses: Dict[str, ServiceHealth] = {
+            service: ServiceHealth.UNKNOWN
+            for service in service_names
+        }
+        try:
+            while not self.stopped:
+                try:
+                    delta: List[HAState] = []
+
+                    for name in service_names:
+                        health: HAState = self.consul.get_local_service_health(
+                            name)
+                        if (health.status != known_statuses[name]):
+                            delta.append(health)
+                            known_statuses[name] = health.status
+                            logging.debug('%s is now %s', name, health.status)
+                    self._broadcast(delta)
+                except HAConsistencyException:
+                    # No action - we'll just try again at next iteration
+                    pass
+                self._sleep(self.interval_sec)
+        except Exception:
+            logging.exception('Aborting due to an error')
+        finally:
+            logging.debug('Thread exited')

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -210,7 +210,8 @@ class ServiceHealth(Enum):
     OK = 1
     UNKNOWN = 2
 
-    def __str__(self):
+    def __repr__(self):
+        """Return human-readable constant name (useful in log output)."""
         return self.name
 
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -117,7 +117,7 @@ class Fid:
         return self.container == 0 and self.key == 0
 
     def __repr__(self):
-        return f'{self.container:#x}:{self.key:#x}'
+        return f'0x{self.container:x}:0x{self.key:x}'
 
     def __eq__(self, other):
         return type(other) is Fid and \
@@ -166,8 +166,6 @@ ReprebStatus = NamedTuple('ReprebStatus', [('fid', Fid),
 
 HaNote = NamedTuple('HaNote', [('obj_t', str), ('note', HaNoteStruct)])
 
-HAState = NamedTuple('HAState', [('fid', Fid), ('status', str)])
-
 # struct m0_stob_id
 StobId = NamedTuple('StobId', [('domain_fid', Fid), ('fid', Fid)])
 
@@ -205,3 +203,15 @@ class HaLinkMessagePromise:
 
     def __repr__(self):
         return 'HaLinkMessagePromise' + str(self._ids)
+
+
+class ServiceHealth(Enum):
+    FAILED = 0
+    OK = 1
+    UNKNOWN = 2
+
+    def __str__(self):
+        return self.name
+
+
+HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -37,6 +37,8 @@ from hax.types import (ConfHaProcess, Fid, FsStatsWithTime, HAState, ObjT,
 
 __all__ = ['ConsulUtil', 'create_process_fid', 'create_drive_fid']
 
+LOG = logging.getLogger('hax')
+
 # XXX What is the difference between `ip_addr` and `address`?
 # The names are hard to discern.
 ServiceData = NamedTuple('ServiceData', [('node', str), ('fid', Fid),
@@ -102,21 +104,19 @@ def repeat_if_fails(wait_seconds=5, max_retries=-1):
             attempt_count = 0
             while (True):
                 try:
-                    logging.debug(
-                        'Attempting to invoke the repeatable call: %s',
-                        f.__name__)
+                    LOG.debug('Attempting to invoke the repeatable call: %s',
+                              f.__name__)
                     result = f(*args, **kwds)
-                    logging.debug('The repeatable call succeeded: %s',
-                                  f.__name__)
+                    LOG.debug('The repeatable call succeeded: %s', f.__name__)
                     return result
                 except HAConsistencyException as e:
                     attempt_count += 1
                     if max_retries >= 0 and attempt_count > max_retries:
-                        logging.warn(
+                        LOG.warn(
                             'Too many errors happened in a row '
                             '(max_retries = %d)', max_retries)
                         raise e
-                    logging.warn(
+                    LOG.warn(
                         f'Got HAConsistencyException: {e.message} '
                         f'(attempt {attempt_count}). The'
                         f' attempt will be repeated in {wait_seconds} seconds')
@@ -310,7 +310,7 @@ class ConsulUtil:
             try:
                 key = f'processes/{srv.fid}'
                 raw_data = self.kv.kv_get(key)
-                logging.debug('Raw value from KV: %s', raw_data)
+                LOG.debug('Raw value from KV: %s', raw_data)
                 data = raw_data['Value']
                 value: str = json.loads(data)['state']
                 return value
@@ -328,7 +328,7 @@ class ConsulUtil:
 
     def get_service_data_by_name(self, name: str) -> List[ServiceData]:
         services = self._catalog_service_get(name)
-        logging.debug('Services "%s" received: %s', name, services)
+        LOG.debug('Services "%s" received: %s', name, services)
         return list(map(mkServiceData, services))
 
     def get_confd_list(self) -> List[ServiceData]:
@@ -427,7 +427,7 @@ class ConsulUtil:
 
         data = json.dumps({'state': ha_process_events[event.chp_event]})
         key = f'processes/{event.fid}'
-        logging.debug('Setting process status in KV: %s:%s', key, data)
+        LOG.debug('Setting process status in KV: %s:%s', key, data)
         self.kv.kv_put(key, data)
 
     def drive_name_to_id(self, uid: str) -> str:
@@ -445,7 +445,7 @@ class ConsulUtil:
 
         data = json.dumps({'state': ha_conf_obj_states[objstate]})
         key = f'process/{fid}'
-        logging.debug('Setting disk state in KV: %s:%s', key, data)
+        LOG.debug('Setting disk state in KV: %s:%s', key, data)
         self.kv.kv_put(key, data)
 
     def get_local_service_health(self, service_name: str) -> HAState:

--- a/stubs/consul/__init__.pyi
+++ b/stubs/consul/__init__.pyi
@@ -15,7 +15,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-from typing import Any, Tuple, Dict, List
+from typing import Any, Tuple, Dict, List, Optional
 
 # This is a stub file for `python-consul` module so that mypy will be able
 # to validate the code leveraging the library.
@@ -35,43 +35,53 @@ class Health:
     def node(
         self,
         node: str,
-        index: int = None,
-        wait: str = None,
-        dc: str = None,
-        token: str = None,
+        index: Optional[int] = None,
+        wait: Optional[str] = None,
+        dc: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> Tuple[int, List[Dict[str, Any]]]: ...
+    def service(
+        self,
+        service: str,
+        index: Optional[int] = None,
+        wait: Optional[str] = None,
+        dc: Optional[str] = None,
+        near: Optional[str] = None,
+        token: Optional[str] = None,
+        node_meta: Optional[Dict[str, Any]] = None,
     ) -> Tuple[int, List[Dict[str, Any]]]: ...
 
 class Catalog:
     def nodes(
         self,
-        index: int = None,
-        wait: str = None,
-        consistency: str = None,
-        dc: str = None,
-        near: str = None,
-        token: str = None,
+        index: Optional[int] = None,
+        wait: Optional[str] = None,
+        consistency: Optional[str] = None,
+        dc: Optional[str] = None,
+        near: Optional[str] = None,
+        token: Optional[str] = None,
         node_meta: Dict[str, str] = None,
     ) -> Tuple[int, List[Dict[str, Any]]]: ...
     def service(
         self,
         service: str,
-        index: int = None,
-        wait: str = None,
-        tag: str = None,
-        consistency: str = None,
-        dc: str = None,
-        near: str = None,
-        token: str = None,
+        index: Optional[int] = None,
+        wait: Optional[str] = None,
+        tag: Optional[str] = None,
+        consistency: Optional[str] = None,
+        dc: Optional[str] = None,
+        near: Optional[str] = None,
+        token: Optional[str] = None,
     ) -> Tuple[int, List[Dict[str, Any]]]: ...
     def services(
         self,
-        index: int = None,
-        wait: str = None,
-        tag: str = None,
-        consistency: str = None,
-        dc: str = None,
-        near: str = None,
-        token: str = None,
+        index: Optional[int] = None,
+        wait: Optional[str] = None,
+        tag: Optional[str] = None,
+        consistency: Optional[str] = None,
+        dc: Optional[str] = None,
+        near: Optional[str] = None,
+        token: Optional[str] = None,
     ) -> Tuple[int, Dict[str, List[Any]]]: ...
 
 class Agent:
@@ -81,34 +91,34 @@ class KV:
     def get(
         self,
         key: str,
-        index: int = None,
-        recurse: bool = False,
-        wait: str = None,
-        token: str = None,
-        keys: bool = False,
-        separator: str = None,
-        dc: str = None,
+        index: Optional[int] = None,
+        recurse: Optional[bool] = False,
+        wait: Optional[str] = None,
+        token: Optional[str] = None,
+        keys: Optional[bool] = False,
+        separator: Optional[str] = None,
+        dc: Optional[str] = None,
     ) -> Tuple[int, Any]: ...
     def put(
         self,
         key: str,
         value: str,
-        cas: int = None,
-        flags: int = None,
-        acquire: str = None,
-        release: str = None,
-        token: str = None,
-        dc: str = None,
+        cas: Optional[int] = None,
+        flags: Optional[int] = None,
+        acquire: Optional[str] = None,
+        release: Optional[str] = None,
+        token: Optional[str] = None,
+        dc: Optional[str] = None,
     ) -> bool: ...
 
 class Session:
     def info(
         self,
         session_id: str,
-        index: int = None,
-        wait: str = None,
-        consistency: str = None,
-        dc: str = None,
+        index: Optional[int] = None,
+        wait: Optional[str] = None,
+        consistency: Optional[str] = None,
+        dc: Optional[str] = None,
     ) -> Tuple[int, Any]: ...
 
 class ConsulException(Exception): ...

--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -2,16 +2,6 @@
   "enable_local_script_checks": true,
   "watches": [
     {
-      "type": "service",
-      "service": "ios",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:8008",
-        "method": "POST",
-        "timeout": "10s"
-      }
-    },
-    {
       "type": "keyprefix",
       "prefix": "bq/",
       "handler_type": "http",
@@ -25,16 +15,6 @@
       "type": "service",
       "service": "ios",
       "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
-    },
-    {
-      "type": "service",
-      "service": "s3service",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:8008",
-        "method": "POST",
-        "timeout": "10s"
-      }
     },
     {
       "type": "service",

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -20,42 +20,12 @@
     {
       "type": "service",
       "service": "confd",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:8008",
-        "method": "POST",
-        "timeout": "10s"
-      }
-    },
-    {
-      "type": "service",
-      "service": "confd",
       "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
     },
     {
       "type": "service",
       "service": "ios",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:8008",
-        "method": "POST",
-        "timeout": "10s"
-      }
-    },
-    {
-      "type": "service",
-      "service": "ios",
       "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
-    },
-    {
-      "type": "service",
-      "service": "s3service",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:8008",
-        "method": "POST",
-        "timeout": "10s"
-      }
     },
     {
       "type": "service",


### PR DESCRIPTION
The issue is caused by this Consul bug reported by @andriytk this winter: https://github.com/hashicorp/consul/issues/7069

The main problem with these delayed service watch handler invocations is that sometimes hax can broadcast (erroneously) a Motr service state as M0_NC_FAILED while the service is actually up and running. Such a broadcast will force all Motr processes and services to disconnect that service that will cause to bigger problems (as listed in https://jts.seagate.com/browse/EOS-13678)

Workaround: don't rely on watch mechanism. Instead, poll the service health status directly from Consul via Health API.


Note: This PR repeats https://github.com/Seagate/cortx-hare/pull/1348 for cortx-1.0 branch