### PR TITLE
EOS-15807: support multiple Motr pool configurations

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1102,14 +1102,18 @@ def pool_drives(m0conf: Dict[Oid, Any],
     for drive_id, node_id in drives:
         if m0conf[drive_id].pvers:  # already assigned to some pool
             over_referenced.setdefault(node_id, []).append(drive_id)
-    if over_referenced:
-        err = '{} referred to by several pools:'.format(
-            'This disk is' if len(over_referenced) == 1 else 'These disks are')
-        for node_id in sorted(over_referenced):
-            err += '\n  ' + m0conf[node_id].name
-            for drive_id in sorted(over_referenced[node_id]):
-                err += '\n   \\_ ' + m0conf[m0conf[drive_id].sdev].filename
-        raise AssertionError(err)
+
+    # TODO: coordinate with Motr component, to make sure that it supports the
+    #       same storage device to be part of more than one pool
+    # if over_referenced:
+    #     err = '{} referred to by several pools:'.format(
+    #         'This disk is' if len(over_referenced) == 1 \
+    #                        else 'These disks are')
+    #     for node_id in sorted(over_referenced):
+    #         err += '\n  ' + m0conf[node_id].name
+    #         for drive_id in sorted(over_referenced[node_id]):
+    #             err += '\n   \\_ ' + m0conf[m0conf[drive_id].sdev].filename
+    #     raise AssertionError(err)
 
     return [drive_id for drive_id, _ in drives]
 
@@ -1728,7 +1732,29 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                 proc_id = ConfProcess.build(conf, node_id, node, proc_t)
                 cluster.m0_clients[proc_id] = new_oid(ObjT.service)
 
+    aux_pools = {}
     for pool in cluster_desc['pools']:
+        parity_group_size = pool['data_units'] + 2 * pool['parity_units']
+        if len(pool.get('disk_refs', [])) == parity_group_size:
+            # more strict requirement, where each node must have only one disk
+            # ref and total number of nodes should be equal to
+            # parity_group_size
+            # len(set([x.get('node')
+            #         for x in pool['disk_refs']])) == parity_group_size):
+            disk_ref_combinations = [
+                list(x) for x in itertools.combinations(
+                                     pool['disk_refs'],
+                                     parity_group_size - pool['parity_units'])
+            ]
+            aux_pools[pool['name']] = [
+                    {'name':         pool['name'] + f'-aux{i:02}',
+                     'data_units':   pool['data_units'] - pool['parity_units'],
+                     'parity_units': pool['parity_units'],
+                     'disk_refs':    comb}
+                    for i, comb in enumerate(disk_ref_combinations, start=1)
+            ]
+
+    for pool in itertools.chain(cluster_desc['pools'], *aux_pools.values()):
         ConfPool.build(conf, root_id, pool)
 
     if conf[root_id].imeta_pver is None:  # no DIX pool defined in the CDF
@@ -1738,6 +1764,9 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         ConfPool.build(conf, root_id, {'type': 'md'})
 
     for prof in cluster_desc['profiles']:
+        prof['pools'] += [aux_pool['name']
+                          for pool_name in prof['pools']
+                          for aux_pool in aux_pools.get(pool_name, [])]
         ConfProfile.build(conf, root_id, prof)
 
     validate_m0conf(conf)


### PR DESCRIPTION
Each storage set corresponds to a standalone Motr pool. A default storage set configuration consists of six nodes, `srvnode-1..6` (three enclosures, each has two controllers). Where every pool in has 4+2 layout, which means — four data units and two parity units in a parity group.

Typical configuration of such pool in the CDF format, expected by cfgen, would be something like this:

```yaml
pools:
  - name: storage-set01
    disk_refs:
      - node: srvnode-1
        path: /dev/mpath1
      - node: srvnode-2
        path: /dev/mpath2
      - node: srvnode-3
        path: /dev/mpath3
      - node: srvnode-4
        path: /dev/mpath4
      - node: srvnode-5
        path: /dev/mpath5
      - node: srvnode-6
        path: /dev/mpath6
    data_units: 4
    parity_units: 2
```

Such a pool can tolerate a failure of two distinct mpath storage devices, out of six total devices. For performance considerations, when only four storage devices remain in the pool, due to a failure of the other two, it's not efficient to write data using original 4+2 layout.  It's better to use 2+2 layout. For this reason, additional pool configurations need to be pre-generated by `cfgen` for every original pool configuration in the CDF. Every such configuration have `-auxNN` suffix added (stands for auxiliary) to the original pool name, where `NN` is a sequential number. For example, for a case where `srvnode-5` and `srvnode-6` have failed, an auxiliary pool config, auto-generated internally by `cfgen` would look like this:

```yaml
pools:
  - name: storage-set01-aux01
    disk_refs:
      - node: srvnode-1
        path: /dev/mpath1
      - node: srvnode-2
        path: /dev/mpath2
      - node: srvnode-3
        path: /dev/mpath3
      - node: srvnode-4
        path: /dev/mpath4
    data_units: 2
    parity_units: 2
```

We have to calculate all possible combinations (without repetition) of the four surviving srvnode's out of the total six nodes, and `cfgen` needs to generate pool configuration with reduced 2+2 layout for each of them internally. There are 15 of them, according to the formula:
```
C(n,k) = n! / ( k! * (n - k)! )
```

In our case `n := 6` and `k := 4`:

```
srvnode1	srvnode1	srvnode1
srvnode2	srvnode2	srvnode2
srvnode3	srvnode3	srvnode3
srvnode4	srvnode5	srvnode6

srvnode1	srvnode1	srvnode1
srvnode2	srvnode2	srvnode2
srvnode4	srvnode4	srvnode5
srvnode5	srvnode6	srvnode6

srvnode1	srvnode1	srvnode1
srvnode3	srvnode3	srvnode3
srvnode4	srvnode4	srvnode5
srvnode5	srvnode6	srvnode6

srvnode1	srvnode2	srvnode2
srvnode4	srvnode3	srvnode3
srvnode5	srvnode4	srvnode4
srvnode6	srvnode5	srvnode6

srvnode2	srvnode2	srvnode3
srvnode3	srvnode4	srvnode4
srvnode5	srvnode5	srvnode5
srvnode6	srvnode6	srvnode6
```

The resulting `confd.dhall` output of a new cfgen implementation is identical to the output generated by an old `cfgen`, as if the following CFD was provided as its input:

```yaml
pools:
  - name: storage-set01
    disk_refs:
      - node: srvnode-1
        path: /dev/mpath1
      - node: srvnode-2
        path: /dev/mpath2
      - node: srvnode-3
        path: /dev/mpath3
      - node: srvnode-4
        path: /dev/mpath4
      - node: srvnode-5
        path: /dev/mpath5
      - node: srvnode-6
        path: /dev/mpath6
    data_units: 4
    parity_units: 2

  - name: storage-set01-aux01
    disk_refs:
      - node: srvnode-1
        path: /dev/mpath1
      - node: srvnode-2
        path: /dev/mpath2
      - node: srvnode-3
        path: /dev/mpath3
      - node: srvnode-4
        path: /dev/mpath4
    data_units: 2
    parity_units: 2

  - name: storage-set01-aux02
    disk_refs:
      - node: srvnode-1
        path: /dev/mpath1
      - node: srvnode-2
        path: /dev/mpath2
      - node: srvnode-3
        path: /dev/mpath3
      - node: srvnode-5
        path: /dev/mpath5
    data_units: 2
    parity_units: 2

  # ... skiped other 12 aux configs ...

  - name: storage-set01-aux15
    disk_refs:
      - node: srvnode-3
        path: /dev/mpath3
      - node: srvnode-4
        path: /dev/mpath4
      - node: srvnode-5
        path: /dev/mpath5
      - node: srvnode-6
        path: /dev/mpath6
    data_units: 2
    parity_units: 2
```