### PR TITLE
Problem: delayed motr service failure notification from hax leads to motr crash

### DIFF
--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -541,7 +541,21 @@ static void msg_is_delivered_cb(struct m0_halon_interface *hi,
 static void msg_is_not_delivered_cb(struct m0_halon_interface *hi,
 				    struct m0_ha_link *hl, uint64_t tag)
 {
-	M0_LOG(M0_DEBUG, "noop");
+	struct m0_fid *proc_fid = &hl->hln_conn_cfg.hlcc_rpc_service_fid;
+
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
+
+	/* Notify hax about delivery failure. */
+	M0_LOG(M0_DEBUG, "msg not delivered, tag=%"PRIu64,
+		hl->hln_tag_broadcast_delivery);
+
+	PyObject *py_fid = toFid(proc_fid);
+	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
+			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
+			    hl->hln_tag_broadcast_delivery, hl);
+	Py_DECREF(py_fid);
+	PyGILState_Release(gstate);
 }
 
 static void link_connected_cb(struct m0_halon_interface *hi,

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -54,13 +54,25 @@ def to_ha_states(data: Any) -> List[HAState]:
     if not data:
         return []
 
-    def get_status(checks: List[Dict[str, Any]]) -> ServiceHealth:
-        ok = all(x.get('Status') == 'passing' for x in checks)
-        return ServiceHealth.OK if ok else ServiceHealth.FAILED
+    def get_svc_node(checks: List[Dict[str, Any]], svc_id: str) -> str:
+        for x in checks:
+            if x.get('ServiceID') == svc_id:
+                return str(x.get('Node'))
+        return ""
+
+    def get_svc_health(item: Any) -> ServiceHealth:
+        node = get_svc_node(item['Checks'], item['Service']['ID'])
+        LOG.debug('Checking current state of the process %s',
+                  item['Service']['ID'])
+        status: ServiceHealth = ConsulUtil().get_service_health(
+                                               item['Service']['Service'],
+                                               node,
+                                               int(item['Service']['ID']))
+        return status
 
     return [
         HAState(fid=create_process_fid(int(t['Service']['ID'])),
-                status=get_status(t['Checks'])) for t in data
+                status=get_svc_health(t)) for t in data
     ]
 
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -216,3 +216,41 @@ class ServiceHealth(Enum):
 
 
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])
+
+
+class m0HaProcessEvent(Enum):
+    M0_CONF_HA_PROCESS_STARTING = 0
+    M0_CONF_HA_PROCESS_STARTED = 1
+    M0_CONF_HA_PROCESS_STOPPING = 2
+    M0_CONF_HA_PROCESS_STOPPED = 3
+
+    def str_to_Enum(self, evt):
+        events = {'M0_CONF_HA_PROCESS_STARTING':
+                  self.M0_CONF_HA_PROCESS_STARTING,
+                  'M0_CONF_HA_PROCESS_STARTED':
+                  self.M0_CONF_HA_PROCESS_STARTED,
+                  'M0_CONF_HA_PROCESS_STOPPING':
+                  self.M0_CONF_HA_PROCESS_STOPPING,
+                  'M0_CONF_HA_PROCESS_STOPPED':
+                  self.M0_CONF_HA_PROCESS_STOPPED}
+        return events[evt]
+
+    def __repr__(self):
+        return self.name
+
+
+class m0HaProcessType(Enum):
+    M0_CONF_HA_PROCESS_OTHER = 0
+    M0_CONF_HA_PROCESS_KERNEL = 1
+    M0_CONF_HA_PROCESS_M0MKFS = 2
+    M0_CONF_HA_PROCESS_M0D = 3
+
+    def str_to_Enum(self):
+        types = {'M0_CONF_HA_PROCESS_OTHER': self.M0_CONF_HA_PROCESS_OTHER,
+                 'M0_CONF_HA_PROCESS_KERNEL': self.M0_CONF_HA_PROCESS_KERNEL,
+                 'M0_CONF_HA_PROCESS_M0MKFS': self.M0_CONF_HA_PROCESS_M0MKFS,
+                 'M0_CONF_HA_PROCESS_M0D': self.M0_CONF_HA_PROCESS_M0D}
+        return types[self.name]
+
+    def __repr__(self):
+        return self.name

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -32,7 +32,8 @@ from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
 
 from hax.exception import HAConsistencyException
-from hax.types import ConfHaProcess, Fid, FsStatsWithTime, ObjT
+from hax.types import (ConfHaProcess, Fid, FsStatsWithTime,
+                       ObjT, ServiceHealth)
 
 __all__ = ['ConsulUtil', 'create_process_fid', 'create_drive_fid']
 
@@ -300,29 +301,29 @@ class ConsulUtil:
             raise HAConsistencyException('Failed to communicate to'
                                          ' Consul Agent') from e
 
+    def get_svc_status(self, srv_fid: Fid) -> str:
+        try:
+            key = f'processes/{srv_fid}'
+            raw_data = self.kv.kv_get(key)
+            LOG.debug('Raw value from KV: %s', raw_data)
+            data = raw_data['Value']
+            value: str = json.loads(data)['state']
+            return value
+        except Exception:
+            return 'Unknown'
+
     def get_m0d_statuses(self) -> List[Tuple[ServiceData, str]]:
         """
         Return the list of all Motr service statuses according to Consul
         watchers. The following services are considered: ios, confd.
         """
-        def get_status(srv: ServiceData) -> str:
-            try:
-                key = f'processes/{srv.fid}'
-                raw_data = self.kv.kv_get(key)
-                LOG.debug('Raw value from KV: %s', raw_data)
-                data = raw_data['Value']
-                value: str = json.loads(data)['state']
-                return value
-            except Exception:
-                return 'Unknown'
-
         m0d_services = set(['ios', 'confd'])
         result = []
         for service_name in self._catalog_service_names():
             if service_name not in m0d_services:
                 continue
             data = self.get_service_data_by_name(service_name)
-            result += [(item, get_status(item)) for item in data]
+            result += [(item, self.get_svc_status(item.fid)) for item in data]
         return result
 
     def get_service_data_by_name(self, name: str) -> List[ServiceData]:
@@ -362,6 +363,33 @@ class ConsulUtil:
                 FidWithType(fid=mk_fid(ObjT.SERVICE, srv_fidk),
                             service_type=srv_type))
         return services
+
+    def is_proc_client(self, process_fid: Fid) -> bool:
+        node_items = self.kv.kv_get('m0conf/nodes', recurse=True)
+        fidk = str(process_fid.key)
+
+        # This is the RegExp to match the keys in Consul KV that describe
+        # the Motr services that are enclosed into the Motr process that has
+        # the given fidk.
+        # We filter out motr client entries to check if the given process fid
+        # corresponds to a motr client or server process.
+        #
+        # Note: we assume that fidk uniquely identifies the given process
+        # within the whole cluster (that's why we are not interested in the
+        # hostnames here).
+        #
+        # Examples of the key that will match:
+        #   m0conf/nodes/srvnode-1/processes/39/services/m0_client_s3
+        regex = re.compile(
+            f'^m0conf\\/.*\\/processes\\/{fidk}\\/services\\/(.+)$')
+        for node in node_items:
+            match_result = re.match(regex, node['Key'])
+            if not match_result:
+                continue
+            srv_type = match_result.group(1)
+            if 'm0_client' in srv_type:
+                return True
+        return False
 
     def get_conf_obj_status(self, obj_t: ObjT, fidk: int) -> str:
         # 'node/<node_name>/process/<process_fidk>/service/type'
@@ -429,6 +457,15 @@ class ConsulUtil:
         LOG.debug('Setting process status in KV: %s:%s', key, data)
         self.kv.kv_put(key, data)
 
+    def get_process_status(self, event: ConfHaProcess) -> None:
+        assert 0 <= event.chp_event < len(ha_process_events), \
+            f'Invalid event type: {event.chp_event}'
+
+        data = json.dumps({'state': ha_process_events[event.chp_event]})
+        key = f'processes/{event.fid}'
+        LOG.debug('Setting process status in KV: %s:%s', key, data)
+        self.kv.kv_put(key, data)
+
     def drive_name_to_id(self, uid: str) -> str:
         drive_id = ''
         # 'm0conf/nodes/<node_name>/processes/<process_fidk>/disks/<disk_uuid>'
@@ -446,6 +483,32 @@ class ConsulUtil:
         key = f'process/{fid}'
         LOG.debug('Setting disk state in KV: %s:%s', key, data)
         self.kv.kv_put(key, data)
+
+    @repeat_if_fails()
+    def get_service_health(self, service_name: str,
+                           node: str, svc_id: int) -> ServiceHealth:
+
+        try:
+            node_data: List[Dict[str, Any]] = self.cns.health.node(node)[1]
+            LOG.debug('Node Data: %s', node_data)
+            status = ServiceHealth.UNKNOWN
+            for item in node_data:
+                if (item['ServiceName'] == service_name and
+                        item['ServiceID'] == str(svc_id)):
+                    if item['Status'] == 'passing':
+                        status = ServiceHealth.OK
+                    elif item['Status'] == 'warning':
+                        fid = create_process_fid(svc_id)
+                        svc_consul_status = self.get_svc_status(fid)
+                        if svc_consul_status in ('M0_CONF_HA_PROCESS_STARTING',
+                                                 'M0_CONF_HA_PROCESS_STARTED'):
+                            status = ServiceHealth.OK
+                    else:
+                        status = ServiceHealth.FAILED
+        except (ConsulException, HTTPError, RequestException) as e:
+            raise HAConsistencyException('Failed to communicate '
+                                         'to Consul Agent') from e
+        return status
 
 
 def dump_json(obj) -> str:


### PR DESCRIPTION
    Motr process now notifies systemd a bit later than earlier. During node crash and failover,
    Consul and watcher is up and it finds that motr confd process has not started yet.
    Presently Hax just checks if the status of the process is passing where if the process is in
    activating state its corresponding consul status is warning, this is interpreted as failed by hax.
    Meanwhile, the entrypoint request from motr process is been serviced by hax, once motr gets the
    entrypoint reply the halink is established. In parallel hax decides that the process has failed
    because the status reported by Consul is warning and not passing. Hax notifies the same to
    everyone including itself and disconnects the halink with the just started motr process.
    On receiving the failure notification motr process tries to fetch the entrypoint details again
    from hax, but this is the second time. It expects halink to be present but its already disconnected.
    Thus motr process on understanding this in the entrypoint reply panics and crashes with
    `Motr panic: !rep->hae_disconnected_previously at ha_entrypoint_state_cb()`.

    Solution:
    1. Check first_request param from entrypoint request and take action as follows,
      1.1. If `first_request = true` notify FAILED for the motr process and disconnect halinks if any
           with respect to that process.
      1.2. Check for only motr server process restarts and wait until FAILED notifications are
           delivered before sending entrypoint reply.
    2. Handle delayed failure notifications from Consul
      2.1. Query the present process status from consul when hax receives notification from Consul
           and broacast the present status only.
      2.2. Check if the status reported by the process is `warning` if not `passing`. In case of
           `warning` check the Consul status of the process if its already M0_CONF_HA_PROCESS_STARTED,
           if so then do not report process as failed again, hax has already reported all the other motr
           processes that the this one has restarted (see point 1).
      2.3. If 2.2 does not satisfy then report FAILED for the process.

    Addresses EOS-14988
    Closes #1396

    Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>