### PR TITLE
EOS-14115: fix ha-notifications race during bootstrap #1363

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -200,7 +200,7 @@ wait_m0mkfs_done() {
     # (see utils/check-service also).
     while [[ -f /tmp/motr-mkfs-pass-$fid ||
              -f /tmp/motr-mkfs-fail-$fid ||
-             $(get-service-health $id) != 'warning' ]]; do
+             $(get-service-health $id) == 'passing' ]]; do
         sleep 1
     done
     # Give hax a chance to get the warning/offline state from Consul

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -187,19 +187,32 @@ case $phase in
        ;;
 esac
 
+# It's critical to check for the service state in Consul catalogue.
+# Otherwise, if synchronisation of service status between Consul
+# servers delays (for some reason), hax may get 'offline' state from
+# Consul for already started m0d process (spoiling its ha_link).
+wait_m0mkfs_done() {
+    local id=$1
+    local fid=$(id2fid $id)
+
+    touch /tmp/motr-mkfs-pass-$fid
+    # Give time for service check to reset m0mkfs' HA state
+    # (see utils/check-service also).
+    while [[ -f /tmp/motr-mkfs-pass-$fid ||
+             -f /tmp/motr-mkfs-fail-$fid ||
+             $(get-service-health $id) != 'warning' ]]; do
+        sleep 1
+    done
+    # Give hax a chance to get the warning/offline state from Consul
+    # and finish ha_link before m0d process is started.
+    sleep 2
+}
+
 for id in $IDs; do
     fid=$(id2fid $id)
     if [[ $do_mkfs ]]; then
         sudo systemctl start motr-mkfs@$fid
-        touch /tmp/motr-mkfs-pass-$fid
-        # Give time for service check to reset m0mkfs' HA state
-        # (see utils/check-service also).
-        while [[ -f /tmp/motr-mkfs-pass-$fid ||
-                 -f /tmp/motr-mkfs-fail-$fid ]] ||
-              [[ $(get-process-state $fid) != M0_CONF_HA_PROCESS_STOPPED ]]; do
-            sleep 1
-        done
-        sleep 1
+        wait_m0mkfs_done $id
     fi
 
     if [[ $do_mkfs != 'mkfs-only' ]]; then

--- a/utils/check-service
+++ b/utils/check-service
@@ -75,6 +75,13 @@ declare -A status=(
     [failing]=2
 )
 
+fid2id() {
+    echo $((16#${1/*:0x/}))
+}
+
+# During bootstrap with m0mkfs we need to report passing and
+# warning (offline) status for m0mkfs process to make sure
+# its ha_link is destroyed before m0d process is started.
 if [[ $service =~ m0d ]]; then
     pass=/tmp/motr-mkfs-pass-$fid
     fail=/tmp/motr-mkfs-fail-$fid
@@ -84,6 +91,12 @@ if [[ $service =~ m0d ]]; then
         touch $fail
         exit ${status[passing]}
     elif [[ -f $fail ]]; then
+        id=$(fid2id $fid)
+        if [[ $(get-service-health $id) != 'passing' ]]; then
+            # The passing/online state is still not synchronized among
+            # Consul servers, don't change it just yet...
+            exit ${status[passing]}
+        fi
         rm $fail
         exit ${status[warning]}
     fi

--- a/utils/get-service-health
+++ b/utils/get-service-health
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -eu -o pipefail
+
+PROG=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: $PROG ID
+
+Get service health status from Consul catalogue.
+
+Options:
+  -h, --help    Show this help and exit.
+
+Examples:
+
+    \$ $PROG 9
+    passed
+EOF
+}
+
+if (($# != 1)); then
+    usage >&2
+    exit 1
+fi
+
+case $1 in
+    -h|--help) usage; exit;;
+esac
+
+id=$1
+curl -Gs localhost:8500/v1/health/node/$(node-name) \
+    --data-urlencode "filter=CheckID == \"service:$id\"" |
+    jq -r '.[].Status'

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -335,7 +335,6 @@ say 'Installing Motr configuration files...'
 while read node _; do
     scp -q $conf_dir/confd.xc $node:$conf_dir
 done < <(get_server_nodes | grep -vw $(node-name) || true)
-echo ' OK'
 
 say 'Waiting for the RC Leader to get elected...'
 wait_rc_leader


### PR DESCRIPTION
During cluster bootstrap with --mkfs option, it is possible
that ha-online notification from Consul about the Motr service
when its m0mkfs process is started will not manage to change
to ha-offline after m0mkfs process has finished. Instead, it
may come after the correspondent m0d process is started already.
This will cause hax to close the ha_link to the newly started
m0d process, so the process would panic:

```
Jan 03 13:02:01.356617 hare64648-build-ssu1 mero-server[5124]: Mero panic: !rep->hae_disconnected_previously at ha_entrypoint_state_cb() ha/ha.c:308 (errno: 0) (last failed: none) [git: 8d44b0a8a] pid: 5124  /var/mero/m0d-0x7200000000000001:0xc/m0trace.5124
Jan 03 13:02:01.356949 hare64648-build-ssu1 mero-server[5124]: Mero panic reason: HA has already decided that this process has failed. There is no good reason to continue doing something, and there is no code yet to handle graceful shutdown in this case. Let's just terminate the process and let HA do it's job.
```

The problem is with how we determine when to start m0d process
after m0mkfs: instead of checking that m0mkfs process is stopped
locally on the node, we should check the service state in Consul
catalogue. Because the ha-state update (which affects ha_link)
happens (via hax) only when the service state is changed in Consul
catalogue. And such a change might be delayed until Consul
synchronises it with all its servers in the cluster.

Solution: check the service state in Consul catalogue and make
sure it became offline before starting m0d process.

This is the same as PR of #1363 but to the cortx-1.0 branch.