### PR TITLE
EOS 15932 No verbose mode present in hctl-shutdown

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import threading
+import argparse
 from queue import Queue
 from socket import gethostname
 from typing import Dict, List, NamedTuple
@@ -40,7 +41,14 @@ shutdown_sequence = ('s3service', 'ios', 'confd', 'hax', 'consul')
 
 
 def _setup_logging():
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="Increase output verbosity",
+                        action="store_true")
+    args = parser.parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+    else:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
 def processfid2str(fidk: int) -> str:
@@ -127,7 +135,10 @@ def exec_silent(cmd: str) -> bool:
 
 def exec(cmd: str) -> None:
     assert cmd
-    print('OK' if exec_silent(cmd) else '**ERROR**')
+    if exec_silent(cmd):
+        logging.info('OK')
+    else:
+        logging.error('**ERROR**')
 
 
 def process_stop(proc: Process) -> None:
@@ -214,8 +225,7 @@ def main() -> None:
             _stop_parallel([proc for proc in processes[svc]])
 
     if leader_node and not is_fake_leader_name(leader_node):
-        print(f'Shutting down RC Leader at {leader_node}... ',
-              end='', flush=True)
+        logging.info(f'Shutting down RC Leader at {leader_node}... ')
         pkill: str = 'sudo pkill --exact -KILL consul &> /dev/null'
         exec(ssh_prefix(leader_node) + pkill)
 


### PR DESCRIPTION
Modified code to take log level as argument through CLI
hctl shutdown needs to be called as 'hctl shutdown -v' to enable debug mode
Replaced messages printed by print() with logger functions.

Output of 'hctl status -v' after changes is as follows,

[root@ssc-vm-c-1822 hare]# hctl shutdown -v
Starting new HTTP connection (1): 127.0.0.1:8500
http://127.0.0.1:8500 "GET /v1/catalog/nodes HTTP/1.1" 200 220
http://127.0.0.1:8500 "GET /v1/health/node/ssc-vm-c-1822.colo.seagate.com HTTP/1.1" 200 313
http://127.0.0.1:8500 "GET /v1/kv/leader HTTP/1.1" 200 158
Started thread
Stopping m0d@0x7200000000000001:0xc (ios) at ssc-vm-c-1822.colo.seagate.com...
Stopped m0d@0x7200000000000001:0xc (ios) at ssc-vm-c-1822.colo.seagate.com
Exiting thread
Started thread
Stopping m0d@0x7200000000000001:0x9 (confd) at ssc-vm-c-1822.colo.seagate.com...
Stopped m0d@0x7200000000000001:0x9 (confd) at ssc-vm-c-1822.colo.seagate.com
Exiting thread
Started thread
Stopping hare-hax at ssc-vm-c-1822.colo.seagate.com...
Stopped hare-hax at ssc-vm-c-1822.colo.seagate.com
Exiting thread
Started thread
Stopping hare-consul-agent at ssc-vm-c-1822.colo.seagate.com...
Stopped hare-consul-agent at ssc-vm-c-1822.colo.seagate.com
Exiting thread

**UT:-**
Tested code with Jenkins build http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.8/job/cortx-custom-ci/339/
