### PR TITLE
Problem: Hax is not broadcasting the events to other node services

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -47,6 +47,9 @@ class ProcessEvent(BaseMessage):
 @dataclass
 class BroadcastHAStates(BaseMessage):
     states: List[HAState]
+    # Differentiates between local and cluster broadcast.
+    # See hax/hax/handler.py
+    is_broadcast_local: bool
     reply_to: Optional[Queue]
 
 

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -22,7 +22,7 @@ from errno import EAGAIN
 from typing import Any, List
 
 from hax.exception import ConfdQuorumException, RepairRebalanceException
-from hax.message import (BroadcastHAStates, EntrypointRequest, HaNvecGetEvent,
+from hax.message import (EntrypointRequest, HaNvecGetEvent,
                          ProcessEvent)
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
@@ -188,18 +188,13 @@ class Motr:
         return message_ids
 
     def _process_event_cb(self, fid, chp_event, chp_type, chp_pid):
-        LOG.info('fid=%s, chp_event=%s', fid, chp_event)
+        LOG.info('fid=%s, chp_event=%s chp_type=%s', fid, chp_event, chp_type)
         self.queue.put(
             ProcessEvent(
                 ConfHaProcess(chp_event=chp_event,
                               chp_type=chp_type,
                               chp_pid=chp_pid,
                               fid=fid)))
-        if chp_event == 3:
-            self.queue.put(
-                BroadcastHAStates(
-                    states=[HAState(fid=fid, status=ServiceHealth.FAILED)],
-                    reply_to=None))
 
     def _stob_ioq_event_cb(self, fid, sie_conf_sdev, sie_stob_id, sie_fd,
                            sie_opcode, sie_rc, sie_offset, sie_size,

--- a/hax/hax/servicemon.py
+++ b/hax/hax/servicemon.py
@@ -75,7 +75,9 @@ class ServiceMonitor(StoppableThread):
         if not state_list:
             return
         LOG.debug('Changes in statuses: %s', state_list)
-        self.q.put(BroadcastHAStates(states=state_list, reply_to=None))
+        self.q.put(BroadcastHAStates(states=state_list,
+                                     is_broadcast_local=False,
+                                     reply_to=None))
 
     def _execute(self):
         service_names: List[str] = self._get_services()
@@ -91,7 +93,7 @@ class ServiceMonitor(StoppableThread):
 
                     for name in service_names:
                         health: HAState = self.consul.get_local_service_health(
-                            name)
+                                              name)
                         if (health.status != known_statuses[name]):
                             delta.append(health)
                             known_statuses[name] = health.status

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -159,6 +159,44 @@ class SnsCmStatus(Enum):
     CM_STATUS_PAUSED = 4
 
 
+class m0HaProcessEvent(Enum):
+    M0_CONF_HA_PROCESS_STARTING = 0
+    M0_CONF_HA_PROCESS_STARTED = 1
+    M0_CONF_HA_PROCESS_STOPPING = 2
+    M0_CONF_HA_PROCESS_STOPPED = 3
+
+    def str_to_Enum(self):
+        events = {'M0_CONF_HA_PROCESS_STARTING':
+                  self.M0_CONF_HA_PROCESS_STARTING,
+                  'M0_CONF_HA_PROCESS_STARTED':
+                  self.M0_CONF_HA_PROCESS_STARTED,
+                  'M0_CONF_HA_PROCESS_STOPPING':
+                  self.M0_CONF_HA_PROCESS_STOPPING,
+                  'M0_CONF_HA_PROCESS_STOPPED':
+                  self.M0_CONF_HA_PROCESS_STOPPED}
+        return events[self.name]
+
+    def __repr__(self):
+        return self.name
+
+
+class m0HaProcessType(Enum):
+    M0_CONF_HA_PROCESS_OTHER = 0
+    M0_CONF_HA_PROCESS_KERNEL = 1
+    M0_CONF_HA_PROCESS_M0MKFS = 2
+    M0_CONF_HA_PROCESS_M0D = 3
+
+    def str_to_Enum(self):
+        types = {'M0_CONF_HA_PROCESS_OTHER': self.M0_CONF_HA_PROCESS_OTHER,
+                 'M0_CONF_HA_PROCESS_KERNEL': self.M0_CONF_HA_PROCESS_KERNEL,
+                 'M0_CONF_HA_PROCESS_M0MKFS': self.M0_CONF_HA_PROCESS_M0MKFS,
+                 'M0_CONF_HA_PROCESS_M0D': self.M0_CONF_HA_PROCESS_M0D}
+        return types[self.name]
+
+    def __repr__(self):
+        return self.name
+
+
 # struct m0_spiel_repreb_status
 ReprebStatus = NamedTuple('ReprebStatus', [('fid', Fid),
                                            ('state', SnsCmStatus),

--- a/rules/ha-notify
+++ b/rules/ha-notify
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+h0q bq HA_NOTIFY "$HARE_RC_EVENT_PAYLOAD"


### PR DESCRIPTION
Hax detects motr process failures through service monitor but broadcasts
the events only to local node's motr processes. Due to this motr processes
from peer nodes do not have knowledge about the failure and continue to
use stale connections.
Motr requires for the processes to reconnect on restarts otherwise
subsequent IO fails. Reconnection happens on the respective process stop/
failed/start events.

Solution:
- Use Hare EQ and BQ infrastructure to broadcast process events to all the
  motr processes in the cluster.
- Distinguish between motr-mkfs and m0d process events using process event
  type.