### PR TITLE
EOS-16201:Hare Run I/O test m0crate: command not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,11 @@ You will probably need to modify `host`, `data_iface`, and `io_disks` values.
   sudo m0crate -S /tmp/m0crate-io.yaml
   ```
   Please note that m0crate will run as shown above when it will be
-  available in default system PATH which will be the case when when
-  setup is created using RPM's. If its created by building Motr
+  available in default system PATH which will be the case when
+  setup is created using RPMs. If its created by building Motr
   source code, then m0crate utility can be run using full path from
-  the motr source directory (./motr/motr/m0crate/m0crate).
+  the motr source directory (say MOTR_SRC).
+  ./MOTR_SRC/motr/m0crate/m0crate
 
 * Stop the cluster.
   ```sh


### PR DESCRIPTION
Problem:
m0crate command throwing error for the steps given in README.md
Error : m0crate: command not found
Solution:
m0crate can be located in motr directory, so the m0crate utility
needs correct path while executing this command.
This only needs a documentation fix, which is done here.
Note : This is in continuation PR
https://github.com/Seagate/cortx-hare/pull/1448

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>