### PR TITLE
Problem: Consul state is not updated in case of process failure

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -21,14 +21,18 @@ import time
 from queue import Empty, Queue
 from typing import List
 
-from hax.message import (BroadcastHAStates, EntrypointRequest, HaNvecGetEvent,
+from hax.message import (BroadcastHAStates, FirstEntrypointRequest,
+                         EntrypointRequest, HaNvecGetEvent,
                          ProcessEvent, SnsRebalancePause, SnsRebalanceResume,
                          SnsRebalanceStart, SnsRebalanceStatus,
                          SnsRebalanceStop, SnsRepairPause, SnsRepairResume,
                          SnsRepairStart, SnsRepairStatus, SnsRepairStop)
 from hax.motr import Motr
+from hax.motr.delivery import DeliveryHerald
 from hax.queue.publish import EQPublisher
-from hax.types import MessageId, StobIoqError, StoppableThread
+from hax.types import (ConfHaProcess, HAState, MessageId, StobIoqError,
+                       m0HaProcessEvent, ServiceHealth, StoppableThread,
+                       HaLinkMessagePromise)
 from hax.util import ConsulUtil, dump_json, repeat_if_fails
 
 LOG = logging.getLogger('hax')
@@ -43,16 +47,36 @@ class ConsumerThread(StoppableThread):
     The thread exits gracefully when it receives message of type Die (i.e.
     it is a 'poison pill').
     """
-    def __init__(self, q: Queue, motr: Motr):
+    def __init__(self, q: Queue, motr: Motr, herald: DeliveryHerald):
         super().__init__(target=self._do_work,
                          name='qconsumer',
                          args=(q, motr))
         self.is_stopped = False
         self.consul = ConsulUtil()
         self.eq_publisher = EQPublisher()
+        self.herald = herald
 
     def stop(self) -> None:
         self.is_stopped = True
+
+    @repeat_if_fails(wait_seconds=1)
+    def _update_process_status(self, event: ConfHaProcess) -> None:
+        # If a consul-related exception appears, it will
+        # be processed by repeat_if_fails.
+        #
+        # This thread will become blocked until that
+        # intermittent error gets resolved.
+        self.consul.update_process_status(event)
+
+    def update_process_failure(self, ha_states: List[HAState]) -> None:
+        for state in ha_states:
+            if state.status == ServiceHealth.FAILED:
+                m0status = m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED
+                pevent = ConfHaProcess(chp_event=m0status,
+                                       chp_type=3,
+                                       chp_pid=0,
+                                       fid=state.fid)
+                self._update_process_status(pevent)
 
     def _do_work(self, q: Queue, motr: Motr):
         ffi = motr._ffi
@@ -78,20 +102,30 @@ class ConsumerThread(StoppableThread):
                         item = pull_msg()
 
                     LOG.debug('Got %s message from queue', item)
-                    if isinstance(item, EntrypointRequest):
+                    if isinstance(item, FirstEntrypointRequest):
+                        LOG.debug('first entrypoint request, broadcast FAILED')
+                        ids: List[MessageId] = motr.broadcast_ha_states(
+                            [HAState(fid=item.process_fid,
+                                     status=ServiceHealth.FAILED)])
+                        LOG.debug('waiting for broadcast of %s for ep: %s',
+                                  ids, item.remote_rpc_endpoint)
+                        self.herald.wait_for_all(HaLinkMessagePromise(ids))
+                        motr.send_entrypoint_request_reply(
+                            EntrypointRequest(
+                                reply_context=item.reply_context,
+                                req_id=item.req_id,
+                                remote_rpc_endpoint=item.remote_rpc_endpoint,
+                                process_fid=item.process_fid,
+                                git_rev=item.git_rev,
+                                pid=item.pid,
+                                is_first_request=item.is_first_request))
+                    elif isinstance(item, EntrypointRequest):
                         # While replying any Exception is catched. In such a
                         # case, the motr process will receive EAGAIN and
                         # hence will need to make new attempt by itself
                         motr.send_entrypoint_request_reply(item)
                     elif isinstance(item, ProcessEvent):
-                        fn = self.consul.update_process_status
-                        # If a consul-related exception appears, it will
-                        # be processed by repeat_if_fails.
-                        #
-                        # This thread will become blocked until that
-                        # intermittent error gets resolved.
-                        decorated = (repeat_if_fails(wait_seconds=5))(fn)
-                        decorated(item.evt)
+                        self._update_process_status(item.evt)
                     elif isinstance(item, HaNvecGetEvent):
                         fn = motr.ha_nvec_get_reply
                         # If a consul-related exception appears, it will
@@ -105,6 +139,7 @@ class ConsumerThread(StoppableThread):
                         LOG.info('HA states: %s', item.states)
                         result: List[MessageId] = motr.broadcast_ha_states(
                             item.states)
+                        self.update_process_failure(item.states)
                         if item.reply_to:
                             item.reply_to.put(result)
                     elif isinstance(item, StobIoqError):

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -53,8 +53,9 @@ def _setup_logging():
     logging.getLogger('consul').setLevel(logging.WARN)
 
 
-def _run_qconsumer_thread(queue: Queue, motr: Motr) -> ConsumerThread:
-    thread = ConsumerThread(queue, motr)
+def _run_qconsumer_thread(queue: Queue, motr: Motr,
+                          herald: DeliveryHerald) -> ConsumerThread:
+    thread = ConsumerThread(queue, motr, herald)
     thread.start()
     return thread
 
@@ -106,7 +107,7 @@ def main():
     # Note that consumer thread must be started before we invoke motr.start(..)
     # Reason: hax process will send entrypoint request and somebody needs
     # to reply it.
-    consumer = _run_qconsumer_thread(q, motr)
+    consumer = _run_qconsumer_thread(q, motr, herald)
 
     try:
         motr.start(cfg.hax_ep,

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -40,6 +40,17 @@ class EntrypointRequest(BaseMessage):
 
 
 @dataclass
+class FirstEntrypointRequest(BaseMessage):
+    reply_context: Any
+    req_id: Uint128
+    remote_rpc_endpoint: str
+    process_fid: Fid
+    git_rev: str
+    pid: int
+    is_first_request: bool
+
+
+@dataclass
 class ProcessEvent(BaseMessage):
     evt: Any
 

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -20,17 +20,17 @@ import ctypes as c
 import logging
 from errno import EAGAIN
 from typing import Any, List
-from queue import Queue
 
 from hax.exception import ConfdQuorumException, RepairRebalanceException
-from hax.message import (BroadcastHAStates, EntrypointRequest, HaNvecGetEvent,
+from hax.message import (BroadcastHAStates, FirstEntrypointRequest,
+                         EntrypointRequest, HaNvecGetEvent,
                          ProcessEvent)
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats, HaNote,
                        HaNoteStruct, HAState, MessageId, ObjT, ReprebStatus,
                        StobIoqError, ServiceHealth, m0HaProcessEvent,
-                       m0HaProcessType, HaLinkMessagePromise)
+                       m0HaProcessType)
 from hax.util import ConsulUtil
 
 LOG = logging.getLogger('hax')
@@ -113,8 +113,8 @@ class Motr:
                                                    str(process_fid)) +
                   ' The request will be processed in another thread.')
         try:
-            cns = ConsulUtil()
-            if is_first_request and (not cns.is_proc_client(process_fid)):
+            if (is_first_request and
+                    (not self.consul_util.is_proc_client(process_fid))):
                 # This is the first start of this process or the process has
                 # restarted.
                 # Let everyone know that the process has restarted so that
@@ -126,19 +126,20 @@ class Motr:
                 # anyway detect the failure and report the same so we exclude
                 # reporting the same during their first entrypoint request.
                 # But we need to do it for motr server processes.
-                q: Queue = Queue(1)
-                LOG.debug('first entrypoint request, broadcasting FAILED')
                 self.queue.put(
-                    BroadcastHAStates(
-                        states=[HAState(fid=process_fid,
-                                        status=ServiceHealth.FAILED)],
-                        reply_to=q))
-                ids: List[MessageId] = q.get()
-                LOG.debug('waiting for broadcast of %s ep: %s',
-                          ids, remote_rpc_endpoint)
-                self.herald.wait_for_all(HaLinkMessagePromise(ids))
+                    FirstEntrypointRequest(
+                        reply_context=reply_context,
+                        req_id=req_id,
+                        remote_rpc_endpoint=remote_rpc_endpoint,
+                        process_fid=process_fid,
+                        git_rev=git_rev,
+                        pid=pid,
+                        is_first_request=is_first_request
+                    ))
+                return
         except Exception:
-            pass
+            LOG.exception('Failed to notify failure for %s',
+                          process_fid)
 
         LOG.debug('enqueue entrypoint request for %s',
                   remote_rpc_endpoint)
@@ -150,7 +151,7 @@ class Motr:
                 process_fid=process_fid,
                 git_rev=git_rev,
                 pid=pid,
-                is_first_request=is_first_request,
+                is_first_request=is_first_request
             ))
 
     def send_entrypoint_request_reply(self, message: EntrypointRequest):
@@ -248,6 +249,14 @@ class Motr:
                           halink_ctx: int):
         LOG.info(
             'Delivered to endpoint'
+            "'{}', process fid = {}".format(proc_endpoint, str(proc_fid)) +
+            'tag= %d', tag)
+        self.herald.notify_delivered(MessageId(halink_ctx=halink_ctx, tag=tag))
+
+    def _msg_not_delivered_cb(self, proc_fid, proc_endpoint: str, tag: int,
+                              halink_ctx: int):
+        LOG.info(
+            'Message delivery failed, endpoint'
             "'{}', process fid = {}".format(proc_endpoint, str(proc_fid)) +
             'tag= %d', tag)
         self.herald.notify_delivered(MessageId(halink_ctx=halink_ctx, tag=tag))

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -20,15 +20,17 @@ import ctypes as c
 import logging
 from errno import EAGAIN
 from typing import Any, List
+from queue import Queue
 
 from hax.exception import ConfdQuorumException, RepairRebalanceException
-from hax.message import (EntrypointRequest, HaNvecGetEvent,
+from hax.message import (BroadcastHAStates, EntrypointRequest, HaNvecGetEvent,
                          ProcessEvent)
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats, HaNote,
                        HaNoteStruct, HAState, MessageId, ObjT, ReprebStatus,
-                       StobIoqError, ServiceHealth)
+                       StobIoqError, ServiceHealth, m0HaProcessEvent,
+                       m0HaProcessType, HaLinkMessagePromise)
 from hax.util import ConsulUtil
 
 LOG = logging.getLogger('hax')
@@ -110,6 +112,36 @@ class Motr:
                   " '{}', process fid = {}".format(remote_rpc_endpoint,
                                                    str(process_fid)) +
                   ' The request will be processed in another thread.')
+        try:
+            cns = ConsulUtil()
+            if is_first_request and (not cns.is_proc_client(process_fid)):
+                # This is the first start of this process or the process has
+                # restarted.
+                # Let everyone know that the process has restarted so that
+                # they can re-establish their connections with the process.
+                # Disconnect all the halinks this process is any.
+                # Motr clients are filtered out as they are the initiators of
+                # the rpc connections to motr ioservices. Presently there's no
+                # need identified to report motr client restarts, Consul will
+                # anyway detect the failure and report the same so we exclude
+                # reporting the same during their first entrypoint request.
+                # But we need to do it for motr server processes.
+                q: Queue = Queue(1)
+                LOG.debug('first entrypoint request, broadcasting FAILED')
+                self.queue.put(
+                    BroadcastHAStates(
+                        states=[HAState(fid=process_fid,
+                                        status=ServiceHealth.FAILED)],
+                        reply_to=q))
+                ids: List[MessageId] = q.get()
+                LOG.debug('waiting for broadcast of %s ep: %s',
+                          ids, remote_rpc_endpoint)
+                self.herald.wait_for_all(HaLinkMessagePromise(ids))
+        except Exception:
+            pass
+
+        LOG.debug('enqueue entrypoint request for %s',
+                  remote_rpc_endpoint)
         self.queue.put(
             EntrypointRequest(
                 reply_context=reply_context,
@@ -196,6 +228,13 @@ class Motr:
                               chp_type=chp_type,
                               chp_pid=chp_pid,
                               fid=fid)))
+
+        if chp_type == m0HaProcessType.M0_CONF_HA_PROCESS_M0D:
+            if chp_event == m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED:
+                self.queue.put(
+                    BroadcastHAStates(
+                        states=[HAState(fid=fid, status=ServiceHealth.OK)],
+                        reply_to=None))
 
     def _stob_ioq_event_cb(self, fid, sie_conf_sdev, sie_stob_id, sie_fd,
                            sie_opcode, sie_rc, sie_offset, sie_size,

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -78,6 +78,8 @@ class DeliveryHerald:
 
         Raises NotDelivered exception when timeout_sec exceeds.
         """
+        i = len(promise._ids)
+
         for msg in promise._ids:
             condition = Condition()
             with self.lock:
@@ -94,6 +96,10 @@ class DeliveryHerald:
                                        '  were delivered to Motr')
                 LOG.debug('Thread unblocked - %s just received',
                           self.recently_delivered[promise])
+                i -= 1
+                if i == 0:
+                    del self.waiting_clients[promise]
+                    del self.recently_delivered[promise]
 
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -82,6 +82,7 @@ class DeliveryHerald:
             condition = Condition()
             with self.lock:
                 self.waiting_clients[promise] = condition
+                LOG.debug('waiting clients %s', self.waiting_clients)
 
             with condition:
                 LOG.debug('Blocking until %s is confirmed', promise)
@@ -91,12 +92,8 @@ class DeliveryHerald:
                     raise NotDelivered('None of message tags =' +
                                        str(promise) +
                                        '  were delivered to Motr')
-                msgid = self.recently_delivered[promise]
-                if msgid in promise:
-                    promise._ids.remove(msgid)
                 LOG.debug('Thread unblocked - %s just received',
                           self.recently_delivered[promise])
-                del self.recently_delivered[promise]
 
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.
@@ -104,6 +101,8 @@ class DeliveryHerald:
             LOG.debug('notify waiting clients %s',
                       self.waiting_clients.items())
             for promise, client in self.waiting_clients.items():
+                LOG.debug('received msg id %s, waiting promise %s',
+                          message_id, promise)
                 if message_id in promise:
                     LOG.debug('Found a waiting client for %s: %s', message_id,
                               promise)

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -18,7 +18,7 @@
 
 import logging
 from threading import Condition, Lock
-from typing import Dict
+from typing import Dict, List
 
 from hax.exception import NotDelivered
 from hax.types import HaLinkMessagePromise, MessageId
@@ -39,9 +39,11 @@ class DeliveryHerald:
         delivery_herald.wait_for_any(HaLinkMessagePromise(tag_list))
         # if we are here then the delivery was confirmed
     """
-    recently_delivered: Dict[HaLinkMessagePromise, MessageId] = {}
-    waiting_clients: Dict[HaLinkMessagePromise, Condition] = {}
-    lock = Lock()
+    def __init__(self):
+        self.recently_delivered: Dict[HaLinkMessagePromise,
+                                      List[MessageId]] = {}
+        self.waiting_clients: Dict[HaLinkMessagePromise, Condition] = {}
+        self.lock = Lock()
 
     def wait_for_any(self,
                      promise: HaLinkMessagePromise,
@@ -78,14 +80,13 @@ class DeliveryHerald:
 
         Raises NotDelivered exception when timeout_sec exceeds.
         """
-        i = len(promise._ids)
 
-        for msg in promise._ids:
-            condition = Condition()
-            with self.lock:
-                self.waiting_clients[promise] = condition
-                LOG.debug('waiting clients %s', self.waiting_clients)
+        condition = Condition()
+        with self.lock:
+            self.waiting_clients[promise] = condition
+            LOG.debug('waiting clients %s', self.waiting_clients)
 
+        while not promise.is_empty():
             with condition:
                 LOG.debug('Blocking until %s is confirmed', promise)
                 condition.wait(timeout=timeout_sec)
@@ -94,12 +95,14 @@ class DeliveryHerald:
                     raise NotDelivered('None of message tags =' +
                                        str(promise) +
                                        '  were delivered to Motr')
+                confirmed_msgs = self.recently_delivered.pop(promise)
                 LOG.debug('Thread unblocked - %s just received',
-                          self.recently_delivered[promise])
-                i -= 1
-                if i == 0:
-                    del self.waiting_clients[promise]
-                    del self.recently_delivered[promise]
+                          confirmed_msgs)
+                del self.waiting_clients[promise]
+                promise.exclude_ids(confirmed_msgs)
+                LOG.debug('After exclusion: %s', promise)
+                if not promise.is_empty():
+                    self.waiting_clients[promise] = condition
 
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.
@@ -107,12 +110,14 @@ class DeliveryHerald:
             LOG.debug('notify waiting clients %s',
                       self.waiting_clients.items())
             for promise, client in self.waiting_clients.items():
-                LOG.debug('received msg id %s, waiting promise %s',
-                          message_id, promise)
+                LOG.debug('received msg id %s, waiting promise %s', message_id,
+                          promise)
                 if message_id in promise:
                     LOG.debug('Found a waiting client for %s: %s', message_id,
                               promise)
-                    self.recently_delivered[promise] = message_id
+                    old_list = self.recently_delivered.get(promise, [])
+                    old_list.append(message_id)
+                    self.recently_delivered[promise] = old_list
                     with client:
                         client.notify()
                     return

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -534,7 +534,6 @@ static void msg_is_delivered_cb(struct m0_halon_interface *hi,
 	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
 			    tag, hl);
-			    /* hl->hln_tag_broadcast_delivery, hl);*/
 	Py_DECREF(py_fid);
 	PyGILState_Release(gstate);
 }
@@ -554,7 +553,7 @@ static void msg_is_not_delivered_cb(struct m0_halon_interface *hi,
 	PyObject *py_fid = toFid(proc_fid);
 	PyObject_CallMethod(hc0->hc_handler, "_msg_not_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
-			    hl->hln_tag_broadcast_delivery, hl);
+			    tag, hl);
 	Py_DECREF(py_fid);
 	PyGILState_Release(gstate);
 }

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -533,7 +533,8 @@ static void msg_is_delivered_cb(struct m0_halon_interface *hi,
 	PyObject *py_fid = toFid(proc_fid);
 	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
-			    hl->hln_tag_broadcast_delivery, hl);
+			    tag, hl);
+			    /* hl->hln_tag_broadcast_delivery, hl);*/
 	Py_DECREF(py_fid);
 	PyGILState_Release(gstate);
 }
@@ -551,7 +552,7 @@ static void msg_is_not_delivered_cb(struct m0_halon_interface *hi,
 		hl->hln_tag_broadcast_delivery);
 
 	PyObject *py_fid = toFid(proc_fid);
-	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
+	PyObject_CallMethod(hc0->hc_handler, "_msg_not_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
 			    hl->hln_tag_broadcast_delivery, hl);
 	Py_DECREF(py_fid);

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -541,7 +541,21 @@ static void msg_is_delivered_cb(struct m0_halon_interface *hi,
 static void msg_is_not_delivered_cb(struct m0_halon_interface *hi,
 				    struct m0_ha_link *hl, uint64_t tag)
 {
-	M0_LOG(M0_DEBUG, "noop");
+	struct m0_fid *proc_fid = &hl->hln_conn_cfg.hlcc_rpc_service_fid;
+
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
+
+	/* Notify hax about delivery failure. */
+	M0_LOG(M0_DEBUG, "msg not delivered, tag=%"PRIu64,
+		hl->hln_tag_broadcast_delivery);
+
+	PyObject *py_fid = toFid(proc_fid);
+	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
+			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
+			    hl->hln_tag_broadcast_delivery, hl);
+	Py_DECREF(py_fid);
+	PyGILState_Release(gstate);
 }
 
 static void link_connected_cb(struct m0_halon_interface *hi,

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -54,13 +54,25 @@ def to_ha_states(data: Any) -> List[HAState]:
     if not data:
         return []
 
-    def get_status(checks: List[Dict[str, Any]]) -> ServiceHealth:
-        ok = all(x.get('Status') == 'passing' for x in checks)
-        return ServiceHealth.OK if ok else ServiceHealth.FAILED
+    def get_svc_node(checks: List[Dict[str, Any]], svc_id: str) -> str:
+        for x in checks:
+            if x.get('ServiceID') == svc_id:
+                return str(x.get('Node'))
+        return ""
+
+    def get_svc_health(item: Any) -> ServiceHealth:
+        node = get_svc_node(item['Checks'], item['Service']['ID'])
+        LOG.debug('Checking current state of the process %s',
+                  item['Service']['ID'])
+        status: ServiceHealth = ConsulUtil().get_service_health(
+                                               item['Service']['Service'],
+                                               node,
+                                               int(item['Service']['ID']))
+        return status
 
     return [
         HAState(fid=create_process_fid(int(t['Service']['ID'])),
-                status=get_status(t['Checks'])) for t in data
+                status=get_svc_health(t)) for t in data
     ]
 
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -17,7 +17,7 @@
 #
 
 import ctypes as c
-from enum import Enum
+from enum import Enum, IntEnum
 from threading import Thread
 from typing import List, NamedTuple, Set
 
@@ -218,21 +218,22 @@ class ServiceHealth(Enum):
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])
 
 
-class m0HaProcessEvent(Enum):
+class m0HaProcessEvent(IntEnum):
     M0_CONF_HA_PROCESS_STARTING = 0
     M0_CONF_HA_PROCESS_STARTED = 1
     M0_CONF_HA_PROCESS_STOPPING = 2
     M0_CONF_HA_PROCESS_STOPPED = 3
 
-    def str_to_Enum(self, evt):
+    @staticmethod
+    def str_to_Enum(evt: str):
         events = {'M0_CONF_HA_PROCESS_STARTING':
-                  self.M0_CONF_HA_PROCESS_STARTING,
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTING,
                   'M0_CONF_HA_PROCESS_STARTED':
-                  self.M0_CONF_HA_PROCESS_STARTED,
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
                   'M0_CONF_HA_PROCESS_STOPPING':
-                  self.M0_CONF_HA_PROCESS_STOPPING,
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING,
                   'M0_CONF_HA_PROCESS_STOPPED':
-                  self.M0_CONF_HA_PROCESS_STOPPED}
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED}
         return events[evt]
 
     def __repr__(self):

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -198,6 +198,13 @@ class HaLinkMessagePromise:
     def __init__(self, message_ids: List[MessageId]):
         self._ids: Set[MessageId] = set(message_ids)
 
+    def exclude_ids(self, ids: List[MessageId]) -> None:
+        for message_id in ids:
+            self._ids.discard(message_id)
+
+    def is_empty(self) -> bool:
+        return not self._ids
+
     def __contains__(self, message_id: MessageId) -> bool:
         return message_id in self._ids
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -216,3 +216,41 @@ class ServiceHealth(Enum):
 
 
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])
+
+
+class m0HaProcessEvent(Enum):
+    M0_CONF_HA_PROCESS_STARTING = 0
+    M0_CONF_HA_PROCESS_STARTED = 1
+    M0_CONF_HA_PROCESS_STOPPING = 2
+    M0_CONF_HA_PROCESS_STOPPED = 3
+
+    def str_to_Enum(self, evt):
+        events = {'M0_CONF_HA_PROCESS_STARTING':
+                  self.M0_CONF_HA_PROCESS_STARTING,
+                  'M0_CONF_HA_PROCESS_STARTED':
+                  self.M0_CONF_HA_PROCESS_STARTED,
+                  'M0_CONF_HA_PROCESS_STOPPING':
+                  self.M0_CONF_HA_PROCESS_STOPPING,
+                  'M0_CONF_HA_PROCESS_STOPPED':
+                  self.M0_CONF_HA_PROCESS_STOPPED}
+        return events[evt]
+
+    def __repr__(self):
+        return self.name
+
+
+class m0HaProcessType(Enum):
+    M0_CONF_HA_PROCESS_OTHER = 0
+    M0_CONF_HA_PROCESS_KERNEL = 1
+    M0_CONF_HA_PROCESS_M0MKFS = 2
+    M0_CONF_HA_PROCESS_M0D = 3
+
+    def str_to_Enum(self):
+        types = {'M0_CONF_HA_PROCESS_OTHER': self.M0_CONF_HA_PROCESS_OTHER,
+                 'M0_CONF_HA_PROCESS_KERNEL': self.M0_CONF_HA_PROCESS_KERNEL,
+                 'M0_CONF_HA_PROCESS_M0MKFS': self.M0_CONF_HA_PROCESS_M0MKFS,
+                 'M0_CONF_HA_PROCESS_M0D': self.M0_CONF_HA_PROCESS_M0D}
+        return types[self.name]
+
+    def __repr__(self):
+        return self.name

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -32,7 +32,8 @@ from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
 
 from hax.exception import HAConsistencyException
-from hax.types import ConfHaProcess, Fid, FsStatsWithTime, ObjT
+from hax.types import (ConfHaProcess, Fid, FsStatsWithTime,
+                       ObjT, ServiceHealth)
 
 __all__ = ['ConsulUtil', 'create_process_fid', 'create_service_fid',
            'create_sdev_fid', 'create_drive_fid']
@@ -309,29 +310,29 @@ class ConsulUtil:
             raise HAConsistencyException('Failed to communicate to'
                                          ' Consul Agent') from e
 
+    def get_svc_status(self, srv_fid: Fid) -> str:
+        try:
+            key = f'processes/{srv_fid}'
+            raw_data = self.kv.kv_get(key)
+            LOG.debug('Raw value from KV: %s', raw_data)
+            data = raw_data['Value']
+            value: str = json.loads(data)['state']
+            return value
+        except Exception:
+            return 'Unknown'
+
     def get_m0d_statuses(self) -> List[Tuple[ServiceData, str]]:
         """
         Return the list of all Motr service statuses according to Consul
         watchers. The following services are considered: ios, confd.
         """
-        def get_status(srv: ServiceData) -> str:
-            try:
-                key = f'processes/{srv.fid}'
-                raw_data = self.kv.kv_get(key)
-                LOG.debug('Raw value from KV: %s', raw_data)
-                data = raw_data['Value']
-                value: str = json.loads(data)['state']
-                return value
-            except Exception:
-                return 'Unknown'
-
         m0d_services = set(['ios', 'confd'])
         result = []
         for service_name in self._catalog_service_names():
             if service_name not in m0d_services:
                 continue
             data = self.get_service_data_by_name(service_name)
-            result += [(item, get_status(item)) for item in data]
+            result += [(item, self.get_svc_status(item.fid)) for item in data]
         return result
 
     def get_service_data_by_name(self, name: str) -> List[ServiceData]:
@@ -373,6 +374,33 @@ class ConsulUtil:
         return services
 
     @repeat_if_fails()
+    def is_proc_client(self, process_fid: Fid) -> bool:
+        node_items = self.kv.kv_get('m0conf/nodes', recurse=True)
+        fidk = str(process_fid.key)
+
+        # This is the RegExp to match the keys in Consul KV that describe
+        # the Motr services that are enclosed into the Motr process that has
+        # the given fidk.
+        # We filter out motr client entries to check if the given process fid
+        # corresponds to a motr client or server process.
+        #
+        # Note: we assume that fidk uniquely identifies the given process
+        # within the whole cluster (that's why we are not interested in the
+        # hostnames here).
+        #
+        # Examples of the key that will match:
+        #   m0conf/nodes/srvnode-1/processes/39/services/m0_client_s3
+        regex = re.compile(
+            f'^m0conf\\/.*\\/processes\\/{fidk}\\/services\\/(.+)$')
+        for node in node_items:
+            match_result = re.match(regex, node['Key'])
+            if not match_result:
+                continue
+            srv_type = match_result.group(1)
+            if 'm0_client' in srv_type:
+                return True
+        return False
+
     def get_conf_obj_status(self, obj_t: ObjT, fidk: int) -> str:
         # 'node/<node_name>/process/<process_fidk>/service/type'
         node_items = self.kv.kv_get('m0conf/nodes', recurse=True)
@@ -500,6 +528,24 @@ class ConsulUtil:
                     break
         return self.sdev_to_drive_fid(sdev_fid)
 
+    def get_process_status(self, event: ConfHaProcess) -> None:
+        assert 0 <= event.chp_event < len(ha_process_events), \
+            f'Invalid event type: {event.chp_event}'
+
+        data = json.dumps({'state': ha_process_events[event.chp_event]})
+        key = f'processes/{event.fid}'
+        LOG.debug('Setting process status in KV: %s:%s', key, data)
+        self.kv.kv_put(key, data)
+
+    def drive_name_to_id(self, uid: str) -> str:
+        drive_id = ''
+        # 'm0conf/nodes/<node_name>/processes/<process_fidk>/disks/<disk_uuid>'
+        node_items = self.kv.kv_get('m0conf/nodes', recurse=True)
+        for x in node_items:
+            if '/disks/' in x['Key'] and uid in x['Key']:
+                drive_id = x['Value']
+        return drive_id
+
     def set_m0_disk_state(self, fid: str, objstate: int) -> None:
         assert 0 <= objstate < len(ha_conf_obj_states), \
             f'Invalid object state: {objstate}'
@@ -508,6 +554,32 @@ class ConsulUtil:
         key = f'process/{fid}'
         LOG.debug('Setting disk state in KV: %s:%s', key, data)
         self.kv.kv_put(key, data)
+
+    @repeat_if_fails()
+    def get_service_health(self, service_name: str,
+                           node: str, svc_id: int) -> ServiceHealth:
+
+        try:
+            node_data: List[Dict[str, Any]] = self.cns.health.node(node)[1]
+            LOG.debug('Node Data: %s', node_data)
+            status = ServiceHealth.UNKNOWN
+            for item in node_data:
+                if (item['ServiceName'] == service_name and
+                        item['ServiceID'] == str(svc_id)):
+                    if item['Status'] == 'passing':
+                        status = ServiceHealth.OK
+                    elif item['Status'] == 'warning':
+                        fid = create_process_fid(svc_id)
+                        svc_consul_status = self.get_svc_status(fid)
+                        if svc_consul_status in ('M0_CONF_HA_PROCESS_STARTING',
+                                                 'M0_CONF_HA_PROCESS_STARTED'):
+                            status = ServiceHealth.OK
+                    else:
+                        status = ServiceHealth.FAILED
+        except (ConsulException, HTTPError, RequestException) as e:
+            raise HAConsistencyException('Failed to communicate '
+                                         'to Consul Agent') from e
+        return status
 
 
 def dump_json(obj) -> str:

--- a/hax/test/test_delivery_herald.py
+++ b/hax/test/test_delivery_herald.py
@@ -24,11 +24,15 @@ from threading import Thread
 from time import sleep
 
 from hax.exception import NotDelivered
+from hax.motr import log_exception
 from hax.motr.delivery import DeliveryHerald
 from hax.types import HaLinkMessagePromise, MessageId
 
 
-class TestDeliveryHerald(unittest.TestCase):
+class TestDeliveryHeraldAny(unittest.TestCase):
+    """
+    Tests wait_for_any() functionality.
+    """
     @classmethod
     def setUpClass(cls):
         logging.basicConfig(
@@ -54,7 +58,7 @@ class TestDeliveryHerald(unittest.TestCase):
         m = MessageId
         herald.wait_for_any(HaLinkMessagePromise(
             [m(100, 1), m(100, 3), m(100, 4)]),
-                            timeout_sec=5)
+                            timeout_sec=10)
         t.join()
         self.assertTrue(notified_ok,
                         'Unexpected exception appeared in notifier thread')
@@ -75,11 +79,13 @@ class TestDeliveryHerald(unittest.TestCase):
         t.start()
 
         m = MessageId
-        with self.assertRaises(NotDelivered):
-            herald.wait_for_any(HaLinkMessagePromise(
-                [m(42, 1), m(42, 3), m(42, 4)]),
-                                timeout_sec=5)
-        t.join()
+        try:
+            with self.assertRaises(NotDelivered):
+                herald.wait_for_any(HaLinkMessagePromise(
+                    [m(42, 1), m(42, 3), m(42, 4)]),
+                                    timeout_sec=5)
+        finally:
+            t.join()
         self.assertTrue(notified_ok,
                         'Unexpected exception appeared in notifier thread')
 
@@ -95,13 +101,140 @@ class TestDeliveryHerald(unittest.TestCase):
                 logging.exception('*** ERROR ***')
                 notified_ok = False
 
-        threads = [Thread(target=fn, args=(MessageId(100, i), )) for i in range(1, 32)]
+        threads = [
+            Thread(target=fn, args=(MessageId(100, i), ))
+            for i in range(1, 32)
+        ]
         for t in threads:
             t.start()
 
-        m = lambda x: MessageId(halink_ctx=100, tag = x)
-        herald.wait_for_any(HaLinkMessagePromise([m(99), m(25), m(28), m(31)]), timeout_sec=5)
-        for t in threads:
+        def m(x):
+            return MessageId(halink_ctx=100, tag=x)
+
+        try:
+            herald.wait_for_any(HaLinkMessagePromise(
+                [m(99), m(25), m(28), m(31)]),
+                                timeout_sec=5)
+        finally:
+            for t in threads:
+                t.join()
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+
+class TestDeliveryHeraldAll(unittest.TestCase):
+    """
+    Tests wait_for_all() functionality.
+    """
+    @classmethod
+    def setUpClass(cls):
+        logging.basicConfig(
+            level=logging.DEBUG,
+            stream=sys.stdout,
+            format='%(asctime)s {%(threadName)s} [%(levelname)s] %(message)s')
+
+    def test_it_works(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn():
+            try:
+                sleep(1.5)
+                herald.notify_delivered(MessageId(halink_ctx=100, tag=1))
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        t = Thread(target=fn)
+        t.start()
+
+        m = MessageId
+        herald.wait_for_all(HaLinkMessagePromise([m(100, 1)]), timeout_sec=5)
+        t.join()
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+    def test_exception_raised_if_not_all_delivered(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn():
+            try:
+                sleep(1.5)
+                herald.notify_delivered(MessageId(halink_ctx=42, tag=3))
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        t = Thread(target=fn)
+        t.start()
+
+        m = MessageId
+        try:
+            with self.assertRaises(NotDelivered):
+                herald.wait_for_all(HaLinkMessagePromise([m(42, 1),
+                                                          m(42, 3)]),
+                                    timeout_sec=5)
+        finally:
             t.join()
+
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+    def test_works_if_all_messages_confirmed(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn():
+            try:
+                sleep(1.5)
+                herald.notify_delivered(MessageId(halink_ctx=42, tag=3))
+                herald.notify_delivered(MessageId(halink_ctx=42, tag=1))
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        t = Thread(target=fn)
+        t.start()
+
+        m = MessageId
+        try:
+            herald.wait_for_all(HaLinkMessagePromise([m(42, 1),
+                                                      m(42, 3)]),
+                                timeout_sec=5)
+        finally:
+            t.join()
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+    def test_works_under_load(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn(msg: MessageId):
+            try:
+                sleep(1.5)
+                herald.notify_delivered(msg)
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        threads = [
+            Thread(target=fn, args=(MessageId(100, i), ))
+            for i in range(1, 32)
+        ]
+        for t in threads:
+            t.start()
+
+        def m(x):
+            return MessageId(halink_ctx=100, tag=x)
+
+        try:
+            herald.wait_for_all(HaLinkMessagePromise(
+                [m(5), m(25), m(28), m(31)]),
+                                timeout_sec=5)
+        finally:
+            for t in threads:
+                t.join()
         self.assertTrue(notified_ok,
                         'Unexpected exception appeared in notifier thread')


### PR DESCRIPTION
    Motr process states are persisted in Consul by hax as and when the motr
    process updates the same to hax. But the process failure is not updated
    in the Consul when a motr process crashes abrubtly, in which case no
    process event is sent.
    fsStatsUpdater thread in the hax checks the motr processes (confd, ios)
    state in Consul and if all are STARTED then it starts rconfc and tries to
    fetch statistics from motr. So if the failure state is not updated in Consul
    fsStatsUpdater always see the motr process states as STARTED and keeps trying
    in which case rconfc fails too.

    Solution:
    Update process failuer in Consul by updating the motr process state to
    M0_CONF_HA_PROCESS_STOPPED.