### PR TITLE
EOS-16393: make test fails due to a Dhall error

### DIFF
--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -27,6 +27,7 @@ in
       , data_iface = "eth1"
       , data_iface_type = None types.Protocol
       , m0_servers =
+          Some
           [ { runs_confd = Some True
             , io_disks =
                 { meta_data = None Text


### PR DESCRIPTION
Jira link: https://jts.seagate.com/browse/EOS-16393

Problem cause: test Dhall files were not aligned to changes in grammar
introduced by #1401 fix.

Here is the change in the grammar that was not addressed in
singlenode.dhall:

```diff
diff --git a/cfgen/dhall/types/ClusterDesc.dhall b/cfgen/dhall/types/ClusterDesc.dhall
index 9996de4..e5d1bbf 100644
--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -28,7 +28,7 @@ let Node =
   { hostname : Text
   , data_iface : Text
   , data_iface_type: Optional ./Protocol.dhall
-  , m0_servers : List M0Server
+  , m0_servers : Optional (List M0Server)
   , m0_clients : { s3 : Natural, other : Natural }
   }
```

Solution: wrap the list into Some in the test file.