### PR TITLE
README: add export when setting M0_SRC_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ and health-checking mechanisms.
     scripts/m0 make
     sudo scripts/install-motr-service --link
 
-    M0_SRC_DIR=$PWD
+    export M0_SRC_DIR=$PWD
     cd -
     ```
 


### PR DESCRIPTION
It's not enough to set M0_SRC_DIR, we need to export it also.