### PR TITLE
EOS-14192: IO fails after ioservice restart

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -22,13 +22,13 @@ from errno import EAGAIN
 from typing import Any, List
 
 from hax.exception import ConfdQuorumException, RepairRebalanceException
-from hax.message import (BroadcastHAStates, EntrypointRequest, HaNvecGetEvent,
+from hax.message import (EntrypointRequest, HaNvecGetEvent,
                          ProcessEvent)
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats, HaNote,
                        HaNoteStruct, HAState, MessageId, ObjT, ReprebStatus,
-                       StobIoqError)
+                       StobIoqError, ServiceHealth)
 from hax.util import ConsulUtil
 
 LOG = logging.getLogger('hax')
@@ -171,7 +171,7 @@ class Motr:
         cns = ConsulUtil()
 
         def ha_obj_state(st):
-            return HaNoteStruct.M0_NC_ONLINE if st.status == 'online' \
+            return HaNoteStruct.M0_NC_ONLINE if st.status == ServiceHealth.OK \
                 else HaNoteStruct.M0_NC_FAILED
 
         notes = []
@@ -195,10 +195,6 @@ class Motr:
                               chp_type=chp_type,
                               chp_pid=chp_pid,
                               fid=fid)))
-        if chp_event == 3:
-            self.queue.put(
-                BroadcastHAStates(states=[HAState(fid=fid, status='offline')],
-                                  reply_to=None))
 
     def _stob_ioq_event_cb(self, fid, sie_conf_sdev, sie_stob_id, sie_fd,
                            sie_opcode, sie_rc, sie_offset, sie_size,


### PR DESCRIPTION
    When motr service (confd or ioservice) fails Consul detects the same via hare
    consul service watcher. The state is updated in the Consul services catalog which
    is then replicated to all the Consul nodes. Consul agents notify the the local hare
    hax service which then broadcasts the event to all the local motr processes.
    The failure broadcast was happening which helps motr clients to disconnect
    from the failed peer motr service but service online broadcast did not
    happen due to wrong status check. Due to this the motr cliens were not able
    to re-establish the connection with the restarted motr service.

    The consul service watch mechanism is based on systemd and watches systemd unit state.
    The watch is triggered every 1s and every change in systemd unit is detected and
    notified to hax service over http.

    Solution:
    Check for ServiceHealth.OK instead of 'online' while broadcasting process event to
    motr services.