### PR TITLE
Problem: hare main branch fails to build

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -214,9 +214,10 @@ def main() -> None:
             _stop_parallel([proc for proc in processes[svc]])
 
     if leader_node and not is_fake_leader_name(leader_node):
-        print(f'Shutting down RC Leader at {leader_node}... ', end='', flush=True)
-        exec(ssh_prefix(leader_node) +
-                'sudo pkill --exact -KILL consul &> /dev/null')
+        print(f'Shutting down RC Leader at {leader_node}... ',
+              end='', flush=True)
+        pkill: str = 'sudo pkill --exact -KILL consul &> /dev/null'
+        exec(ssh_prefix(leader_node) + pkill)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
flake8 validation fails,
```
13:16:52  make[4]: Entering directory `/root/rpmbuild/BUILD/cortx-hare/cfgen'
13:16:52  utils/hare-shutdown:217:80: E501 line too long (82 > 79 characters)
13:16:52  utils/hare-shutdown:218:38: W504 line break after binary operator
13:16:52  utils/hare-shutdown:219:17: E127 continuation line over-indented for visual indent
13:16:52  make[3]: *** [flake8] Error 1
13:16:52  make[3]: *** Waiting for unfinished jobs....
```

Solution:
Fix the above style errors reported by flake8