### PR TITLE
Problem: No configuration present for stale bot. Hence bot is auto-closing issues as default behavior

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,14 @@
-# .github/stale.yml file is required to enable the plugin.
-# The file can be empty.
-#
-# See more information at https://github.com/probot/stale#usage
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 6
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: false
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - feature
+# Label to use when marking an issue as stale
+staleLabel: needs-attention
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    This issue/pull request has been marked as `needs attention` as it has been left pending without new activity for 6 days.
+    Tagging @mssawant for appropriate assignment.
+    Sorry for the delay & Thank you for contributing to CORTX. We will get back to you as soon as possible.


### PR DESCRIPTION
Stale bot configuration is removed as  'Stale' bot spams with notifications. However this causes auto closing of issues. Please refer - https://github.com/Seagate/cortx-hare/issues/1325
To fix this added stale bot configuration again with 6 days before sending notification. 

