### PR TITLE
EOS-14739:fs_free_seg, fs_free_disk is not reducing after a huge s3 IOs

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -24,7 +24,7 @@ from typing import List
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
 from hax.types import FsStatsWithTime, StoppableThread
-from hax.util import ConsulUtil
+from hax.util import ConsulUtil, repeat_if_fails
 
 LOG = logging.getLogger('hax')
 
@@ -92,12 +92,14 @@ class FsStatsUpdater(StoppableThread):
             ffi.shun_motr_thread()
             LOG.debug('filesystem stats updater thread exited')
 
+    @repeat_if_fails()
     def _ioservices_running(self) -> List[bool]:
         statuses = self.consul.get_m0d_statuses()
         LOG.debug('The following statuses received: %s', statuses)
         started = ['M0_CONF_HA_PROCESS_STARTED' == v[1] for v in statuses]
         return started
 
+    @repeat_if_fails()
     def _ensure_motr_all_started(self):
         while True:
             started = self._ioservices_running()

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -372,6 +372,7 @@ class ConsulUtil:
                             service_type=srv_type))
         return services
 
+    @repeat_if_fails()
     def get_conf_obj_status(self, obj_t: ObjT, fidk: int) -> str:
         # 'node/<node_name>/process/<process_fidk>/service/type'
         node_items = self.kv.kv_get('m0conf/nodes', recurse=True)


### PR DESCRIPTION
The changes in this PR are for two issues :
1. The original one as reported in JIRA ticket :
In this, hax service had got stopped upon getting HAConsistencyException while trying to access Consul KV in function get_conf_obj_status. This had happened when the consul had lost the leader and new leader election again had happened. So, in this PR the decorator has been put for get_conf_obj_status to make retries forever.

2. The issue which I had seen during attempts to repro, and mentioned in the JIRA ticket comments (failure which had occurred during access to consul catalog) :
Similar to above, the decorator has been put around function "_ensure_motr_all_started".

The testing for this issue has been done by killing the consul process and checking that the retries are being made and recovery is successful and hax / fs-stats-updater doesn't get stopped.

The Jenkins build is passed for this PR branch changes :
http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.8/job/cortx-custom-ci/142/
RPM used for testing on hardware : 
http://cortx-storage.colo.seagate.com/releases/cortx/github/integration-custom-ci/release/centos-7.8.2003/custom-build-142