### PR TITLE
 Problem: mypy doesn't detect missing args of function

### DIFF
--- a/cfgen/Makefile
+++ b/cfgen/Makefile
@@ -33,8 +33,9 @@ flake8: $(PYTHON_SCRIPTS)
 	flake8 $(FLAKE8_OPTS) $^
 
 .PHONY: typecheck
+override MYPY_OPTS := --config-file ../hax/mypy.ini $(MYPY_OPTS)
 typecheck: $(PYTHON_SCRIPTS)
-	set -eu -o pipefail; for f in $^; do MYPYPATH=../stubs mypy $$f; done
+	set -eu -o pipefail; for f in $^; do MYPYPATH=../stubs mypy $(MYPY_OPTS) $$f; done
 
 .PHONY: test-cfgen
 test-cfgen: unpack-dhall-prelude

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -139,10 +139,10 @@ def main(argv=None):
     cluster = build_cluster(cluster_desc)
 
     outs: List[Tuple[str, Callable[..., str], List[Any]]] = [
-        ('consul-agents.json', generate_consul_agents, cluster),
-        ('consul-kv.json', generate_consul_kv, cluster, opts.dhall_dir),
-        ('confd.dhall', generate_confd, cluster.m0conf, opts.dhall_dir)]
-    for path, generate, *args in outs:
+        ('consul-agents.json', generate_consul_agents, [cluster]),
+        ('consul-kv.json', generate_consul_kv, [cluster, opts.dhall_dir]),
+        ('confd.dhall', generate_confd, [cluster.m0conf, opts.dhall_dir])]
+    for path, generate, args in outs:
         with open(os.path.join(opts.output_dir, path), 'w') as f:
             f.write(generate(*args))
 

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -88,7 +88,7 @@ def main():
     # _run_qconsumer_thread function.
     #
     # [KN] Note: The server is launched in the main thread.
-    q = Queue(maxsize=8)
+    q: Queue = Queue(maxsize=8)
 
     util: ConsulUtil = ConsulUtil()
     cfg = _get_motr_fids(util)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -121,7 +121,7 @@ def get_sns_status(motr_queue: Queue,
                    status_type: Union[Type[SnsRepairStatus],
                                       Type[SnsRebalanceStatus]]):
     def fn(request):
-        queue = Queue(1)
+        queue: Queue = Queue(1)
         motr_queue.put(
             status_type(reply_to=queue,
                         fid=Fid.parse(request.query['pool_fid'])))

--- a/hax/mypy.ini
+++ b/hax/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.6
 warn_return_any = True
+check_untyped_defs = True
 
 [mypy-urllib3]
 ignore_missing_imports = True


### PR DESCRIPTION
Solution:
1. make mypy behavior stricter. Use `--check-untyped-defs` flags
everywhere in the build pipeline. More details on this solution: https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code)
2. fix the type errors uncovered by enabling this mode.

The issue was revealed in #1410 
