### PR TITLE
EOS-13263: Hare utility to mask features and logrotate configuration is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,12 +142,13 @@ CFGEN_SHARE        = $(DESTDIR)/$(PREFIX)/share/cfgen
 CONSUL_LIBEXEC     = $(DESTDIR)/$(PREFIX)/libexec/consul
 CONSUL_SHARE       = $(DESTDIR)/$(PREFIX)/share/consul
 HARE_CONF          = $(DESTDIR)/$(PREFIX)/conf
+HARE_CONF_LOG      = $(DESTDIR)/$(PREFIX)/conf/logrotate
 HARE_LIBEXEC       = $(DESTDIR)/$(PREFIX)/libexec
 HARE_RULES         = $(DESTDIR)/$(PREFIX)/rules
 HAX_EXE            = $(DESTDIR)/$(PREFIX)/bin/hax
 HAX_EGG_LINK       = $(DESTDIR)/$(PREFIX)/lib/python3.$(PY3_VERSION_MINOR)/site-packages/hax.egg-link
 SYSTEMD_CONFIG_DIR = $(DESTDIR)/usr/lib/systemd/system
-LOGROTATE_CONF_DIR = $(DESTDIR)/etc/logrotate.d
+ETC_CRON_DIR       = /etc/cron.hourly
 
 # dhall-bin {{{2
 vendor/dhall-bin/$(DHALL_VERSION)/dhall-$(DHALL_VERSION)-x86_64-linux.tar.bz2:
@@ -204,17 +205,12 @@ unpack-dhall-prelude: fetch-dhall-prelude
 
 # install {{{2
 .PHONY: install
-install: install-dirs install-cfgen install-hax install-systemd install-vendor
+install: install-dirs install-cfgen install-hax install-systemd install-vendor install-provisioning
 	@$(call _info,Installing hare utils)
 	@for f in utils/*; do \
 	     $(call _log,copying $$f -> $(HARE_LIBEXEC)); \
 	     install $$f $(HARE_LIBEXEC); \
 	 done
-	@$(call _info,Installing hare provisioning)
-	@$(call _log,copying setup.yaml -> $(HARE_CONF))
-	@install provisioning/setup.yaml $(HARE_CONF)
-	@$(call _log,copying hare-logrotate -> $(LOGROTATE_CONF_DIR))
-	@install --mode=0644 provisioning/hare-logrotate $(LOGROTATE_CONF_DIR)
 	@$(call _info,Installing RC rules)
 	@for f in rules/*; do \
 	     $(call _log,copying $$f -> $(HARE_RULES)); \
@@ -229,10 +225,13 @@ install: install-dirs install-cfgen install-hax install-systemd install-vendor
 	@install utils/h0q $(DESTDIR)/$(PREFIX)/bin
 	@$(call _log,linking h0q -> $(DESTDIR)/usr/bin)
 	@ln -sf /$(PREFIX)/bin/h0q $(DESTDIR)/usr/bin
+	@$(call _log,copying m0trace-prune -> $(ETC_CRON_DIR))
+	@install utils/m0trace-prune $(ETC_CRON_DIR)
 
 .PHONY: install-dirs
 install-dirs:
 	@for d in $(HARE_CONF) \
+		  $(HARE_CONF_LOG) \
 		  $(HARE_LIBEXEC) \
 		  $(HARE_RULES) \
 		  $(DESTDIR)/run/cortx \
@@ -294,9 +293,22 @@ install-vendor:
 	@install --verbose --directory $(DESTDIR)/$(PREFIX)/bin
 	@install --verbose $(wildcard vendor/dhall-bin/current/*) $(DESTDIR)/$(PREFIX)/bin
 
+.PHONY: install-provisioning
+install-provisioning:
+	@$(call _info,Installing hare provisioning)
+	@for f in provisioning/*; do \
+	     $(call _log,copying $$f -> $(HARE_CONF)); \
+	     install $$f $(HARE_CONF); \
+	 done
+	@$(call _info,Installing hare provisioning/logrotate)
+	@for f in provisioning/logrotate/*; do \
+	     $(call _log,copying $$f -> $(HARE_CONF_LOG)); \
+	     install $$f $(HARE_CONF_LOG); \
+	 done
+
 # devinstall {{{2
 .PHONY: devinstall
-devinstall: install-dirs devinstall-cfgen devinstall-hax devinstall-systemd devinstall-vendor
+devinstall: install-dirs devinstall-cfgen devinstall-hax devinstall-systemd devinstall-vendor devinstall-provisioning
 	@$(call _info,linking hare utils)
 	@for f in utils/*; do \
 	     $(call _log,linking $$f -> $(HARE_LIBEXEC)); \
@@ -319,6 +331,8 @@ devinstall: install-dirs devinstall-cfgen devinstall-hax devinstall-systemd devi
 	@$(call _log,changing permission of $(DESTDIR)/var/lib/hare)
 	@chgrp hare $(DESTDIR)/var/lib/hare
 	@chmod --changes g+w $(DESTDIR)/var/lib/hare
+	@$(call _log,copying m0trace-prune -> $(ETC_CRON_DIR))
+	@install utils/m0trace-prune $(ETC_CRON_DIR)
 
 .PHONY: devinstall-cfgen
 devinstall-cfgen: CFGEN_INSTALL_CMD = ln -sf
@@ -362,6 +376,19 @@ devinstall-vendor:
 	@$(call _info,Installing Dhall)
 	@install --verbose --directory $(DESTDIR)/$(PREFIX)/bin
 	@ln -v -sf $(addprefix $(TOP_SRC_DIR), $(wildcard vendor/dhall-bin/current/*)) $(DESTDIR)/$(PREFIX)/bin
+
+.PHONY: devinstall-provisioning
+devinstall-provisioning:
+	@$(call _info,Installing hare provisioning)
+	@for f in provisioning/*; do \
+	     $(call _log,copying $$f -> $(HARE_CONF)); \
+	     install $$f $(HARE_CONF); \
+	 done
+	@$(call _info,Installing hare provisioning/logrotate)
+	@for f in provisioning/logrotate/*; do \
+	     $(call _log,copying $$f -> $(HARE_CONF_LOG)); \
+	     install $$f $(HARE_CONF_LOG); \
+	 done
 
 # Uninstall ------------------------------------------- {{{1
 #

--- a/provisioning/logrotate/virtual
+++ b/provisioning/logrotate/virtual
@@ -1,0 +1,9 @@
+/var/log/hare/*.log
+{
+    rotate 10
+    maxsize 50M
+    weekly
+    compress
+    missingok
+    copytruncate
+}

--- a/provisioning/setup.py
+++ b/provisioning/setup.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
+# report unsupported features, etc.
+
+import argparse
+import asyncio
+import json
+import logging
+import shutil
+import subprocess
+
+from eos.utils.product_features import unsupported_features
+
+
+def get_data_from_provisioner_cli(method, output_format='json') -> str:
+    try:
+        process = subprocess.run(['provisioner', method, f'--out={output_format}'],
+                                 check=True,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 shell=False)
+        stdout = process.stdout
+        rc = process.returncode
+    except Exception as e:
+        logging.error('Failed to fetch data from provisioner (%s)', e)
+        return 'unknown'
+    if rc != 0:
+        return 'unknown'
+    res = stdout.decode('utf-8')
+    return json.loads(res)['ret'] if res else 'unknown'
+
+
+def logrotate_config():
+    try:
+        setup_info = get_data_from_provisioner_cli('get_setup_info')
+        if setup_info != 'unknown':
+            server_type = setup_info['server_type']
+            shutil.copyfile(f'/opt/seagate/cortx/hare/conf/logrotate/{server_type}',
+                            '/etc/logrotate.d/hare')
+    except Exception as error:
+        logging.error('Error setting logrotate values for hare (%s)', error)
+
+
+def _report_unsupported_features(features_unavailable):
+    uf_db = unsupported_features.UnsupportedFeaturesDB()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(uf_db.store_unsupported_features('hare',
+                            features_unavailable))
+
+
+class UnsupportedFeatures(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            features_unavailable = []
+            path = '/opt/seagate/cortx/hare/conf/setup_info.json'
+            with open(path) as hare_features_info:
+                hare_unavailable_features = json.load(hare_features_info)
+                setup_info = get_data_from_provisioner_cli('get_setup_info')
+                if setup_info != 'unknown':
+                    for setup in hare_unavailable_features['setup_types']:
+                        if setup['name'] == setup_info['server_type']:
+                            features_unavailable.extend(
+                                setup['unsupported_features'])
+                            _report_unsupported_features(features_unavailable)
+        except Exception as error:
+            logging.error('Error reporting hare unsupported features (%s)',
+                          error)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description='Configure hare settings')
+    p.add_argument('--report-unavailable-features',
+                   nargs=0,
+                   help='Report unsupported features according to setup type',
+                   action=UnsupportedFeatures)
+    p.parse_args(argv)
+    logrotate_config()
+
+
+if __name__ == '__main__':
+    main()

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -1,7 +1,7 @@
 hare:
   post_install:
-    script: null
-    args: null
+    script: /opt/seagate/cortx/hare/conf/setup.py
+    args: --report-unavailable-features
   init:
     script: null
     args: null

--- a/provisioning/setup_info.json
+++ b/provisioning/setup_info.json
@@ -1,0 +1,20 @@
+{
+    "setup_types": [
+        {
+            "name":"virtual",
+            "unsupported_features": ["hctl_node"]
+        },
+        {
+            "name":"5u84",
+            "unsupported_features": []
+        },
+        {
+            "name":"PODS",
+            "unsupported_features": []
+        },
+        {
+            "name":"JBOD",
+            "unsupported_features": ["hctl_node"]
+        }
+    ]
+}

--- a/utils/m0trace-prune
+++ b/utils/m0trace-prune
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -eu -o pipefail
+# set -x
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+
+PROG=${0##*/}
+
+usage() {
+cat <<EOF
+Usage: $PROG [<option>]
+
+Prune Hax m0trace files.
+
+Options:
+    -n <nr files> Max number of m0trace files to retain.
+    -h, --help    Display help and exit.
+EOF
+}
+
+TEMP=$(getopt --options hn: \
+              --longoptions help \
+              --name "$PROG" -- "$@" || true)
+
+(($? == 0)) || { usage >&2; exit 1; }
+
+eval set -- "$TEMP"
+
+declare -A default_nr_files_to_prune=(
+    [virtual]=2
+    [physical]=5
+)
+
+max_files_to_retain=
+while true; do
+    case "$1" in
+        -h|--help)   usage; exit ;;
+        -n)          max_files_to_retain=$2; shift 2 ;;
+        --)          shift; break ;;
+        *)           break ;;
+    esac
+done
+
+hax_m0_dir=/var/motr/hax
+get_max_files_by_platform() {
+    if [[ $(systemd-detect-virt) = none ]]; then
+        echo ${default_nr_files_to_prune[physical]}
+    else
+        echo ${default_nr_files_to_prune[virtual]}
+    fi
+}
+
+max_files_to_retain=${max_files_to_retain:-$(get_max_files_by_platform)}
+
+total_m0trace_files=$(find $hax_m0_dir -maxdepth 1 -type f -name "m0trace.*" | wc -l)
+echo "$total_m0trace_files present, $max_files_to_retain to be retained"
+if (( $total_m0trace_files > $max_files_to_retain )); then
+    nr_files_to_prune=$(( $total_m0trace_files - $max_files_to_retain ))
+    echo "Pruning $nr_files_to_prune from $total_m0trace_files"
+    files_to_prune=`ls -tr $hax_m0_dir | grep m0trace | head -n -$max_files_to_retain`
+    for file in $files_to_prune; do
+        echo "Removing $hax_m0_dir/$file"
+        rm -f $hax_m0_dir/$file
+    done
+fi


### PR DESCRIPTION
- CSM requires Hare to report any unavailable features based on the
   installation type.
- Logrotate settings for hare logs must be configured based on the given installation
   type. Such a utility is missing in hare.
- Cron job for pruning hax m0trace files is also missing based on the installation
   type.

Solution:
    - Add a utility to accept options for configuring logrotate and to report
    masked features based on the installation type fetched from the provisioner.
    Sample provisioner installation information,
    ```
    {
    "ret": {
    "nodes": 1,
    "server_type": "physical",
    "servers_per_node": 2,
    "storage_type": "5u84"
    }
    }
    ```
    - Add a cron job script to prune /var/motr/hax/m0trace.* files based on the
      installation type (virtual or physical).