### PR TITLE
Problem: make devinstall fails

### DIFF
--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -6,6 +6,7 @@ setuptools
 wheel
 
 #:runtime-requirements:
+idna<3,>=2.5
 aiohttp
 click
 dataclasses


### PR DESCRIPTION
requests module from aiohttp has a dependency on a specific range of idna
package version which leads to the following make devinstall error,
```
Installed /root/cortx-hare/hax
Processing dependencies for hax==1.0.0
error: idna 3.1 is installed but idna<3,>=2.5 is required by {'requests'}
make: *** [/opt/seagate/cortx/hare/lib/python3.6/site-packages/hax.egg-link] Error 1
```

Solution:
Add idna version range to be installed to hax/requirements.txt

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>