### PR TITLE
Problem: rpm build for hare main branch fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ HARE_RULES         = $(DESTDIR)/$(PREFIX)/rules
 HAX_EXE            = $(DESTDIR)/$(PREFIX)/bin/hax
 HAX_EGG_LINK       = $(DESTDIR)/$(PREFIX)/lib/python3.$(PY3_VERSION_MINOR)/site-packages/hax.egg-link
 SYSTEMD_CONFIG_DIR = $(DESTDIR)/usr/lib/systemd/system
+LOGROTATE_CONF_DIR = $(DESTDIR)/etc/logrotate.d
 ETC_CRON_DIR       = /etc/cron.hourly
 
 # dhall-bin {{{2
@@ -305,6 +306,8 @@ install-provisioning:
 	     $(call _log,copying $$f -> $(HARE_CONF_LOG)); \
 	     install $$f $(HARE_CONF_LOG); \
 	 done
+	@$(call _log,copying provisioning/logrotate/hare -> $(LOGROTATE_CONF_DIR))
+	@install --mode=0644 provisioning/logrotate/hare $(LOGROTATE_CONF_DIR)
 
 # devinstall {{{2
 .PHONY: devinstall

--- a/provisioning/logrotate/hare
+++ b/provisioning/logrotate/hare
@@ -1,0 +1,9 @@
+/var/log/hare/*.log
+{
+    rotate 10
+    maxsize 50M
+    weekly
+    compress
+    missingok
+    copytruncate
+}


### PR DESCRIPTION
Hare logrotate configuration is supposed to be installed at
/etc/logrotate.d/hare as part of rpm build but the installation
code is missing from the Makefile. This was added as part of
the commit `0cd9cb4` but was removed by `3483beb` as the logrotate
configuration is required to be installed as per the installation type
(i.e. virtual or physical) using hare setup.py utility as part of
the provisioning. But this is breaking the rpm build presently.

Solution:
Restore /etc/logrotate.d/hare installation logic in Makefile and
install a default logrotate configuration ($HARE_SRC/provisioning/
logrotate/hare) for hare before setup.py utility is invoked to
update it as per the installation type.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>