### PR TITLE
Problem: make rpm fails as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ HAX_EXE            = $(DESTDIR)/$(PREFIX)/bin/hax
 HAX_EGG_LINK       = $(DESTDIR)/$(PREFIX)/lib/python3.$(PY3_VERSION_MINOR)/site-packages/hax.egg-link
 SYSTEMD_CONFIG_DIR = $(DESTDIR)/usr/lib/systemd/system
 LOGROTATE_CONF_DIR = $(DESTDIR)/etc/logrotate.d
-ETC_CRON_DIR       = /etc/cron.hourly
+ETC_CRON_DIR       = $(DESTDIR)/etc/cron.hourly
 
 # dhall-bin {{{2
 vendor/dhall-bin/$(DHALL_VERSION)/dhall-$(DHALL_VERSION)-x86_64-linux.tar.bz2:
@@ -235,6 +235,7 @@ install-dirs:
 		  $(HARE_CONF_LOG) \
 		  $(HARE_LIBEXEC) \
 		  $(HARE_RULES) \
+		  $(ETC_CRON_DIR) \
 		  $(DESTDIR)/run/cortx \
 		  $(DESTDIR)/var/log/hare \
 		  $(DESTDIR)/etc/logrotate.d \

--- a/hare.spec
+++ b/hare.spec
@@ -76,8 +76,9 @@ rm -rf %{buildroot}
 %{_exec_prefix}/lib/systemd/system/*
 %{_sharedstatedir}/hare/
 %{_localstatedir}/motr/hax/
+%{_sysconfdir}/cron.hourly/*
+%{_sysconfdir}/logrotate.d/*
 /opt/seagate/cortx/hare/*
-/etc/logrotate.d/hare
 
 %post
 systemctl daemon-reload


### PR DESCRIPTION
Solution: Fix installation of m0trace-prune cron file by using DESTDIR prefix for `install` target and referring the file with `%{_sysconfdir}/cron.hourly/*` in hare.spec.

Closes #1388.