### PR TITLE
EOS-15919 Make distclean does not delete all the untracked files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ clean: clean-hax clean-mypy clean-dhall-prelude
 clean-hax:
 	@$(call _info,Cleaning hax)
 	@for d in hax/build hax/dist hax/hax.egg-info hax/*.so \
-	          hax/hax/__pycache__; do \
+		  hax/hax/__pycache__ hax/hax/motr/__pycache__ \
+		  hax/hax/queue/__pycache__ hax/test/__pycache__; do \
 	     if [[ -e $$d ]]; then \
 	         $(call _log,removing $$d); \
 	         rm -rf $$d; \


### PR DESCRIPTION
EOS-15919 Make distclean doesn't delete all files.

Solution: Added code in Makefile to delete leftover files, which
are created at the time of make and which should be deleted at
make distclean.
Test steps:
1. executed - make
2. executed - make distclean
Relevant output :
--> Cleaning hax
    removing hax/build
    removing hax/dist
    removing hax/hax.egg-info
    removing hax/libhax.cpython-36m-x86_64-linux-gnu.so
    removing hax/hax/__pycache__
    removing hax/hax/motr/__pycache__ dir
    removing hax/hax/queue/__pycache__ dir
    removing hax/test/__pycache__ dir
3. executed - git clean -n -fdx
It returned nothing.

Signed-off-by: Shipra Gupta <shipra.gupta@seagate.com>