### PR TITLE
Problem: multiple SNS pools are not supported

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional, \
 import yaml
 
 
-__version__ = '0.12.2'
+__version__ = '0.13'
 
 
 def parse_opts(argv):
@@ -90,6 +90,9 @@ pools:
   - name: <str>
     type: sns|dix|md   # optional, defaults to "sns";
                        # "sns" - data pool, "dix" - KV, "md" - meta-data pool.
+    disk_refs:  # optional section
+      - path: <str>  # io_disks.data value
+        node: <str>  # optional; 'hostname' of the corresponding node
     data_units: <int>
     parity_units: <int>
     allowed_failures:  # optional section; no failures will be allowed
@@ -100,6 +103,15 @@ pools:
       encl: <int>
       ctrl: <int>
       disk: <int>
+
+# Profile is a reference to pools.  When Motr client is started, it receives
+# profile fid from the command line.  Motr client can only use the pools
+# referred to by its profile.
+#
+profiles:  # This section is optional.  If it is missing, a single "default"
+           # profile referring to all pools will be created.
+  - name: <str>
+    pools: [ <str> ]
 ...  # end of the document (optional)""")
         sys.exit()
 
@@ -209,13 +221,24 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
             m0d.setdefault('runs_confd', False)
             m0d['_io_disks'] = get_disks(node['hostname'], mock_p,
                                          m0d['io_disks']['data'])
+    if 'profiles' not in desc:
+        sns_pools = [pool['name'] for pool in desc['pools']
+                     if pool_type(pool) is PoolT.sns]
+        desc['profiles'] = [{'name': 'default', 'pools': sns_pools}]
 
 
 def validate_cluster_desc(desc: Dict[str, Any]) -> None:
+    validate_nodes_desc(desc['nodes'])
+    validate_pools_desc(desc['pools'])
+    if 'profiles' in desc:
+        validate_profiles_desc(desc['profiles'], desc['pools'])
+
+
+def validate_nodes_desc(nodes_desc: List[Dict[str, Any]]) -> None:
     Node = NamedTuple('Node', [('name', str), ('ipaddr', str)])
     nodes = [Node(name=x['hostname'],
                   ipaddr=x['facts'][ipaddr_key(x['data_iface'])])
-             for x in desc['nodes']]
+             for x in nodes_desc]
     assert all_unique(x.name for x in nodes), \
         "Node names ('hostname' values in the CDF) are not unique:\n" + \
         '\n'.join('  ' + x.name for x in nodes)
@@ -225,7 +248,7 @@ def validate_cluster_desc(desc: Dict[str, Any]) -> None:
 
     total_nr_confds = total_nr_disks = 0
 
-    for node in desc['nodes']:
+    for node in nodes_desc:
         name = node['hostname']
         assert name
         iface = node['data_iface']
@@ -254,7 +277,7 @@ Make sure the value of data_iface in the CDF is correct."""
         for m0d in node['m0_servers']:
             disks.extend(m0d['_io_disks'])
         assert all_unique(disks), \
-            f'{name}: Same disk used by several IO services'
+            f'{name}: The same disk is used by several IO services'
         total_nr_disks += len(disks)
 
         assert (nr_confds + node['m0_clients']['s3']
@@ -264,11 +287,19 @@ Make sure the value of data_iface in the CDF is correct."""
     assert total_nr_confds > 0, 'At least one confd is required'
     assert total_nr_disks > 0, 'No disks found'
 
-    pool_types = set()
-    for pool in desc['pools']:
+
+def validate_pools_desc(pools_desc: List[Dict[str, Any]]) -> None:
+    pool_names = [x['name'] for x in pools_desc]
+    assert all_unique(pool_names), \
+        'Pool names are not unique:\n' + \
+        '\n'.join('  ' + x for x in pool_names)
+    assert all(s for s in pool_names), 'Pool name must not be empty'
+
+    pool_types: Set[PoolT] = set()
+    for pool in pools_desc:
         name = pool['name']
-        t = pool.get('type', 'sns')
-        if t == 'sns':
+        t = pool_type(pool)
+        if t is PoolT.sns:
             d = pool.get('allowed_failures')
             assert d is None or d['disk'] <= pool['parity_units'], """\
 {}: Cannot allow that many disk failures ({})
@@ -282,8 +313,65 @@ Pools of {t!r} type can only have 1 data unit."""
             assert t not in pool_types, \
                 f'{name}: No more than one {t!r} pool can be defined'
         pool_types.add(t)
-    assert 'sns' in pool_types, \
+
+        if 'disk_refs' not in pool:
+            continue
+
+        # XXX Do we want to support disk_refs for DIX and MD pools as well?
+        assert t is PoolT.sns, \
+            f"{name}: disk_refs are only supported for pools of 'sns' type"
+        disk_refs = pool['disk_refs']
+        assert disk_refs, \
+            f'Pool {name!r}: disk_refs must not be empty' \
+            ' (it can be omitted though)'
+        assert all_unique(repr(x) for x in disk_refs), \
+            f'Pool {name!r}: disk_refs must be unique'
+
+    assert PoolT.sns in pool_types, \
         "At least one pool of 'sns' type must be defined"
+
+    sns_pools = [pool for pool in pools_desc if pool_type(pool) is PoolT.sns]
+    unrestricted = [pool['name'] for pool in sns_pools
+                    if 'disk_refs' not in pool]
+    assert len(unrestricted) <= 1, """\
+These pools compete for disks: {}
+Leave only one of them or allot disks using disk_refs""".format(
+        ', '.join(unrestricted))
+    assert any('disk_refs' in pool for pool in sns_pools) == \
+        (not unrestricted), \
+        "'sns' pools with and without disk_refs cannot be used together"
+
+
+def validate_profiles_desc(profiles_desc: List[Dict[str, Any]],
+                           pools_desc: List[Dict[str, Any]]) -> None:
+    assert profiles_desc, \
+        'List of profiles must not be empty (it can be omitted though)'
+    assert all_unique(x['name'] for x in profiles_desc), \
+        'Profile names are not unique:\n' + \
+        '\n'.join('  ' + x['name'] for x in profiles_desc)
+    assert all(x['name'] for x in profiles_desc), \
+        'Profile name must not be empty'
+
+    Pool = NamedTuple('Pool', [('name', str), ('type', PoolT)])
+    all_pools = [Pool(pool['name'], pool_type(pool)) for pool in pools_desc]
+
+    for prof in profiles_desc:
+        name, pools = prof['name'], prof['pools']
+        assert pools, f"Profile {name!r} doesn't refer to any pools"
+        for case, select in [
+                ('unknown', lambda _: True),
+                ('non-sns', lambda t: t is PoolT.sns)]:
+            bad = [s for s in pools
+                   if s not in [pool.name for pool in all_pools
+                                if select(pool.type)]]
+            assert not bad, \
+                'Profile {!r} refers to {} pool{}: {}'.format(
+                    name,
+                    case,
+                    's' if len(bad) > 1 else '',
+                    ', '.join(bad))
+        assert all_unique(pools), \
+            f'Profile {name!r} has non-unique pool references'
 
 
 @lru_cache(maxsize=1)
@@ -383,6 +471,26 @@ Oid.__doc__ = 'Motr conf object identifier'
 Oid.fidk.__doc__ = '.f_key part of the corresponding m0_fid'
 
 
+def oid_to_fidstr(oid: Oid) -> str:
+    """Convert Oid to string representation of fid.
+
+    >>> oid_to_fidstr(Oid(type=ObjT.process, fidk=85))
+    '0x7200000000000001:0x55'
+    """
+    assert oid.type is not ObjT.pver_f
+    fid_tcontainer = ord({
+        ObjT.root: 't', ObjT.fdmi_flt_grp: 'g', ObjT.fdmi_filter: 'l',
+        # software subtree
+        ObjT.node: 'n', ObjT.process: 'r', ObjT.service: 's', ObjT.sdev: 'd',
+        # hardware subtree
+        ObjT.site: 'S', ObjT.rack: 'a', ObjT.enclosure: 'e',
+        ObjT.controller: 'c', ObjT.drive: 'k',
+        # pools subtree
+        ObjT.pool: 'o', ObjT.pver: 'v', ObjT.objv: 'j', ObjT.profile: 'p'
+    }[oid.type])
+    return '{:#x}:{:#x}'.format(fid_tcontainer << 56 | 1, oid.fidk)
+
+
 def _infinite_counter(start: int = 0) -> Iterator[int]:
     k = start
     while True:
@@ -430,7 +538,7 @@ class Endpoint:
     def __repr__(self):
         args = ', '.join([f'proto={self.proto!r}',
                           f'ipaddr={self.ipaddr!r}',
-                          f'portal={self.portal}'
+                          f'portal={self.portal}',
                           f'tmid={self.tmid}'])
         return f'{self.__class__.__name__}({args})'
 
@@ -571,7 +679,7 @@ class ConfProcess(ToDhall):
     def __repr__(self):
         args = ', '.join([f'nr_cpu={self.nr_cpu}',
                           f'memsize_MB={self.memsize_MB}',
-                          f'endpoint={self.endpoint}',
+                          f'endpoint={self.endpoint!r}',
                           f'services={self.services}'])
         return f'{self.__class__.__name__}({args})'
 
@@ -685,7 +793,7 @@ class ConfService(ToDhall):
 
     def __repr__(self):
         args = ', '.join([f'stype={self.type}',
-                          f'endpoint={self.endpoint}',
+                          f'endpoint={self.endpoint!r}',
                           f'sdevs={self.sdevs}'])
         return f'{self.__class__.__name__}({args})'
 
@@ -725,7 +833,7 @@ class ConfSdev(ToDhall):
 
     def __repr__(self):
         args = ', '.join([f'dev_idx={self.dev_idx}',
-                          f'filename={self.filename}',
+                          f'filename={self.filename!r}',
                           f'size={self.size}',
                           f'blksize={self.blksize}'])
         return f'{self.__class__.__name__}({args})'
@@ -924,8 +1032,16 @@ class ConfDrive(ToDhall):
 PoolT = Enum('PoolT', 'sns dix md')  # PoolType.dhall
 
 
-def pool_drives(m0conf: Dict[Oid, Any], ptype: PoolT) -> List[Oid]:
-    if ptype == PoolT.dix:
+def pool_type(pool_desc: Dict[str, Any]) -> PoolT:
+    return PoolT[pool_desc.get('type', 'sns')]
+
+
+def pool_drives(m0conf: Dict[Oid, Any],
+                pool_desc: Dict[str, Any]) -> List[Oid]:
+    ptype = pool_type(pool_desc)
+    assert 'disk_refs' not in pool_desc or ptype is PoolT.sns
+
+    if ptype is PoolT.dix:
         cas = [(svc_id, ctrl_id)
                for ctrl_id in m0conf if ctrl_id.type is ObjT.controller
                for proc_id in m0conf[m0conf[ctrl_id].node].processes
@@ -938,12 +1054,51 @@ def pool_drives(m0conf: Dict[Oid, Any], ptype: PoolT) -> List[Oid]:
                                                     blksize=1)))
                 for (svc_id, ctrl_id) in cas]
 
-    if ptype == PoolT.md:
+    if ptype is PoolT.md:
         return [m0conf[ctrl_id].drives[0]
                 for ctrl_id in m0conf if ctrl_id.type is ObjT.controller]
 
-    assert ptype == PoolT.sns
-    return [oid for oid in m0conf if oid.type is ObjT.drive]
+    assert ptype is PoolT.sns
+    all_drives: List[Tuple[Oid, Oid]] = [
+        (drive_id, m0conf[ctrl_id].node)
+        for ctrl_id in m0conf if ctrl_id.type is ObjT.controller
+        for drive_id in m0conf[ctrl_id].drives
+    ]
+    assert all_drives
+    assert all(drive_id.type is ObjT.drive and node_id.type is ObjT.node
+               for drive_id, node_id in all_drives)
+
+    disk_refs = pool_desc.get('disk_refs')
+    if disk_refs is None:
+        drives = all_drives
+    else:
+        assert disk_refs
+        drives = []
+        for ref in disk_refs:
+            targets = [(drive_id, node_id)
+                       for drive_id, node_id in all_drives
+                       if ref['path'] == m0conf[m0conf[drive_id].sdev].filename
+                       and ref.get('node') in (None, m0conf[node_id].name)]
+            assert len(targets) == 1  # guaranteed by validate_pools_desc()
+            drives.extend(targets)
+        assert all_unique(drives), \
+            'Pool {!r}: some of disk_refs refer to the same disk'.format(
+                pool_desc['name'])
+
+    over_referenced: Dict[Oid, List[Oid]] = {}  # node-to-drives mapping
+    for drive_id, node_id in drives:
+        if m0conf[drive_id].pvers:  # already assigned to some pool
+            over_referenced.setdefault(node_id, []).append(drive_id)
+    if over_referenced:
+        err = '{} referred to by several pools:'.format(
+            'This disk is' if len(over_referenced) == 1 else 'These disks are')
+        for node_id in sorted(over_referenced):
+            err += '\n  ' + m0conf[node_id].name
+            for drive_id in sorted(over_referenced[node_id]):
+                err += '\n   \\_ ' + m0conf[m0conf[drive_id].sdev].filename
+        raise AssertionError(err)
+
+    return [drive_id for drive_id, _ in drives]
 
 
 Failures = NamedTuple('Failures', [('site', int),
@@ -975,12 +1130,15 @@ class ConfPool(ToDhall):
     _objt = ObjT.pool
     _downlinks = {Downlink('pvers', ObjT.pver)}
 
-    def __init__(self, pvers: List[Oid]):
+    def __init__(self, pvers: List[Oid], name: Optional[str]):
         assert all(x.type in (ObjT.pver, ObjT.pver_f) for x in pvers)
         self.pvers = pvers
+        self._name = name
 
     def __repr__(self):
-        return f'{self.__class__.__name__}(pvers={self.pvers})'
+        args = ', '.join([f'pvers={self.pvers}',
+                          f'name={self._name!r}'])
+        return f'{self.__class__.__name__}({args})'
 
     def to_dhall(self, oid: Oid) -> str:
         assert oid.type is ObjT.pool
@@ -990,39 +1148,39 @@ class ConfPool(ToDhall):
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
-              pool_desc: Dict[str, Any], profile: Oid) -> Oid:
+              pool_desc: Dict[str, Any]) -> Oid:
         assert parent.type is ObjT.root
-        assert profile.type is ObjT.profile
 
         pool_id = new_oid(ObjT.pool)
-        m0conf[pool_id] = cls(pvers=[])
-        m0conf[profile].pools.append(pool_id)
+        m0conf[pool_id] = cls(pvers=[], name=pool_desc.get('name'))
         m0conf[parent].pools.append(pool_id)
 
-        t = PoolT[pool_desc.get('type', 'sns')]
-        drives = pool_drives(m0conf, t)
+        drives = pool_drives(m0conf, pool_desc)
+        t = pool_type(pool_desc)
         assert ('data_units' in pool_desc) == ('parity_units' in pool_desc)
         if 'data_units' in pool_desc:
             pd_attrs = PDClustAttrs0(pool_desc['data_units'],
                                      pool_desc['parity_units'])
         else:
-            if t == PoolT.dix:
+            if t is PoolT.dix:
                 # For CAS service N must be equal to 1.  CAS records are
                 # indivisible pieces of data, the whole CAS record is
                 # always stored on one node.
                 data_units = 1
             else:
-                assert t == PoolT.md
+                assert t is PoolT.md
                 data_units = len(drives)
             pd_attrs = PDClustAttrs0(data_units=data_units, parity_units=0)
-        tolerance = None if t == PoolT.sns else Failures(0, 0, 0, 1, 0)
+        tolerance = None if t is PoolT.sns else Failures(0, 0, 0, 1, 0)
         pver = ConfPver.build(m0conf, pool_id, pd_attrs, drives, tolerance)
-        if t == PoolT.dix:
+        if t is PoolT.dix:
+            assert m0conf[parent].imeta_pver is None
             m0conf[parent].imeta_pver = pver
-        elif t == PoolT.md:
+        elif t is PoolT.md:
+            assert m0conf[parent].mdpool is None
             m0conf[parent].mdpool = pool_id
         else:
-            assert t == PoolT.sns
+            assert t is PoolT.sns
             d = pool_desc.get('allowed_failures')
             for v in gen_allowances(Failures(0, 0, 0, 0, 0) if d is None else
                                     Failures(d['site'],
@@ -1274,14 +1432,17 @@ class ConfObjv(ToDhall):
 
 class ConfProfile(ToDhall):
     _objt = ObjT.profile
-    _downlinks = {Downlink('pools', ObjT.pool)}
+    _downlinks: Set[Downlink] = set()
 
-    def __init__(self, pools: List[Oid]):
+    def __init__(self, pools: List[Oid], name: str):
         assert all(x.type is ObjT.pool for x in pools)
         self.pools = pools
+        self._name = name
 
     def __repr__(self):
-        return f'{self.__class__.__name__}(pools={self.pools})'
+        args = ', '.join([f'pools={self.pools}',
+                          f'name={self._name!r}'])
+        return f'{self.__class__.__name__}({args})'
 
     def to_dhall(self, oid: Oid) -> str:
         assert oid.type is ObjT.profile
@@ -1290,12 +1451,30 @@ class ConfProfile(ToDhall):
         return '{ %s }' % args
 
     @classmethod
-    def build(cls, m0conf: Dict[Oid, Any], parent: Oid) -> Oid:
+    def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
+              prof_desc: Dict[str, Any]) -> Oid:
         assert parent.type is ObjT.root
+
+        pool_ids = dict((m0conf[pool_id]._name, pool_id) for pool_id in m0conf
+                        if pool_id.type is ObjT.pool
+                        and m0conf[pool_id]._name in prof_desc['pools'])
+        prof_pools = [pool_ids[pool] for pool in prof_desc['pools']]
+
+        root = m0conf[parent]
+        dix_pools = [pool for pool in root.pools
+                     if root.imeta_pver in m0conf[pool].pvers]
+        assert len(dix_pools) == 1
+        dix_pool = dix_pools[0]
+        if dix_pool not in prof_pools:
+            prof_pools.append(dix_pool)
+
+        assert root.mdpool is not None
+        if root.mdpool not in prof_pools:
+            prof_pools.append(root.mdpool)
+
         prof_id = new_oid(ObjT.profile)
-        m0conf[prof_id] = cls(pools=[])
-        assert not m0conf[parent].profiles
-        m0conf[parent].profiles = [prof_id]  # XXX-TODO: multiple profiles
+        m0conf[prof_id] = cls(pools=prof_pools, name=prof_desc['name'])
+        m0conf[parent].profiles.append(prof_id)
         return prof_id
 
 
@@ -1315,17 +1494,71 @@ def generate_consul_agents(cluster: Cluster) -> str:
         indent=2) + '\n'
 
 
-def fid2str(id: Oid) -> str:
-    types = {ObjT.root: 't', ObjT.fdmi_flt_grp: 'g', ObjT.fdmi_filter: 'l',
-             ObjT.node: 'n', ObjT.process: 'r', ObjT.service: 's',
-             ObjT.sdev: 'd', ObjT.pool: 'o', ObjT.pver: 'v', ObjT.objv: 'j',
-             ObjT.site: 'S', ObjT.rack: 'a', ObjT.enclosure: 'e',
-             ObjT.controller: 'c', ObjT.drive: 'k', ObjT.profile: 'p'}
-    return f'{hex((ord(types[id.type]) << 56)+1)}:{hex(id.fidk)}'
+def consul_kv_drives(m0conf: Dict[Oid, Any]) -> Dict[str, str]:
+    state_unknown = json.dumps({'state': 'M0_NC_UNKNOWN'})
+    d = {}
+    for site_id, site in m0conf.items():
+        if site_id.type is not ObjT.site:
+            continue
+        site_key = 'm0conf/sites/' + oid_to_fidstr(site_id)
+        d[site_key] = state_unknown
+        for rack_id in site.racks:
+            assert rack_id.type is ObjT.rack
+            rack_key = f'{site_key}/racks/' + oid_to_fidstr(rack_id)
+            d[rack_key] = state_unknown
+            for encl_id in m0conf[rack_id].encls:
+                assert encl_id.type is ObjT.enclosure
+                encl_key = f'{rack_key}/encls/' + oid_to_fidstr(encl_id)
+                d[encl_key] = state_unknown
+                for ctrl_id in m0conf[encl_id].ctrls:
+                    assert ctrl_id.type is ObjT.controller
+                    ctrl_key = f'{encl_key}/ctrls/' + \
+                        oid_to_fidstr(ctrl_id)
+                    d[ctrl_key] = json.dumps(
+                        {'node': oid_to_fidstr(m0conf[ctrl_id].node),
+                         'state': 'M0_NC_UNKNOWN'})
+                    for drive_id in m0conf[ctrl_id].drives:
+                        assert drive_id.type is ObjT.drive
+                        drive_key = f'{ctrl_key}/drives/' + \
+                            oid_to_fidstr(drive_id)
+                        d[drive_key] = json.dumps(
+                            {'sdev': oid_to_fidstr(m0conf[drive_id].sdev),
+                             'state': 'M0_NC_UNKNOWN'})
+    return d
+
+
+def consul_kv_sdevs(m0conf: Dict[Oid, Any]) -> Dict[str, str]:
+    d = {}
+    for node_id, node in m0conf.items():
+        if node_id.type is not ObjT.node:
+            continue
+        node_key = 'm0conf/nodes/' + oid_to_fidstr(node_id)
+        d[node_key] = json.dumps({'name': node.name,
+                                  'state': 'M0_NC_UNKNOWN'})
+        for proc_id in node.processes:
+            assert proc_id.type is ObjT.process
+            proc_key = f'{node_key}/processes/' + oid_to_fidstr(proc_id)
+            # XXX-VERIFYME Can we really convert from portal (int) to name?
+            proc_name = ProcT(m0conf[proc_id].endpoint.portal).name
+            d[proc_key] = json.dumps({'name': proc_name,
+                                      'state': 'M0_NC_UNKNOWN'})
+            for svc_id in m0conf[proc_id].services:
+                assert svc_id.type is ObjT.service
+                svc_key = f'{proc_key}/services/' + oid_to_fidstr(svc_id)
+                stype = m0conf[svc_id].type.name[len('M0_CST_'):].lower()
+                d[svc_key] = json.dumps({'name': stype,
+                                         'state': 'M0_NC_UNKNOWN'})
+                for sdev_id in m0conf[svc_id].sdevs:
+                    assert sdev_id.type is ObjT.sdev
+                    sdev_key = f'{svc_key}/sdevs/' + oid_to_fidstr(sdev_id)
+                    d[sdev_key] = json.dumps(
+                        {'path': m0conf[sdev_id].filename,
+                         'state': 'M0_NC_UNKNOWN'})
+    return d
 
 
 def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
-    assert os.path.isabs(dhall_dir)
+    assert os.path.isabs(dhall_dir)  # XXX DELETEME
     assert all(k.type is ObjT.process and v.type is ObjT.service
                for k, v in cluster.m0_clients.items())
 
@@ -1339,20 +1572,6 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
     ConsulService = NamedTuple('ConsulService', [
         ('node_name', str), ('proc_id', Oid), ('ep', Endpoint),
         ('svc_id', Oid), ('stype', str), ('meta_data', Optional[str])])
-
-    def profile() -> str:
-        profiles = [x for x in m0conf.keys() if x.type is ObjT.profile]
-        assert len(profiles) != 0
-        # Need to return all when it support multiple profiles
-        return fid2str(profiles[0])
-
-    def sns_pools() -> str:
-        for root_id, root in m0conf.items():
-            if root_id.type is ObjT.root:
-                return ' '.join([fid2str(x) for x in root.pools
-                                 if x is not root.mdpool and
-                                 root.imeta_pver not in m0conf[x].pvers])
-        raise RuntimeError('Impossible happened')
 
     def processes() -> Iterator[ConsulService]:
         for node_id, node in m0conf.items():
@@ -1379,83 +1598,27 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                                         stype=ProcT(proc_ep.portal).name,
                                         meta_data=None)
 
-    def drives() -> List:
-        site_drives = []
-        for site_id, site in m0conf.items():
-            if site_id.type is not ObjT.site:
-                continue
-            site_key = f'm0conf/sites/{fid2str(site_id)}'
-            site_val = json.dumps({'state': 'M0_NC_UNKNOWN'})
-            site_drives.append((site_key, site_val))
-            for rack_id in site.racks:
-                assert rack_id.type is ObjT.rack
-                rack = m0conf[rack_id]
-                rack_key = f'{site_key}/racks/{fid2str(rack_id)}'
-                rack_val = json.dumps({'state': 'M0_NC_UNKNOWN'})
-                site_drives.append((rack_key, rack_val))
-                for encl_id in rack.encls:
-                    assert encl_id.type is ObjT.enclosure
-                    encl = m0conf[encl_id]
-                    encl_key = f'{rack_key}/encls/{fid2str(encl_id)}'
-                    encl_val = json.dumps({'state': 'M0_NC_UNKNOWN'})
-                    site_drives.append((encl_key, encl_val))
-                    for ctrl_id in encl.ctrls:
-                        assert ctrl_id.type is ObjT.controller
-                        ctrl = m0conf[ctrl_id]
-                        ctrl_key = f'{encl_key}/ctrls/{fid2str(ctrl_id)}'
-                        ctrl_val = json.dumps({'node': fid2str(ctrl.node),
-                                               'state': 'M0_NC_UNKNOWN'})
-                        site_drives.append((ctrl_key, ctrl_val))
-                        for drive_id in ctrl.drives:
-                            assert drive_id.type is ObjT.drive
-                            drive = m0conf[drive_id]
-                            key = f'{ctrl_key}/drives/{fid2str(drive_id)}'
-                            val = json.dumps({'sdev': fid2str(drive.sdev),
-                                              'state': 'M0_NC_UNKNOWN'})
-                            site_drives.append((key, val))
-        return site_drives
+    def sns_pools() -> List[Oid]:
+        for root_id, root in m0conf.items():
+            if root_id.type is ObjT.root:
+                return [x for x in root.pools
+                        if x != root.mdpool and
+                        root.imeta_pver not in m0conf[x].pvers]
+        raise RuntimeError('Impossible happened')
 
-    def sdevs() -> List:
-        node_sdevs = []
-        for node_id, node in m0conf.items():
-            if node_id.type is not ObjT.node:
-                continue
-            node_key = f'm0conf/nodes/{fid2str(node_id)}'
-            node_val = json.dumps({'name': node.name,
-                                   'state': 'M0_NC_UNKNOWN'})
-            node_sdevs.append((node_key, node_val))
-            for proc_id in node.processes:
-                assert proc_id.type is ObjT.process
-                proc = m0conf[proc_id]
-                proc_key = f'{node_key}/processes/{fid2str(proc_id)}'
-                proc_name = ProcT(proc.endpoint.portal).name
-                proc_val = json.dumps({'name': proc_name,
-                                       'state': 'M0_NC_UNKNOWN'})
-                node_sdevs.append((proc_key, proc_val))
-                for svc_id in m0conf[proc_id].services:
-                    stype = m0conf[svc_id].type.name[len('M0_CST_'):].lower()
-                    svc_key = f'{proc_key}/services/{fid2str(svc_id)}'
-                    svc_val = json.dumps({'name': stype,
-                                          'state': 'M0_NC_UNKNOWN'})
-                    node_sdevs.append((svc_key, svc_val))
-                    for sdev_id in m0conf[svc_id].sdevs:
-                        assert sdev_id.type is ObjT.sdev
-                        sdev = m0conf[sdev_id]
-                        disk_key = f'{svc_key}/sdevs/{fid2str(sdev_id)}'
-                        disk_val = json.dumps({'path': sdev.filename,
-                                               'state': 'M0_NC_UNKNOWN'})
-                        node_sdevs.append((disk_key, disk_val))
-        return node_sdevs
-
-    node_sdevs = [dict(key=k, value=v) for k, v in sdevs()]
-    site_drives = [dict(key=k, value=v) for k, v in drives()]
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
         ('eq-epoch', 1),
         ('leader', ''),
         ('last_fidk', _fidk_gen),
-        ('m0conf/profiles', profile()),
-        ('m0conf/profiles/pools', sns_pools()),
+        *[('m0conf/pools/' + oid_to_fidstr(pool_id), m0conf[pool_id]._name)
+          for pool_id in sns_pools()],
+        *[('m0conf/profiles/' + oid_to_fidstr(prof_id),
+           json.dumps({
+               'name': prof._name,
+               'pools': [m0conf[pool_id]._name for pool_id in prof.pools]
+           }))
+          for prof_id, prof in m0conf.items() if prof_id.type is ObjT.profile],
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/services/'
            f'{x.stype}', x.svc_id.fidk) for x in processes()],
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/'
@@ -1463,7 +1626,9 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
           for x in processes() if x.stype == 'ios' and x.meta_data],
         *[(f'm0conf/nodes/{x.node_name}/processes/{x.proc_id.fidk}/endpoint',
            str(x.ep))
-          for x in processes()])] + node_sdevs + site_drives,
+          for x in processes()],
+        *consul_kv_sdevs(m0conf).items(),
+        *consul_kv_drives(m0conf).items())],
                       indent=2) + '\n'
 
 
@@ -1549,17 +1714,17 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                 proc_id = ConfProcess.build(conf, node_id, node, proc_t)
                 cluster.m0_clients[proc_id] = new_oid(ObjT.service)
 
-    # XXX-TODO: support multiple profiles
-    prof_id = ConfProfile.build(conf, root_id)
-
     for pool in cluster_desc['pools']:
-        ConfPool.build(conf, root_id, pool, prof_id)
+        ConfPool.build(conf, root_id, pool)
 
     if conf[root_id].imeta_pver is None:  # no DIX pool defined in the CDF
-        ConfPool.build(conf, root_id, {'type': 'dix'}, prof_id)
+        ConfPool.build(conf, root_id, {'type': 'dix'})
 
     if conf[root_id].mdpool is None:  # no Metadata pool defined in the CDF
-        ConfPool.build(conf, root_id, {'type': 'md'}, prof_id)
+        ConfPool.build(conf, root_id, {'type': 'md'})
+
+    for prof in cluster_desc['profiles']:
+        ConfProfile.build(conf, root_id, prof)
 
     validate_m0conf(conf)
     assert cluster.consul_servers

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional, \
 import yaml
 
 
-__version__ = '0.12.1'
+__version__ = '0.12.2'
 
 
 def parse_opts(argv):
@@ -316,13 +316,14 @@ def get_facts(hostname: str, mock_p: bool, *args: str) -> Dict[str, Any]:
 
 def fabricate_facts(hostname: str, *args: str) -> Dict[str, Any]:
     rng = random.randrange
+    ipaddress = '.'.join(str(n) for n in [
+        random.choice([10, 172, 192]), rng(256), rng(256), rng(256)])
     fabricated = {
         'processorcount': rng(1, 21),
-        'memorysize_mb': '{:.2f}'.format(random.uniform(512, 16000)),
-        'ipaddress_eth1': '.'.join(str(n) for n in [
-            random.choice([10, 172, 192]), rng(256), rng(256), rng(256)]),
+        'memorysize_mb': '{:.2f}'.format(random.uniform(512, 16000))
     }
-    return dict((k, fabricated[k]) for k in args)
+    return dict((k, ipaddress if k.startswith('ipaddress_') else fabricated[k])
+                for k in args)
 
 
 Disk = NamedTuple('Disk', [('path', str), ('size', int), ('blksize', int)])

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -39,8 +39,10 @@
 , Protocol    = ./types/Protocol.dhall
 
 , ClusterDesc = ./types/ClusterDesc.dhall
+, DiskRef     = ./types/DiskRef.dhall
 , FailVec     = ./types/FailVec.dhall
 , PoolType    = ./types/PoolType.dhall
+, PoolsRef    = ./types/PoolsRef.dhall
 
 , Obj         = ./types/Obj.dhall
 , ObjT        = ./types/ObjT.dhall

--- a/cfgen/dhall/types/DiskRef.dhall
+++ b/cfgen/dhall/types/DiskRef.dhall
@@ -18,31 +18,6 @@
 
 -}
 
--- m0d process
-let M0Server =
-  { runs_confd : Optional Bool
-  , io_disks : { meta_data: Optional Text, data : List Text }
-  }
-
-let Node =
-  { hostname : Text
-  , data_iface : Text
-  , data_iface_type: Optional ./Protocol.dhall
-  , m0_servers : List M0Server
-  , m0_clients : { s3 : Natural, other : Natural }
-  }
-
-let Pool =
-  { name : Text
-  , type : Optional ./PoolType.dhall
-  , disk_refs : Optional (List ./DiskRef.dhall)
-  , data_units : Natural    -- N
-  , parity_units : Natural  -- K
-  , allowed_failures : Optional ./FailVec.dhall
-  }
-
-in
-{ nodes : List Node
-, pools : List Pool
-, profiles : Optional (List ./PoolsRef.dhall)
+{ path : Text
+, node : Optional Text
 }

--- a/cfgen/dhall/types/PoolsRef.dhall
+++ b/cfgen/dhall/types/PoolsRef.dhall
@@ -18,31 +18,6 @@
 
 -}
 
--- m0d process
-let M0Server =
-  { runs_confd : Optional Bool
-  , io_disks : { meta_data: Optional Text, data : List Text }
-  }
-
-let Node =
-  { hostname : Text
-  , data_iface : Text
-  , data_iface_type: Optional ./Protocol.dhall
-  , m0_servers : List M0Server
-  , m0_clients : { s3 : Natural, other : Natural }
-  }
-
-let Pool =
-  { name : Text
-  , type : Optional ./PoolType.dhall
-  , disk_refs : Optional (List ./DiskRef.dhall)
-  , data_units : Natural    -- N
-  , parity_units : Natural  -- K
-  , allowed_failures : Optional ./FailVec.dhall
-  }
-
-in
-{ nodes : List Node
-, pools : List Pool
-, profiles : Optional (List ./PoolsRef.dhall)
+{ name : Text
+, pools : List Text
 }

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -1,0 +1,79 @@
+nodes:
+  - hostname: srvnode-1
+    data_iface: enp175s0f1_c1
+    data_iface_type: o2ib
+    m0_servers:
+      - runs_confd: true
+        io_disks:
+          data: []
+      - io_disks:
+          meta_data: /dev/vg_metadata_srvnode-1/lv_raw_metadata
+          data:
+            - /dev/foo
+            - /dev/disk/by-id/dm-name-mpatha
+            - /dev/disk/by-id/dm-name-mpathb
+            - /dev/disk/by-id/dm-name-mpathc
+            - /dev/disk/by-id/dm-name-mpathd
+            - /dev/disk/by-id/dm-name-mpathe
+            - /dev/disk/by-id/dm-name-mpathf
+    m0_clients:
+      s3: 11
+      other: 3
+  - hostname: srvnode-2
+    data_iface: enp175s0f1_c2
+    data_iface_type: o2ib
+    m0_servers:
+      - runs_confd: true
+        io_disks:
+          data: []
+      - io_disks:
+          meta_data: /dev/vg_metadata_srvnode-2/lv_raw_metadata
+          data:
+            - /dev/foo
+            - /dev/disk/by-id/dm-name-mpathg
+            - /dev/disk/by-id/dm-name-mpathh
+            - /dev/disk/by-id/dm-name-mpathi
+            - /dev/disk/by-id/dm-name-mpathj
+            - /dev/disk/by-id/dm-name-mpathk
+            - /dev/disk/by-id/dm-name-mpathl
+    m0_clients:
+      s3: 11
+      other: 3
+pools:
+  - name: tier1-nvme
+    disk_refs:
+      - path: /dev/foo
+        node: srvnode-1
+      - path: /dev/foo
+        node: srvnode-2
+    data_units: 1
+    parity_units: 0
+  - name: tier2-ssd
+    disk_refs:
+      - path: /dev/disk/by-id/dm-name-mpatha
+      - path: /dev/disk/by-id/dm-name-mpathb
+      - path: /dev/disk/by-id/dm-name-mpathg
+      - path: /dev/disk/by-id/dm-name-mpathh
+    data_units: 2
+    parity_units: 1
+    allowed_failures: { site: 0, rack: 0, encl: 0, ctrl: 0, disk: 1 }
+  - name: tier3-hdd
+    disk_refs:
+      - path: /dev/disk/by-id/dm-name-mpathc
+      - path: /dev/disk/by-id/dm-name-mpathd
+      - path: /dev/disk/by-id/dm-name-mpathe
+      - path: /dev/disk/by-id/dm-name-mpathf
+      - path: /dev/disk/by-id/dm-name-mpathi
+      - path: /dev/disk/by-id/dm-name-mpathj
+      - path: /dev/disk/by-id/dm-name-mpathk
+      - path: /dev/disk/by-id/dm-name-mpathl
+    data_units: 2
+    parity_units: 1
+    allowed_failures: { site: 0, rack: 0, encl: 0, ctrl: 0, disk: 1 }
+profiles:
+  - name: fast
+    pools: [ tier1-nvme, tier2-ssd ]
+  - name: archive
+    pools: [ tier3-hdd ]
+  - name: all
+    pools: [ tier1-nvme, tier2-ssd, tier3-hdd ]

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -29,6 +29,20 @@ nodes:
 pools:
   - name: the pool
     #type: sns  # optional; supported values: "sns" (default), "dix", "md"
+    #disk_refs:
+    #  - { path: /dev/loop0, node: localhost }
+    #  - path: /dev/loop1
+    #  - path: /dev/loop2
+    #  - path: /dev/loop3
+    #  - path: /dev/loop4
+    #  - path: /dev/loop5
+    #  - path: /dev/loop6
+    #  - path: /dev/loop7
+    #  - path: /dev/loop8
+    #  - path: /dev/loop9
     data_units: 1
     parity_units: 0
     #allowed_failures: { site: 0, rack: 0, encl: 0, ctrl: 0, disk: 0 }
+#profiles:
+#  - name: default
+#    pools: [ the pool ]

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -51,9 +51,11 @@ in
 , pools =
     [ { name = "the pool"
       , type = None types.PoolType
+      , disk_refs = None (List types.DiskRef)
       , data_units = 1
       , parity_units = 0
       , allowed_failures = None types.FailVec
       }
     ]
+, profiles = None (List types.PoolsRef)
 } : types.ClusterDesc

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -118,22 +118,112 @@ optional arguments:
 
 ```
 $ hctl status
-Profile: 0x7000000000000001:0x3d
 Data pools:
-    0x6f00000000000001:0x3e
+    # fid name
+    0x6f00000000000001:0x2e 'tier1-ssd'
+    0x6f00000000000001:0x39 'tier2-hdd'
+Profiles:
+    # fid name: pool(s)
+    0x7000000000000001:0x54 'fast': 'tier1-ssd'
+    0x7000000000000001:0x55 'slow': 'tier2-hdd'
+    0x7000000000000001:0x56 'both': 'tier1-ssd' 'tier2-hdd'
 Services:
-    ssc-vm-c-0553.colo.seagate.com
-    [started]  hax        0x7200000000000001:0x23  192.168.9.107@tcp:12345:1:1
-    [started]  confd      0x7200000000000001:0x26  192.168.9.107@tcp:12345:2:1
-    [started]  ioservice  0x7200000000000001:0x29  192.168.9.107@tcp:12345:2:2
-    [unknown]  m0_client  0x7200000000000001:0x37  192.168.9.107@tcp:12345:4:1
-    [unknown]  m0_client  0x7200000000000001:0x3a  192.168.9.107@tcp:12345:4:2
-    ssc-vm-c-0552.colo.seagate.com  (RC)
-    [started]  hax        0x7200000000000001:0x6   192.168.9.108@tcp:12345:1:1
-    [started]  confd      0x7200000000000001:0x9   192.168.9.108@tcp:12345:2:1
-    [started]  ioservice  0x7200000000000001:0xc   192.168.9.108@tcp:12345:2:2
-    [unknown]  m0_client  0x7200000000000001:0x1a  192.168.9.108@tcp:12345:4:1
-    [unknown]  m0_client  0x7200000000000001:0x1d  192.168.9.108@tcp:12345:4:2
+    localhost  (RC)
+    [started]  hax        0x7200000000000001:0x6   172.28.128.45@tcp:12345:1:1
+    [started]  confd      0x7200000000000001:0x9   172.28.128.45@tcp:12345:2:1
+    [started]  ioservice  0x7200000000000001:0xc   172.28.128.45@tcp:12345:2:2
+    [unknown]  m0_client  0x7200000000000001:0x28  172.28.128.45@tcp:12345:4:1
+    [unknown]  m0_client  0x7200000000000001:0x2b  172.28.128.45@tcp:12345:4:2
+```
+
+```
+$ hctl status --json
+{
+  "pools": [
+    {
+      "fid": "0x6f00000000000001:0x2e",
+      "name": "tier1-ssd"
+    },
+    {
+      "fid": "0x6f00000000000001:0x39",
+      "name": "tier2-hdd"
+    }
+  ],
+  "profiles": [
+    {
+      "fid": "0x7000000000000001:0x54",
+      "name": "fast",
+      "pools": [
+        "tier1-ssd"
+      ]
+    },
+    {
+      "fid": "0x7000000000000001:0x55",
+      "name": "slow",
+      "pools": [
+        "tier2-hdd"
+      ]
+    },
+    {
+      "fid": "0x7000000000000001:0x56",
+      "name": "both",
+      "pools": [
+        "tier1-ssd",
+        "tier2-hdd"
+      ]
+    }
+  ],
+  "filesystem": {
+    "stats": {
+      "fs_free_seg": 8590389096,
+      "fs_total_seg": 8590951472,
+      "fs_free_disk": 104689827840,
+      "fs_avail_disk": 104689827840,
+      "fs_total_disk": 104689827840,
+      "fs_svc_total": 2,
+      "fs_svc_replied": 2
+    },
+    "timestamp": 1602613220.761281,
+    "date": "2020-10-13T18:20:20.761281"
+  },
+  "nodes": [
+    {
+      "name": "localhost",
+      "svcs": [
+        {
+          "name": "hax",
+          "fid": "0x7200000000000001:0x6",
+          "ep": "172.28.128.45@tcp:12345:1:1",
+          "status": "started"
+        },
+        {
+          "name": "confd",
+          "fid": "0x7200000000000001:0x9",
+          "ep": "172.28.128.45@tcp:12345:2:1",
+          "status": "started"
+        },
+        {
+          "name": "ioservice",
+          "fid": "0x7200000000000001:0xc",
+          "ep": "172.28.128.45@tcp:12345:2:2",
+          "status": "started"
+        },
+        {
+          "name": "m0_client",
+          "fid": "0x7200000000000001:0x28",
+          "ep": "172.28.128.45@tcp:12345:4:1",
+          "status": "unknown"
+        },
+        {
+          "name": "m0_client",
+          "fid": "0x7200000000000001:0x2b",
+          "ep": "172.28.128.45@tcp:12345:4:2",
+          "status": "unknown"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ## Node management

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -26,15 +26,14 @@ Key | Value | Description
 `m0conf/nodes/<node_fid>/processes/<process_fid>` | `{ "name": "<process name>", "state": "<HA state>" }` |
 `m0conf/nodes/<node_fid>/processes/<process_fid>/services/<svc_fid>` | `{ "name": "<service name>", "state": "<HA state>" }` |
 `m0conf/nodes/<node_fid>/processes/<process_fid>/services/<svc_fid>/sdevs/<sdev_fid>` | `{ "path": "<sdev path>", "state": "<HA state>" }` |
+`m0conf/pools/<pool_fid>` | pool name | Name of the pool as specified in the CDF.  Example: `tier1-nvme`.
+`m0conf/profiles/<profile_fid>` | `{ "name": "<profile_name>", "pools": [ "<pool_name>" ] }` | "pools" - names of the _SNS_ pools associated with this profile.  `<profile_name>` and `<pool_name>`s are specified in the CDF.
 `m0conf/sites/<site_fid>` | `{ "state": "<HA state>" }` | [HA state](#ha-state) of this site.
 `m0conf/sites/<site_fid>/racks/<rack_fid>` | `{ "state": "<HA state>" }` | [HA state](#ha-state) of this rack.
 `m0conf/sites/<site_fid>/racks/<rack_fid>/encls/<encl_fid>` | `{ "state": "<HA state>" }` | [HA state](#ha-state) of this enclosure.
 `m0conf/sites/<site_fid>/racks/<rack_fid>/encls/<encl_fid>/ctrls/<ctrl_fid>` | `{ "node": "<node_fid>", "state": "<HA state>" }` | Fid of the corresponding node and [HA state](#ha-state) of this controller.
 `m0conf/sites/<site_fid>/racks/<rack_fid>/encls/<encl_fid>/ctrls/<ctrl_fid>/drives/<drive_fid>` | `{ "dev": "<sdev_fid>", "state": "<HA state>" }` | Fid of the corresponding storage device and [HA state](#ha-state) of this drive.
-`m0conf/profiles/<profile_fidk>` | `[ <pool_fidk> ]` | Array of fid keys of the SNS pools associated with this profile.
 `processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
-`profile` | fid | Profile fid in string format.  Example: `"0x7000000000000001:0x4"`.
-`profile/pools` | fids | Space-separated list of fids of SNS pools.
 `sspl.SYSTEM_INFORMATION.log_level` | | This key is used by SSPL.
 `stats/filesystem` | JSON object | See ['stats/filesystem' value](#statsfilesystem-value) below.
 `timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.
@@ -59,13 +58,6 @@ Key | Value | Description
   Right now we don't know for sure if this will actually be a problem.
   The [specification of `bootstrap` script](rfc/6/README.md) should
   cover this topic.
--->
-<!--
-  XXX Human-readable pool names (e.g., "tier1-nvme", "tier2-ssd", "tier3-hdd")
-  proved to be quite useful in multi-pool setups.  If pool information is
-  ever needed, consider the following format of pool entries:
-
-  `m0conf/pools/<pool_fidk>` | `{ "name": <pool name>, ...N K failvec... }`
 -->
 <!--
   XXX 'sspl.SYSTEM_INFORMATION.log_level' does not conform to the naming

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -27,7 +27,6 @@ import sys
 from subprocess import PIPE, Popen
 from typing import Any, Dict, List, NamedTuple, Optional
 
-import simplejson as j
 from consul import Consul, ConsulException
 from hax.exception import HAConsistencyException
 from hax.util import repeat_if_fails
@@ -47,67 +46,93 @@ class Fid:
         return f'{self.__class__.__name__}({self.container:#x}, {self.key:#x})'
 
 
-class FidEncoder(j.JSONEncoder):
+class FidEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Fid):
             return str(obj)
         return super().default(obj)
 
 
+Profile = NamedTuple('Profile', [
+    ('fid', str), ('name', str), ('pools', List[str])])
+
+Pool = NamedTuple('Pool', [('fid', str), ('name', str)])
+
 Process = NamedTuple('Process', [('name', str), ('fid', Fid), ('ep', str),
                                  ('status', str)])
 
-Host = NamedTuple('Host', [('name', str), ('svcs', List[Process])])
+Node = NamedTuple('Node', [('name', str), ('svcs', List[Process])])
 
 
 def processfid2str(fidk: int) -> str:
     return '{:#x}:{:#x}'.format(ord('r') << 56 | 1, fidk)
 
 
-def get_kv(cns: Consul, key: str, recurse: bool = False) -> Any:
-    """
-    Returns the given value from Consul KV. May throw HAConsistencyException in
-    case of an intermittent connection error or while Consul is re-electing
-    internal Raft leader.
+def kv_item(cns: Consul, key: str, recurse: bool = False) -> Any:
+    """Gets Consul KV item.
+
+    May throw HAConsistencyException in case of an intermittent connection
+    error or while Consul is re-electing internal Raft leader.
+
+    The _value_ returned is for the specified key, or if `recurse` is True
+    a list of _values_ for all keys with the given prefix is returned.
+
+    Each _value_ looks like this:
+    ```
+    {
+      "CreateIndex": 100,
+      "ModifyIndex": 200,
+      "LockIndex": 200,
+      "Key": "foo",
+      "Flags": 0,
+      "Value": "bar",
+      "Session": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
+    }
+    ```
+    Returns None if the requested `key` does not exists.
     """
     try:
-        kv: Dict[str, Any] = cns.kv.get(key, recurse=recurse)[1]
-        if kv is None:
-            return None
-        if isinstance(kv, list):
-            return kv
-        val = kv['Value']
-        return val.decode() if val else None
+        # See https://python-consul.readthedocs.io/en/latest/#consul-kv
+        val = cns.kv.get(key, recurse=recurse)[1]
+        assert val is None or recurse == (type(val) is list)
+        return val
     except (ConsulException, HTTPError, RequestException) as e:
         raise HAConsistencyException('Could not access Consul KV') from e
 
 
-def get_kv_safe(cns: Consul, key: str, **kwargs) -> str:
-    return get_kv(cns, key, **kwargs) or ''
+def kv_value_as_str(cns: Consul, key: str) -> Optional[str]:
+    item = kv_item(cns, key)
+    return None if item is None else item['Value'].decode()
 
 
 def leader_tag(cns: Consul, host: str) -> str:
-    return ' (RC)' if get_kv_safe(cns, 'leader') == host else ''
+    return ' (RC)' if kv_value_as_str(cns, 'leader') == host else ''
 
 
-def profile(cns: Consul) -> str:
-    return get_kv_safe(cns, 'm0conf/profiles')
+def profiles(cns: Consul) -> List[Profile]:
+    profs = []
+    for x in kv_item(cns, 'm0conf/profiles/', recurse=True):
+        fidstr = x['Key'].split('/')[-1]
+        payload = json.loads(x['Value'])
+        profs.append(Profile(
+            fid=fidstr, name=payload['name'], pools=payload['pools']))
+    return profs
 
 
-def sns_pools(cns: Consul) -> List[str]:
-    return get_kv_safe(cns, 'm0conf/profiles/pools').split(' ')
+def sns_pools(cns: Consul) -> List[Pool]:
+    return [Pool(fid=x['Key'].split('/')[-1], name=x['Value'].decode())
+            for x in kv_item(cns, 'm0conf/pools/', recurse=True)]
 
 
-def hosts(cns: Consul) -> List[str]:
-    data = get_kv(cns, 'm0conf/nodes', recurse=True)
-    host_names = [json.loads(x['Value'])['name'] for x in data
-                  if len(x['Key'].split('/')) == 3]
-    return host_names
+def node_names(cns: Consul) -> List[str]:
+    data = kv_item(cns, 'm0conf/nodes/', recurse=True)
+    return [json.loads(x['Value'])['name'] for x in data
+            if len(x['Key'].split('/')) == 3]  # XXX Yuck!
 
 
-def get_fs_stats(cns: Consul) -> Optional[Any]:
-    data = get_kv(cns, 'stats/filesystem') or '{"stats": {}}'
-    return j.loads(data)
+def get_fs_stats(cns: Consul) -> Any:
+    stats = kv_value_as_str(cns, 'stats/filesystem')
+    return {'stats': {}} if stats is None else json.loads(stats)
 
 
 def proc_id2name(cns: Consul, node: str, proc_id: int) -> str:
@@ -117,16 +142,16 @@ def proc_id2name(cns: Consul, node: str, proc_id: int) -> str:
         'ios': 'ioservice',
         'm0_client_s3': 's3server'
     }
-    services = get_kv(cns,
-                      f'm0conf/nodes/{node}/processes/{proc_id}/services',
-                      recurse=True)
+    services = kv_item(cns,
+                       f'm0conf/nodes/{node}/processes/{proc_id}/services/',
+                       recurse=True)
     assert services
     for svc in services:
         # key looks like
-        # 'm0conf/nodes/{node}/processes/{proc_id}/services/<svc_name>'
-        svc_name = svc['Key'].split('/')[-1]
-        if svc_name in names:
-            return names[svc_name]
+        # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
+        svc_type = svc['Key'].split('/')[-1]
+        if svc_type in names:
+            return names[svc_type]
     return 'm0_client'
 
 
@@ -135,32 +160,34 @@ def fid_key(fid: str) -> int:
     return int(key, 16)
 
 
-def node_name2id(cns: Consul, node_name: str) -> Any:
-    data = get_kv(cns, 'm0conf/nodes/', recurse=True)
-    for x in data:
-        if len(x['Key'].split('/')) == 3 and \
-           json.loads(x['Value'])['name'] == node_name:
-            return x['Key'].split('/')[-1]
-
-    assert False
-    return ''
+def node_name2fid(cns: Consul, node_name: str) -> Any:
+    for x in kv_item(cns, 'm0conf/nodes/', recurse=True):
+        parts = x['Key'].split('/', 3)
+        if len(parts) == 3 and json.loads(x['Value'])['name'] == node_name:
+            return parts[-1]
+    raise RuntimeError(f'Cannot find Consul KV entry for node {node_name!r}')
 
 
 def processes(cns: Consul, node_name: str) -> List[Process]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/...' entries
     # from the KV.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md).
-    node_id = node_name2id(cns, node_name)
-    data = get_kv(cns, f'm0conf/nodes/{node_id}/processes', recurse=True)
-    proc_ids = [x['Key'].split('/')[-1] for x in data
-                if len(x['Key'].split('/')) == 5]
-    fidk_list = list(map(fid_key, proc_ids))
-    fidk_list.sort()
+    node_fid = node_name2fid(cns, node_name)
+    proc_fidks = []
+    for x in kv_item(cns, f'm0conf/nodes/{node_fid}/processes/', recurse=True):
+        parts = x['Key'].split('/', 5)
+        if len(parts) == 5:
+            proc_fidks.append(fid_key(parts[-1]))
     return [
-        Process(name=proc_id2name(cns, node_name, k),
-                fid=Fid(0x7200000000000001, k),
-                ep=get_kv_safe(
-                    cns, f'm0conf/nodes/{node_name}/processes/{k}/endpoint'),
-                status=process_status(cns, node_name, k)) for k in fidk_list
+        Process(
+            name=proc_id2name(cns, node_name, k),
+            fid=Fid(0x7200000000000001, k),
+            ep=(
+                kv_value_as_str(
+                    cns,
+                    f'm0conf/nodes/{node_name}/processes/{k}/endpoint'
+                ) or '**ERROR**'),
+            status=process_status(cns, node_name, k))
+        for k in sorted(proc_fidks)
     ]
 
 
@@ -181,13 +208,13 @@ def cluster_online() -> bool:
 
 @repeat_if_fails(max_retries=24)
 def get_cluster_status(cns: Consul) -> Dict[str, Any]:
-    nodes = [(Host(name=h, svcs=processes(cns, h)))._asdict()
-             for h in hosts(cns)]
     return {
-        'profile': profile(cns),
         'pools': [x for x in sns_pools(cns)],
+        'profiles': [{'fid': x.fid, 'name': x.name, 'pools': x.pools}
+                     for x in profiles(cns)],
         'filesystem': get_fs_stats(cns),
-        'nodes': nodes
+        'nodes': [Node(name=h, svcs=processes(cns, h))
+                  for h in node_names(cns)]
     }
 
 
@@ -205,32 +232,40 @@ def setup_logging():
 
 
 @repeat_if_fails(max_retries=24)
-def show_text_status(cns: Consul):
+def show_text_status(cns: Consul) -> None:
     # In-memory buffer required because an intermittent Consul exception can
     # happen right in the middle of printing something. It is good to postpone
     # the printing to stdout until the moment when those exceptions can't
     # appear anymore.
     with io.StringIO() as stream:
-        # Raised exception will cross  the 'with' border so that the stream
+        # Raised exception will cross the 'with' border so that the stream
         # will be closed and its memory will be released.
-        #
         def echo(text):
             print(text, file=stream)
 
-        def flush():
-            print(stream.getvalue())
+        pools = sns_pools(cns)
+        assert pools
+        echo('Data pool{}:'.format('s' if len(pools) > 1 else ''))
+        echo('    # fid name')
+        for pool in pools:
+            echo(f'    {pool.fid} {pool.name!r}')
 
-        echo('Profile: ' + profile(cns))
-        echo('Data pools:')
-        for x in sns_pools(cns):
-            echo(f'    {x}')
+        profs = profiles(cns)
+        assert profs
+        echo('Profile{}:'.format('s' if len(profs) > 1 else ''))
+        echo('    # fid name: pool(s)')
+        for prof in profs:
+            assert prof.pools
+            pools_repr = ' '.join(repr(x) for x in prof.pools)
+            echo(f'    {prof.fid} {prof.name!r}: {pools_repr}')
+
         echo('Services:')
-        for h in hosts(cns):
+        for h in node_names(cns):
             echo(f'    {h} {leader_tag(cns, h)}')
             for p in processes(cns, h):
                 fid: str = f'{p.fid}'
                 echo(f'    [{p.status}]  {p.name:<9}  {fid:<23}  {p.ep}')
-        flush()
+        print(stream.getvalue(), end='')  # flush
 
 
 def main(argv=None):
@@ -238,14 +273,15 @@ def main(argv=None):
     opts = parse_opts(argv)
     cns = Consul()
     if not cluster_online():
-        print('Cluster is not running.', file=sys.stderr)
+        print('Cluster is not running', file=sys.stderr)
         return 1
 
     if opts.json:
         status = get_cluster_status(cns)
-        print(j.dumps(status, indent=2, cls=FidEncoder))
-        return 0
-    show_text_status(cns)
+        print(json.dumps(status, indent=2, cls=FidEncoder))
+    else:
+        show_text_status(cns)
+    return 0
 
 
 if __name__ == '__main__':

--- a/utils/m0crate-io-conf
+++ b/utils/m0crate-io-conf
@@ -23,14 +23,14 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 PATH=$PATH:/opt/seagate/cortx/hare/bin
 
-## Return profile fid.
+## Fid of the first profile.
 ##
 ## Sample output:
 ## ```
 ## 0x7000000000000001:0x2e
 ## ```
-profile_fid() {
-    consul kv get m0conf/profiles
+first_profile_fid() {
+    consul kv get -keys 'm0conf/profiles/' | head -1 | cut -d/ -f3
 }
 
 ## Return process fid and endpoint of every motr client.
@@ -65,7 +65,7 @@ CrateConfig_Sections: [MOTR_CONFIG, WORKLOAD_SPEC]
 MOTR_CONFIG:
    MOTR_LOCAL_ADDR: $local_ep
    MOTR_HA_ADDR:    $hax_ep
-   PROF: <$(profile_fid)>  # Profile fid
+   PROF: <$(first_profile_fid)>  # Profile fid
    LAYOUT_ID: 9                      # Defines the UNIT_SIZE (9: 1MB)
    IS_OOSTORE: 1                     # Is oostore-mode?
    IS_READ_VERIFY: 0                 # Enable read-verify?

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -203,8 +203,11 @@ append_s3_svc() {
           }
         ]
     }"
+    local first_profile_fid=$(
+        consul kv get -keys 'm0conf/profiles/' | head -1 | cut -d/ -f3)
+    [[ -n $first_profile_fid ]]  # assert
     cat <<EOF | sudo tee /etc/sysconfig/s3server-$fid > /dev/null
-MOTR_PROFILE_FID=`consul kv get m0conf/profiles`
+MOTR_PROFILE_FID=$first_profile_fid
 MOTR_S3SERVER_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'


### PR DESCRIPTION
### 🧑‍🔬 Note to QA engineers and Hare maintainers

This patch should not break LDR1 setups (they use single SNS pool).  Please run the usual set of LDR1 tests (preferably on HW setup) and if they pass — merge the patch.  It's OK to postpone testing of multipool configurations.  **The longer this branch remains unmerged, the more it rots.**

---

Context:
- _Pools_ refer to non-overlapping sets of disks.
- _Profile_ is a reference to one or more pools.
- When Motr client is started, it receives profile fid from the command line.  Motr client will only be able to use those pools, which are referred to by its profile.

So far `cfgen` was only able to generate Motr configuration with a single SNS pool and a single profile.  This patch adds multipools support.

Solution:
* Extend CDF format so that multiple SNS pools and profiles can be specified:
  - add optional `disk_refs` field to pool descriptor.  `disk_refs` assign disks to SNS pools;
  - add optional `profiles` section.
* Update `hctl status` to show fids and names of profiles and SNS pools.
* Modify Consul KV schema:
  - revise `m0conf/profiles/` entries;
  - add `m0conf/pools/` entries;
  - update 4/KV RFC correspondingly.

![global config update](https://user-images.githubusercontent.com/17462/97111000-f002c500-16e4-11eb-9c1c-a4c457b3252a.jpeg)

Some uses of multiple pools:
* Distribute pools between groups of users.  When users work with different pools, they are less likely to overwrite each other's data.
* Use different striping patterns: 8+2 for one pool, 16+2 for another, etc.
* Hardware addition --- new disks form new pool.

---

Jira: [EOS-13951](https://jts.seagate.com/browse/EOS-13951)