### PR TITLE
Problem: rpm build fails due to wrong logrotate file in hare.spec

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -77,7 +77,7 @@ rm -rf %{buildroot}
 %{_sharedstatedir}/hare/
 %{_localstatedir}/motr/hax/
 /opt/seagate/cortx/hare/*
-/etc/logrotate.d/hare-logrotate
+/etc/logrotate.d/hare
 
 %post
 systemctl daemon-reload


### PR DESCRIPTION
Hare logrotate file is copied as /etc/logrotate.d/hare by setup.py but
hare.spec is referring to /etc/logrotate.d/hare_logrotate.

Solution:
Fix hare logrotate file name in hare.spec from /etc/logrotate.d/hare_logrotate
to /etc/logrotate.d/hare