### PR TITLE
Problem: service-monitor thread can exit early if Consul fails

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -239,6 +239,13 @@ class ConsulUtil:
             raise HAConsistencyException('Failed to communicate '
                                          'to Consul Agent') from e
 
+    def _get_service_health(self, service_name: str) -> List[Dict[str, Any]]:
+        try:
+            return self.cns.health.service(service_name)[1]
+        except (ConsulException, HTTPError, RequestException) as e:
+            raise HAConsistencyException('Failed to communicate '
+                                         'to Consul Agent') from e
+
     def _local_service_by_name(self, name: str) -> Dict[str, Any]:
         """
         Returns the service data by its name assuming that it runs at the same
@@ -512,7 +519,7 @@ class ConsulUtil:
     def get_local_service_health(self, service_name: str) -> HAState:
         local_nodename = self.get_local_nodename()
         srv_data: List[Dict[str,
-                            Any]] = self.cns.health.service(service_name)[1]
+                            Any]] = self._get_service_health(service_name)
         local_services = [
             srv for srv in srv_data if srv['Node']['Node'] == local_nodename
         ]


### PR DESCRIPTION
At HW logs I saw the following error stacktrace (when Consul became
unavailable):

```
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: 2020-10-08 07:27:49,152 [ERROR] {service-monitor} Aborting due to an error
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: Traceback (most recent call last):
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: File "/opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/servicemon.py", line 94, in _execute
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: name)
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: File "/opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/util.py", line 454, in get_local_service_health
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: Any]] = self.cns.health.service(service_name)[1]
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/consul/base.py", line 1537, in service
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: params=params)
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/consul/std.py", line 22, in get
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: self.session.get(uri, verify=self.verify, cert=self.cert)))
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/consul/base.py", line 223, in cb
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: CB._status(response, allow_404=allow_404)
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/consul/base.py", line 188, in _status
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: raise ConsulException("%d %s" % (response.code, response.body))
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: consul.base.ConsulException: 500 rpc error making call: EOF
Oct 08 07:27:49 inteln13-m07.colo.seagate.com hare-hax[140861]: 2020-10-08 07:27:49,153 [DEBUG] {service-monitor} Thread exited
```

The problem cause is that servicemon communicates to
cns.health.service() and that call has no specific try-catch block that
would raise HAConsistencyException (like it is already done to other
Consul communication calls).

Solution: wrap the code with proper try-catch block, raise
HAConsistencyException to adhere common practice of intermittent errors
processing.