### PR TITLE
bootstrap-node: fix hax startup of client-only nodes

### DIFF
--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -156,11 +156,10 @@ wait_m0d_started() {
     done
 }
 
-if [[ -n $CONFD_IDs || -n $IOS_IDs ]]; then
-    sudo mkdir -p /var/motr/hax
-    sudo systemctl start hare-hax
-    wait_active hare-hax 5
-fi
+# Make sure hax is always started.
+sudo mkdir -p /var/motr/hax
+sudo systemctl start hare-hax
+wait_active hare-hax 5
 
 if [[ -n $CONFD_IDs && $phase == phase1 ]]; then
     [[ -f /var/lib/hare/confd.xc ]] ||


### PR DESCRIPTION
Currently, hax starts on the nodes which run confd or ios
which is wrong. Client-only nodes should have hax running also.

Solution: fix bootstrap-node to start hax always on the node,
regardless of its configuration.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>