### PR TITLE
EOS-15143: Consul http_max_conns_per_client exceeds and leads to connection reset

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -30,12 +30,12 @@ LOG = logging.getLogger('hax')
 
 
 class FsStatsUpdater(StoppableThread):
-    def __init__(self, motr: Motr, interval_sec=5):
+    def __init__(self, motr: Motr, consul_util: ConsulUtil, interval_sec=5):
         super().__init__(target=self._execute,
                          name='fs-stats-updater',
                          args=(motr, ))
         self.stopped = False
-        self.consul = ConsulUtil()
+        self.consul = consul_util
         self.interval_sec = interval_sec
         self.event = Event()
 

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -59,8 +59,9 @@ def _run_qconsumer_thread(queue: Queue, motr: Motr) -> ConsumerThread:
     return thread
 
 
-def _run_stats_updater_thread(motr: Motr) -> FsStatsUpdater:
-    thread = FsStatsUpdater(motr, interval_sec=30)
+def _run_stats_updater_thread(motr: Motr,
+                              consul_util: ConsulUtil) -> FsStatsUpdater:
+    thread = FsStatsUpdater(motr, consul_util, interval_sec=30)
     thread.start()
     return thread
 
@@ -99,7 +100,8 @@ def main():
 
     ffi = HaxFFI()
     herald = DeliveryHerald()
-    motr = Motr(queue=q, rm_fid=cfg.rm_fid, ffi=ffi, herald=herald)
+    motr = Motr(queue=q, rm_fid=cfg.rm_fid, ffi=ffi, herald=herald,
+                consul_util=util)
 
     # Note that consumer thread must be started before we invoke motr.start(..)
     # Reason: hax process will send entrypoint request and somebody needs
@@ -112,10 +114,10 @@ def main():
                    ha_service=cfg.ha_fid,
                    rm_service=cfg.rm_fid)
         LOG.info('Motr API has been started')
-        stats_updater = _run_stats_updater_thread(motr)
+        stats_updater = _run_stats_updater_thread(motr, util)
         # [KN] This is a blocking call. It will work until the program is
         # terminated by signal
-        run_server(q, herald, threads_to_wait=[consumer, stats_updater])
+        run_server(q, herald, util, threads_to_wait=[consumer, stats_updater])
     except Exception:
         LOG.exception('Exiting due to an exception')
     finally:


### PR DESCRIPTION
    Various sub modules of hax create multiple ConsulUtil instances which
    inturn create multiple Consul objects. In running cluster and with rising consul
    users there's a possiblity that the default number of allowed Consul client http connections
    (200) may exceed which leeds to Consul randomly dropping the subsequent http requests.
    This is presently leading to hax exception (as below) and prevents from updating filesystem
    stats in Concul kv leading to EOS-15143 issue.
    Exception stack is as follows (trace truncated),
    ```
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: Traceback (most recent call last):
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: chunked=chunked,
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: six.raise_from(e, None)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "<string>", line 3, in raise_from
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: httplib_response = conn.getresponse()
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/http/client.py", line 1346, in getresponse
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: response.begin()
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/http/client.py", line 307, in begin
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: version, status, reason = self._read_status()
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/http/client.py", line 268, in _read_status
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: return self._sock.recv_into(b)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: ConnectionResetError: [Errno 104] Connection reset by peer
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: During handling of the above exception, another exception occurred:
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: Traceback (most recent call last):
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: timeout=timeout
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 756, in urlopen
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/util/retry.py", line 531, in increment
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: raise six.reraise(type(error), error, _stacktrace)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/packages/six.py", line 734, in reraise
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: raise value.with_traceback(tb)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: chunked=chunked,
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: six.raise_from(e, None)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "<string>", line 3, in raise_from
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: httplib_response = conn.getresponse()
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/http/client.py", line 1346, in getresponse
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: response.begin()
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/http/client.py", line 307, in begin
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: version, status, reason = self._read_status()
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/http/client.py", line 268, in _read_status
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: return self._sock.recv_into(b)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: During handling of the above exception, another exception occurred:
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: Traceback (most recent call last):
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/util.py", line 145, in kv_get_raw
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: return self.cns.kv.get(key, **kwargs)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/consul/base.py", line 554, in get
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: params=params)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/consul/std.py", line 22, in get
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: self.session.get(uri, verify=self.verify, cert=self.cert)))
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/requests/sessions.py", line 555, in get
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: return self.request('GET', url, **kwargs)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/requests/sessions.py", line 542, in request
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: resp = self.send(prep, **send_kwargs)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/requests/sessions.py", line 655, in send
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: r = adapter.send(request, **kwargs)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/requests/adapters.py", line 498, in send
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: raise ConnectionError(err, request=request)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: The above exception was the direct cause of the following exception:
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: Traceback (most recent call last):
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/handler.py", line 106, in _do_work
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: item.states)
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/motr/__init__.py", line 213, in broadcast_ha_st
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/motr/__init__.py", line 281, in _generate_sub_s
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/util.py", line 339, in get_services_by_parent_p
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/util.py", line 150, in kv_get
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: return self.kv_get_raw(key, **kwargs)[1]
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: File "/home/520478/cortx-hare-fork/cortx-hare-fork-new/cortx-hare-1/hax/hax/util.py", line 147, in kv_get_raw
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: raise HAConsistencyException('Could not access Consul KV') from e
    Nov 22 11:14:20 ssc-vm-c-0552.colo.seagate.com hare-hax[11757]: hax.exception.HAConsistencyException
    ```

    References: https://github.com/hashicorp/consul/issues/7668
                https://www.consul.io/docs/agent/options.html#http_max_conns_per_client

    Solution:
    Re-use the ConsulUtil object instantiated by hax.py in various other hax submodules.

    Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>