### PR TITLE
Problem: Rule for drive failure event is broken

### DIFF
--- a/hax/hax/queue/__init__.py
+++ b/hax/hax/queue/__init__.py
@@ -86,11 +86,13 @@ class BQProcessor:
         ids: List[MessageId] = q.get()
         self.herald.wait_for_any(HaLinkMessagePromise(ids))
 
-    def to_ha_state(self, objinfo: dict) -> Optional[HAState]:
+    def to_ha_state(self, objinfo: Dict[str, str]) -> Optional[HAState]:
         try:
             sdev_fid = self.confobjutil.drive_to_sdev_fid(
                 objinfo['node'], objinfo['device'])
+            state = ServiceHealth.OK if objinfo[
+                'state'] == 'online' else ServiceHealth.FAILED
         except KeyError as error:
             LOG.error('Invalid json payload, no key (%s) present', error)
             return None
-        return HAState(sdev_fid, status=objinfo['state'])
+        return HAState(sdev_fid, status=state)


### PR DESCRIPTION
**Note: for main branch only**

The fix with service health polling brought a regression (due to the
lack of typing in Python code).

HAState.status field changed its type: str -> ServiceHealth but the code
in drive failure event processing didn't reflect that change.

Solution:
1. Improve type hints in drive failure event processing logic (so that
the problem becomes obvious)
2. Fix the code.

Notes: cortx-1.0 branch doesn't have this problem (I saw it and resolved while resolving the merge conflicts in https://github.com/Seagate/cortx-hare/pull/1350). So this change is needed for main branch only.