### PR TITLE
EOS-15799 Management: display cluster configuration

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -61,7 +61,11 @@ Pool = NamedTuple('Pool', [('fid', str), ('name', str)])
 Process = NamedTuple('Process', [('name', str), ('fid', Fid), ('ep', str),
                                  ('status', str)])
 
+Device = NamedTuple('Device', [('name', str), ('status', str)])
+
 Node = NamedTuple('Node', [('name', str), ('svcs', List[Process])])
+
+Devices = NamedTuple('Devices', [('node_name', str), ('devs', List[Device])])
 
 
 def processfid2str(fidk: int) -> str:
@@ -206,6 +210,23 @@ def cluster_online() -> bool:
     return exit_code == 0
 
 
+def devices(cns: Consul, node_name: str) -> List[Device]:
+    node_fid = node_name2fid(cns, node_name)
+    device_list = []
+    # Get entries from KV for "m0conf/nodes/<node_id>/processes/
+    #           <process_fidk>/services/<svc_fid>/sdevs/<sdev_fid>"
+    # We are getting lists of all sdevs for given node
+    for x in kv_item(cns, f'm0conf/nodes/{node_fid}/processes/', recurse=True):
+        parts = x['Key'].split('/', 9)
+        if len(parts) == 9:
+            if parts[-2] == 'sdevs':
+                device_list.append(Device(
+                    name=json.loads(x['Value'])['path'],
+                    status=json.loads(x['Value'])['state']))
+
+    return device_list
+
+
 @repeat_if_fails(max_retries=24)
 def get_cluster_status(cns: Consul) -> Dict[str, Any]:
     return {
@@ -214,7 +235,9 @@ def get_cluster_status(cns: Consul) -> Dict[str, Any]:
                      for x in profiles(cns)],
         'filesystem': get_fs_stats(cns),
         'nodes': [Node(name=h, svcs=processes(cns, h))
-                  for h in node_names(cns)]
+                  for h in node_names(cns)],
+        'devices': [Devices(node_name=h, devs=devices(cns, h))
+                    for h in node_names(cns)]
     }
 
 
@@ -265,6 +288,11 @@ def show_text_status(cns: Consul) -> None:
             for p in processes(cns, h):
                 fid: str = f'{p.fid}'
                 echo(f'    [{p.status}]  {p.name:<9}  {fid:<23}  {p.ep}')
+        echo('Devices:')
+        for h in node_names(cns):
+            echo(f'    {h}')
+            for d in devices(cns, h):
+                echo(f'    [{d.status}]  {d.name}')
         print(stream.getvalue(), end='')  # flush
 
 


### PR DESCRIPTION
Modified code to get list of devices and status.
Code will read entries from KV present in the below format "m0conf/nodes/<node_id>/processes/<process_fidk>/services/<svc_fid>/sdevs/<sdev_fid>"
