### PR TITLE
hare-consul: improve consul-data dir name

### DIFF
--- a/systemd/hare-consul
+++ b/systemd/hare-consul
@@ -34,4 +34,4 @@ exec consul agent \
      -client "$CLIENT" \
      $JOIN \
      -config-dir=/var/lib/hare/consul-$MODE-conf \
-     -data-dir=/var/lib/hare/consul-$BIND $EXTRA_OPTS
+     -data-dir=/var/lib/hare/consul-data-$BIND $EXTRA_OPTS

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -90,7 +90,7 @@ if [[ -n $extra_opts ]]; then
 fi
 
 # Prepare for consul-agent startup:
-sudo rm -rf /var/lib/hare/consul-$bind_addr
+sudo rm -rf /var/lib/hare/consul-data-$bind_addr
 
 conf_dir=consul-$mode-conf
 sudo mkdir -p /var/lib/hare/$conf_dir


### PR DESCRIPTION
Rename `consul-<IP>` to `consul-data-<IP>` so that it would be
easier to filter out the consul-data directory from the rest
of the configuration files at /var/lib/hare.