### PR TITLE
Problem: Hax consumer thread logs long debug messages

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -77,7 +77,6 @@ class ConsumerThread(StoppableThread):
                             raise StopIteration()
                         item = pull_msg()
 
-                    LOG.debug('Got %s message from queue', item)
                     if isinstance(item, EntrypointRequest):
                         # While replying any Exception is catched. In such a
                         # case, the motr process will receive EAGAIN and


### PR DESCRIPTION
Problem: Hax consumer thread logs long debug messages

Hax consymer thread writes long debug log messages. It creates
IEM processing in SSPL slow. This needs to be fixed by writing
proper optimised messages.

Solution:
Skip long hax debgug messages.
