### PR TITLE
Problem: hax generates redundant DEBUG logs

### DIFF
--- a/hax/hax/log.py
+++ b/hax/hax/log.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+import sys
+
+"""Custom log level which is more verbose than DEBUG"""
+TRACE: int = 5
+
+LOG = logging.getLogger('hax')
+
+__all__ = ['TRACE', 'setup_logging']
+
+
+def setup_logging(log_level: int = logging.DEBUG):
+    """
+    Initializes the logging for the whole application.
+
+    Registers special 'hax' named logger, configures the logging format and
+    sets the verbosity level to `log_level`.
+
+    Register custom verbosity level called TRACE. Here is the example
+    how tracing can be done:
+            LOG.log(TRACE, 'This is a trace message')
+
+    Note: This function must be invoked before any logging happens.
+    """
+    # INFO = 20, DEBUG = 10, so trace is less than DEBUG
+    logging.addLevelName(TRACE, 'TRACE')
+    hax_logger = LOG
+    hax_logger.setLevel(log_level)
+
+    formatter = logging.Formatter(
+        '%(asctime)s [%(levelname)s] {%(threadName)s} %(message)s')
+    console = logging.StreamHandler(sys.stdout)
+    console.setFormatter(formatter)
+
+    logging.getLogger('').addHandler(console)
+    logging.getLogger('consul').setLevel(logging.WARN)

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -113,22 +113,18 @@ def repeat_if_fails(wait_seconds=5, max_retries=-1):
             attempt_count = 0
             while (True):
                 try:
-                    LOG.debug('Attempting to invoke the repeatable call: %s',
-                              f.__name__)
-                    result = f(*args, **kwds)
-                    LOG.debug('The repeatable call succeeded: %s', f.__name__)
-                    return result
+                    return f(*args, **kwds)
                 except HAConsistencyException as e:
                     attempt_count += 1
                     if max_retries >= 0 and attempt_count > max_retries:
                         LOG.warn(
-                            'Too many errors happened in a row '
-                            '(max_retries = %d)', max_retries)
+                            'Function %s: Too many errors happened in a row '
+                            '(max_retries = %d)', f.__name__, max_retries)
                         raise e
-                    LOG.warn(
-                        f'Got HAConsistencyException: {e.message} '
-                        f'(attempt {attempt_count}). The'
-                        f' attempt will be repeated in {wait_seconds} seconds')
+                    LOG.warn(f'Got HAConsistencyException: {e.message} while '
+                             f'invoking function {f.__name__} '
+                             f'(attempt {attempt_count}). The attempt will be '
+                             f'repeated in {wait_seconds} seconds')
                     sleep(wait_seconds)
 
         return wrapper

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -24,6 +24,7 @@ from base64 import b64encode
 from functools import wraps
 from time import sleep
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from hax.log import TRACE
 
 import simplejson
 from consul import Consul, ConsulException
@@ -310,7 +311,7 @@ class ConsulUtil:
         try:
             key = f'processes/{srv_fid}'
             raw_data = self.kv.kv_get(key)
-            LOG.debug('Raw value from KV: %s', raw_data)
+            LOG.log(TRACE, 'Raw value from KV: %s', raw_data)
             data = raw_data['Value']
             value: str = json.loads(data)['state']
             return value
@@ -333,7 +334,7 @@ class ConsulUtil:
 
     def get_service_data_by_name(self, name: str) -> List[ServiceData]:
         services = self._catalog_service_get(name)
-        LOG.debug('Services "%s" received: %s', name, services)
+        LOG.log(TRACE, 'Services "%s" received: %s', name, services)
         return list(map(mkServiceData, services))
 
     def get_confd_list(self) -> List[ServiceData]:

--- a/hax/test/test_delivery_herald.py
+++ b/hax/test/test_delivery_herald.py
@@ -24,7 +24,7 @@ from threading import Thread
 from time import sleep
 
 from hax.exception import NotDelivered
-from hax.motr import log_exception
+from hax.log import TRACE
 from hax.motr.delivery import DeliveryHerald
 from hax.types import HaLinkMessagePromise, MessageId
 
@@ -35,10 +35,11 @@ class TestDeliveryHeraldAny(unittest.TestCase):
     """
     @classmethod
     def setUpClass(cls):
-        logging.basicConfig(
-            level=logging.DEBUG,
-            stream=sys.stdout,
-            format='%(asctime)s {%(threadName)s} [%(levelname)s] %(message)s')
+        # It seems like when unittest is invoked from setup.py,
+        # some default logging configuration is already applied;
+        # invoking setup_logging() will make the log messages to appear twice.
+        logging.addLevelName(TRACE, 'TRACE')
+        logging.getLogger('hax').setLevel(TRACE)
 
     def test_it_works(self):
         herald = DeliveryHerald()


### PR DESCRIPTION
Solution:
1. Remove obviously redundant logging in `@repeat_if_fails` decorator
2. Add custom TRACE verbosity level and use it in DeliveryHerald (since the logs make sense but probably in tests only)

Closes #1420