### PR TITLE
Problem: "nodes" subtree in "hctl status --json" is broken

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -23,6 +23,7 @@ import json
 import argparse
 import io
 import logging
+import simplejson
 import sys
 from subprocess import PIPE, Popen
 from typing import Any, Dict, List, NamedTuple, Optional
@@ -45,12 +46,8 @@ class Fid:
     def __repr__(self):
         return f'{self.__class__.__name__}({self.container:#x}, {self.key:#x})'
 
-
-class FidEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, Fid):
-            return str(obj)
-        return super().default(obj)
+    def for_json(self):
+        return self.__str__()
 
 
 Profile = NamedTuple('Profile', [
@@ -306,7 +303,7 @@ def main(argv=None):
 
     if opts.json:
         status = get_cluster_status(cns)
-        print(json.dumps(status, indent=2, cls=FidEncoder))
+        print(simplejson.dumps(status, indent=2, for_json=True))
     else:
         show_text_status(cns)
     return 0


### PR DESCRIPTION
Process type is a typing.NamedTuple which is converted to JSON with json
library incorrectly. This makes the part of "hctl status --json" payload already unparseable.

Here is how this subtree looks now:
```
  "nodes": [
    [
      "localhost",
      [
        [
          "hax",
          "0x7200000000000001:0x6",
          "192.168.6.214@tcp:12345:1:1",
          "started"
        ],
        [
          "confd",
          "0x7200000000000001:0x9",
          "192.168.6.214@tcp:12345:2:1",
          "started"
        ],
        [
          "ioservice",
          "0x7200000000000001:0xc",
          "192.168.6.214@tcp:12345:2:2",
          "started"
        ],
        [
          "m0_client",
          "0x7200000000000001:0x28",
          "192.168.6.214@tcp:12345:4:1",
          "unknown"
        ],
        [
          "m0_client",
          "0x7200000000000001:0x2b",
          "192.168.6.214@tcp:12345:4:2",
          "unknown"
        ]
      ]
    ]
  ]
```
So under "nodes" there is a list which messes up node name (string) with Process details (erroneously shown as sub-lists).

Solution: use simplejson instead for handling --json option.

Fixed output looks as follows:
```
  "nodes": [
    {
      "name": "localhost",
      "svcs": [
        {
          "name": "hax",
          "fid": "0x7200000000000001:0x6",
          "ep": "192.168.6.214@tcp:12345:1:1",
          "status": "started"
        },
        {
          "name": "confd",
          "fid": "0x7200000000000001:0x9",
          "ep": "192.168.6.214@tcp:12345:2:1",
          "status": "started"
        },
        {
          "name": "ioservice",
          "fid": "0x7200000000000001:0xc",
          "ep": "192.168.6.214@tcp:12345:2:2",
          "status": "started"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x28",
          "ep": "192.168.6.214@tcp:12345:4:1",
          "status": "unknown"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x2b",
          "ep": "192.168.6.214@tcp:12345:4:2",
          "status": "unknown"
        }
      ]
    }
  ]
```

