### PR TITLE
Problem: hax creates multiple ConsulUtil instances

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -30,12 +30,12 @@ LOG = logging.getLogger('hax')
 
 
 class FsStatsUpdater(StoppableThread):
-    def __init__(self, motr: Motr, interval_sec=5):
+    def __init__(self, motr: Motr, consul_util: ConsulUtil, interval_sec=5):
         super().__init__(target=self._execute,
                          name='fs-stats-updater',
                          args=(motr, ))
         self.stopped = False
-        self.consul = ConsulUtil()
+        self.consul = consul_util
         self.interval_sec = interval_sec
         self.event = Event()
 

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -185,10 +185,11 @@ async def encode_exception(request, handler):
 def run_server(
     queue: Queue,
     herald: DeliveryHerald,
+    consul_util: ConsulUtil,
     threads_to_wait: List[StoppableThread] = [],
     port=8008,
 ):
-    node_address = ConsulUtil().get_hax_ip_address()
+    node_address = consul_util.get_hax_ip_address()
 
     # We can't use broad 0.0.0.0 IP address to make it possible to run
     # multiple hax instances at the same machine (i.e. in failover situation).


### PR DESCRIPTION
Various sub-modules of hax create multiple ConsulUtil instances which in turn create multiple Consul objects. These objects are usually destroyed by Python's GC, but sometimes there might be lagging and the number of such connections would grow beyond 200 - the default limit in Consul. After this, nobody could connect
to Consul.

Solution: re-use the ConsulUtil object instantiated by hax.py in various other hax submodules.