### PR TITLE
EOS-16201:Hare Run I/O test m0crate: command not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ clean: clean-hax clean-mypy clean-dhall-prelude
 clean-hax:
 	@$(call _info,Cleaning hax)
 	@for d in hax/build hax/dist hax/hax.egg-info hax/*.so \
-	          hax/hax/__pycache__; do \
+		  hax/hax/__pycache__ hax/hax/motr/__pycache__ \
+		  hax/hax/queue/__pycache__ hax/test/__pycache__; do \
 	     if [[ -e $$d ]]; then \
 	         $(call _log,removing $$d); \
 	         rm -rf $$d; \

--- a/README.md
+++ b/README.md
@@ -187,8 +187,13 @@ You will probably need to modify `host`, `data_iface`, and `io_disks` values.
   ```sh
   /opt/seagate/cortx/hare/libexec/m0crate-io-conf >/tmp/m0crate-io.yaml
   dd if=/dev/urandom of=/tmp/128M bs=1M count=128
-  sudo ./motr/motr/m0crate/m0crate -S /tmp/m0crate-io.yaml
+  sudo m0crate -S /tmp/m0crate-io.yaml
   ```
+  Please note that m0crate will run as shown above when it will be
+  available in default system PATH which will be the case when when
+  setup is created using RPM's. If its created by building Motr
+  source code, then m0crate utility can be run using full path from
+  the motr source directory (./motr/motr/m0crate/m0crate).
 
 * Stop the cluster.
   ```sh

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ You will probably need to modify `host`, `data_iface`, and `io_disks` values.
   ```sh
   /opt/seagate/cortx/hare/libexec/m0crate-io-conf >/tmp/m0crate-io.yaml
   dd if=/dev/urandom of=/tmp/128M bs=1M count=128
-  sudo m0crate -S /tmp/m0crate-io.yaml
+  sudo ./motr/motr/m0crate/m0crate -S /tmp/m0crate-io.yaml
   ```
 
 * Stop the cluster.


### PR DESCRIPTION
Problem:
m0crate command throwing error for the steps given in README.md
Error : m0crate: command not found
Solution:
m0crate can be located in motr directory, so the m0crate utility
needs correct path while executing this command.
This only needs a documentation fix, which is done here.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>