### PR TITLE
Problem: setup.py uses wrong utils package

### DIFF
--- a/provisioning/logrotate/physical
+++ b/provisioning/logrotate/physical
@@ -1,0 +1,9 @@
+/var/log/hare/*.log
+{
+    rotate 10
+    maxsize 50M
+    weekly
+    compress
+    missingok
+    copytruncate
+}

--- a/provisioning/setup.py
+++ b/provisioning/setup.py
@@ -28,8 +28,7 @@ import logging
 import shutil
 import subprocess
 
-from eos.utils.product_features import unsupported_features
-
+from cortx.utils.product_features import unsupported_features
 
 def get_data_from_provisioner_cli(method, output_format='json') -> str:
     try:
@@ -76,7 +75,7 @@ class UnsupportedFeatures(argparse.Action):
                 setup_info = get_data_from_provisioner_cli('get_setup_info')
                 if setup_info != 'unknown':
                     for setup in hare_unavailable_features['setup_types']:
-                        if setup['name'] == setup_info['server_type']:
+                        if setup['server_type'] == setup_info['server_type']:
                             features_unavailable.extend(
                                 setup['unsupported_features'])
                             _report_unsupported_features(features_unavailable)

--- a/provisioning/setup_info.json
+++ b/provisioning/setup_info.json
@@ -1,19 +1,22 @@
 {
     "setup_types": [
         {
-            "name":"virtual",
+            "server_type":"virtual",
             "unsupported_features": ["hctl_node"]
         },
         {
-            "name":"5u84",
+            "server_type":"physical",
+            "storage_type":"5u84",
             "unsupported_features": []
         },
         {
-            "name":"PODS",
+            "server_type":"physical",
+            "storage_type":"PODS",
             "unsupported_features": []
         },
         {
-            "name":"JBOD",
+            "server_type":"physical",
+            "storage_type":"JBOD",
             "unsupported_features": ["hctl_node"]
         }
     ]


### PR DESCRIPTION
eos.utils python utils package is renamed to cortx-py-utils. Also
logrotate configuration file for `physical` setup is missing.

Solution:
- Use cortx-utils package instead of eos.utils package.
- Add logrotate configuration file for `physical` setups.
- Update setup_info.json file to use `server_type` instead of name.