### PR TITLE
Problem: `hctl status` output isn't part of `hctl reportbug` bundle

### DIFF
--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -85,6 +85,10 @@ sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
 sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
      > systemctl-status.txt || true
 
+# cluster status
+sudo timeout --kill-after 30 15 hctl status \
+     > hctl-status.txt || true
+
 extra_files=(
     /etc/sysconfig/motr
     /opt/seagate/cortx-prvsnr/pillar/components/cluster.sls


### PR DESCRIPTION
Solution: include `hctl status` output into `hctl reportbug` bundle.
Limit max execution time of `hctl status` command to 30 seconds in case
it hangs.