### PR TITLE
Problem: hax starts rconfc in context of fileStatsUpdater

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -19,12 +19,11 @@
 import datetime
 import logging
 from threading import Event
-from typing import List
 
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
 from hax.types import FsStatsWithTime, StoppableThread
-from hax.util import ConsulUtil, repeat_if_fails
+from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
 
@@ -44,46 +43,35 @@ class FsStatsUpdater(StoppableThread):
         self.stopped = True
         self.event.set()
 
-    def _sleep(self, interval_sec) -> None:
-        interrupted = self.event.wait(timeout=interval_sec)
-        if interrupted:
-            raise InterruptedException()
-
     @log_exception
     def _execute(self, motr: Motr):
         try:
             ffi = motr._ffi
             LOG.info('filesystem stats updater thread has started')
             ffi.adopt_motr_thread()
-            self._ensure_motr_all_started()
             while not self.stopped:
                 if not self._am_i_rc():
-                    self._sleep(self.interval_sec)
+                    wait_for_event(self.event, self.interval_sec)
                     continue
-
-                started = self._ioservices_running()
-                if not all(started):
-                    self._sleep(self.interval_sec)
+                if not motr.is_spiel_ready():
+                    wait_for_event(self.event, self.interval_sec)
                     continue
-                result: int = motr.start_rconfc()
-                if result == 0:
-                    stats = motr.get_filesystem_stats()
-                    motr.stop_rconfc()
-                    if not stats:
-                        continue
-                    LOG.debug('FS stats are as follows: %s', stats)
-                    now_time = datetime.datetime.now()
-                    data = FsStatsWithTime(stats=stats,
-                                           timestamp=now_time.timestamp(),
-                                           date=now_time.isoformat())
-                    try:
-                        self.consul.update_fs_stats(data)
-                    except HAConsistencyException:
-                        LOG.debug('Failed to update Consul KV '
-                                  'due to an intermittent error. The '
-                                  'error is swallowed since new attempts '
-                                  'will be made timely')
-                self._sleep(self.interval_sec)
+                stats = motr.get_filesystem_stats()
+                if not stats:
+                    continue
+                LOG.debug('FS stats are as follows: %s', stats)
+                now_time = datetime.datetime.now()
+                data = FsStatsWithTime(stats=stats,
+                                       timestamp=now_time.timestamp(),
+                                       date=now_time.isoformat())
+                try:
+                    self.consul.update_fs_stats(data)
+                except HAConsistencyException:
+                    LOG.debug('Failed to update Consul KV '
+                              'due to an intermittent error. The '
+                              'error is swallowed since new attempts '
+                              'will be made timely')
+                wait_for_event(self.event, self.interval_sec)
         except InterruptedException:
             # No op. _sleep() has interrupted before the timeout exceeded:
             # the application is shutting down.
@@ -95,22 +83,6 @@ class FsStatsUpdater(StoppableThread):
             LOG.debug('Releasing motr-related resources for this thread')
             ffi.shun_motr_thread()
             LOG.debug('filesystem stats updater thread exited')
-
-    @repeat_if_fails()
-    def _ioservices_running(self) -> List[bool]:
-        statuses = self.consul.get_m0d_statuses()
-        LOG.debug('The following statuses received: %s', statuses)
-        started = ['M0_CONF_HA_PROCESS_STARTED' == v[1] for v in statuses]
-        return started
-
-    @repeat_if_fails()
-    def _ensure_motr_all_started(self):
-        while True:
-            started = self._ioservices_running()
-            if all(started):
-                LOG.debug('According to Consul all confds have been started')
-                return
-            self._sleep(5)
 
     def _am_i_rc(self):
         # The call is already marked with @repeat_if_fails

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -61,6 +61,7 @@ class Motr:
         self.rm_fid = rm_fid
         self.herald = herald
         self.consul_util = consul_util
+        self.spiel_ready = False
 
         if not self._ha_ctx:
             LOG.error('Cannot initialize Motr API. m0_halon_interface_init'
@@ -103,6 +104,9 @@ class Motr:
                                'Please check Motr logs for more details.')
         LOG.debug('confc has been stopped successfuly')
         return result
+
+    def is_spiel_ready(self):
+        return self.spiel_ready
 
     @log_exception
     def _entrypoint_request_cb(self, reply_context: Any, req_id: Any,
@@ -291,6 +295,8 @@ class Motr:
         ]
 
     def close(self):
+        LOG.debug('Stopping rconfc')
+        self.stop_rconfc()
         LOG.debug('Shutting down Motr API')
         self._ffi.destroy(self._ha_ctx)
         self._ha_ctx = 0

--- a/hax/hax/motr/rconfc.py
+++ b/hax/hax/motr/rconfc.py
@@ -1,0 +1,58 @@
+import logging
+from threading import Event
+
+from hax.exception import InterruptedException
+from hax.motr import Motr, log_exception
+from hax.types import StoppableThread
+from hax.util import ConsulUtil, wait_for_event
+
+LOG = logging.getLogger('hax')
+
+
+class RconfcStarter(StoppableThread):
+    """
+    A short-lived thread that is intended to start rconfc.
+
+    Effectively, rconfc could have been started in the same thread where Motr
+    context is initialized but there is a chance of deadlock (confd quorum
+    will not appear until confd's will receive entrypoint reply but that reply
+    can happen when Motr is initialized in hax).
+    """
+    def __init__(self, motr: Motr, consul_util: ConsulUtil):
+        super().__init__(target=self._execute,
+                         name='rconfc-starter',
+                         args=(motr, ))
+        self.stopped = False
+        self.consul = consul_util
+        self.event = Event()
+
+    def stop(self) -> None:
+        LOG.debug('Stop signal received')
+        self.stopped = True
+        self.event.set()
+
+    @log_exception
+    def _execute(self, motr: Motr):
+        try:
+            ffi = motr._ffi
+            LOG.debug('rconfc starter thread has started')
+            ffi.adopt_motr_thread()
+            self.consul.ensure_motr_all_started(self.event)
+            while (not self.stopped) and (not motr.spiel_ready):
+                started = self.consul.ensure_ioservices_running()
+                if not all(started):
+                    wait_for_event(self.event, 5)
+                    continue
+                result: int = motr.start_rconfc()
+                if result == 0:
+                    motr.spiel_ready = True
+        except InterruptedException:
+            # No op. sleep() has interrupted before the timeout exceeded:
+            # the application is shutting down.
+            # There are no resources that we need to dispose specially.
+            pass
+        except Exception:
+            LOG.exception('Aborting due to an error')
+        finally:
+            ffi.shun_motr_thread()
+            LOG.debug('rconfc starter thread exited')


### PR DESCRIPTION
Presently only one spiel command is being invoked as part of fileStatsUpdater thread
but spiel use cases increase, e.g. sns repair/rebalance, rconfc must be started
only once.

Solution:
Create a motr runnable that is started as part of motr start operation.
Start rconfc as part of motr thread but wait for motr services to start.