### PR TITLE
cfgen: fix client-only nodes configuration

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -217,10 +217,14 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
         node['facts']['_memsize_MB'] = int(float(
             node['facts']['memorysize_mb']))
 
+        if 'm0_servers' not in node:
+            continue
+
         for m0d in node['m0_servers']:
             m0d.setdefault('runs_confd', False)
             m0d['_io_disks'] = get_disks(node['hostname'], mock_p,
                                          m0d['io_disks']['data'])
+
     if 'profiles' not in desc:
         sns_pools = [pool['name'] for pool in desc['pools']
                      if pool_type(pool) is PoolT.sns]
@@ -256,6 +260,12 @@ def validate_nodes_desc(nodes_desc: List[Dict[str, Any]]) -> None:
         assert node['facts'][ipaddr_key(iface)], \
             f"""{name}: {iface!r} interface has no IP address
 Make sure the value of data_iface in the CDF is correct."""
+
+        if 'm0_servers' not in node:
+            assert (node['m0_clients']['s3']
+                    + node['m0_clients']['other'] > 0), \
+                f'{name}: At least one client should be configured'
+            continue
 
         nr_confds = sum(1 for m0d in node['m0_servers'] if m0d['runs_confd'])
         assert nr_confds < 2, f'{name}: Too many confd services'
@@ -1688,7 +1698,10 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
         ctrl_id = None
-        if any(m0d['_io_disks'] for m0d in node['m0_servers']):
+        m0ds = []
+        if 'm0_servers' in node:
+            m0ds = node['m0_servers']
+        if any(m0d['_io_disks'] for m0d in m0ds):
             ctrl_id = ConfController.build(conf,
                                            ConfEnclosure.build(conf, rack_id),
                                            node_id)
@@ -1696,7 +1709,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         ConfProcess.build(conf, node_id, node, ProcT.hax)
 
         confd_p = False
-        for m0d in node['m0_servers']:
+        for m0d in m0ds:
             ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
                               ctrl_id)
             if m0d['runs_confd']:

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1698,9 +1698,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
         ctrl_id = None
-        m0ds = []
-        if 'm0_servers' in node:
-            m0ds = node['m0_servers']
+        m0ds = node.get('m0_servers', [])
         if any(m0d['_io_disks'] for m0d in m0ds):
             ctrl_id = ConfController.build(conf,
                                            ConfEnclosure.build(conf, rack_id),

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional, \
 import yaml
 
 
-__version__ = '0.13'
+__version__ = '0.14'
 
 
 def parse_opts(argv):
@@ -75,7 +75,7 @@ nodes:
     data_iface: <str>  # name of network interface; e.g., eth1, eth1:c1
     data_iface_type: tcp|o2ib  # type of network interface;
                                # optional, defaults to "tcp"
-    m0_servers:
+    m0_servers:        # optional for client-only nodes
       - runs_confd: <bool>  # optional, defaults to false
         io_disks:
           meta_data: <str>  # device path for meta-data;

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -28,7 +28,7 @@ let Node =
   { hostname : Text
   , data_iface : Text
   , data_iface_type: Optional ./Protocol.dhall
-  , m0_servers : List M0Server
+  , m0_servers : Optional (List M0Server)
   , m0_clients : { s3 : Natural, other : Natural }
   }
 

--- a/rfc/18/README.md
+++ b/rfc/18/README.md
@@ -30,7 +30,7 @@ nodes:
     data_iface: <str>  # name of network interface; e.g., eth1, eth1:c1
     data_iface_type: tcp|o2ib  # type of network interface;
                                # optional, defaults to "tcp"
-    m0_servers:
+    m0_servers:        # optional for client-only nodes
       - runs_confd: <bool>  # optional, defaults to false
         io_disks:
           meta_data: <str>  # device path for meta-data;


### PR DESCRIPTION
Currently, any cluster node requires confd or ios to be
configured, which is wrong for the client-only nodes.

Solution: fix cfgen to support client-only nodes which don't
requite confd or ios to be configured.

Closes #1401.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>