### PR TITLE
hax/setup.py: fix make devinstall

### DIFF
--- a/hax/setup.py
+++ b/hax/setup.py
@@ -79,7 +79,7 @@ def get_motr_dir():
     d = os.environ.get('M0_SRC_DIR')
     if d:
         return d
-    return P.normpath(P.dirname(P.abspath(__file__)) + '/../../cortx-motr')
+    return P.normpath(P.dirname(P.abspath(__file__)) + '/../../motr')
 
 
 def get_motr_libs_dir():


### PR DESCRIPTION
Currently, if one follows https://github.com/Seagate/cortx-hare#installation
document, the installation fails on make devinstall:

```
[vagrant@cmu hare]$ sudo make devinstall
...
--> Installing hax with 'source /data/hare/.py3venv/bin/activate; python3.6 setup.py develop --prefix /opt/seagate/cortx/hare'
Traceback (most recent call last):
  File "setup.py", line 141, in <module>
    library_dirs=[get_motr_libs_dir()],
  File "setup.py", line 97, in get_motr_libs_dir
    assert P.isfile(libmotr), f'{libmotr}: No such file'
AssertionError: /data/cortx-motr/motr/.libs/libmotr.so: No such file
make: *** [/opt/seagate/cortx/hare/lib/python3.6/site-packages/hax.egg-link] Error 1
```

The problem is that it's assumed that Motr sources are located
at `../cortx-motr` path while the clone command in the document
checks out Motr at `../motr` path.

Solution: fix setup.py to align with the documentation and assume
the Motr sources are installed at `../motr`.

Closes #1425.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>