### PR TITLE
EOS-16642 Add option '-d' for 'hctl status' to add devices info in ou…

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -225,17 +225,21 @@ def devices(cns: Consul, node_name: str) -> List[Device]:
 
 
 @repeat_if_fails(max_retries=24)
-def get_cluster_status(cns: Consul) -> Dict[str, Any]:
-    return {
+def get_cluster_status(cns: Consul, devices_requested: bool) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
         'pools': [x for x in sns_pools(cns)],
         'profiles': [{'fid': x.fid, 'name': x.name, 'pools': x.pools}
                      for x in profiles(cns)],
         'filesystem': get_fs_stats(cns),
         'nodes': [Node(name=h, svcs=processes(cns, h))
-                  for h in node_names(cns)],
-        'devices': [Devices(node_name=h, devs=devices(cns, h))
-                    for h in node_names(cns)]
+                  for h in node_names(cns)]
     }
+
+    if devices_requested:
+        result['devices'] = [Devices(node_name=h, devs=devices(cns, h))
+                             for h in node_names(cns)]
+
+    return result
 
 
 def parse_opts(argv):
@@ -243,6 +247,9 @@ def parse_opts(argv):
                                 usage='%(prog)s [OPTION]')
     p.add_argument('--json',
                    help='show output in JSON format',
+                   action='store_true')
+    p.add_argument("-d", "--devices",
+                   help='include devices info',
                    action='store_true')
     return p.parse_args(argv)
 
@@ -252,7 +259,7 @@ def setup_logging():
 
 
 @repeat_if_fails(max_retries=24)
-def show_text_status(cns: Consul) -> None:
+def show_text_status(cns: Consul, devices_requested: bool) -> None:
     # In-memory buffer required because an intermittent Consul exception can
     # happen right in the middle of printing something. It is good to postpone
     # the printing to stdout until the moment when those exceptions can't
@@ -285,11 +292,12 @@ def show_text_status(cns: Consul) -> None:
             for p in processes(cns, h):
                 fid: str = f'{p.fid}'
                 echo(f'    [{p.status}]  {p.name:<9}  {fid:<23}  {p.ep}')
-        echo('Devices:')
-        for h in node_names(cns):
-            echo(f'    {h}')
-            for d in devices(cns, h):
-                echo(f'    [{d.status}]  {d.name}')
+        if devices_requested:
+            echo('Devices:')
+            for h in node_names(cns):
+                echo(f'    {h}')
+                for d in devices(cns, h):
+                    echo(f'    [{d.status}]  {d.name}')
         print(stream.getvalue(), end='')  # flush
 
 
@@ -302,10 +310,10 @@ def main(argv=None):
         return 1
 
     if opts.json:
-        status = get_cluster_status(cns)
+        status = get_cluster_status(cns, opts.devices)
         print(simplejson.dumps(status, indent=2, for_json=True))
     else:
-        show_text_status(cns)
+        show_text_status(cns, opts.devices)
     return 0
 
 


### PR DESCRIPTION
Added new options '-d' and '--devices' to include devices info in 'hctl status' output
By default devices info will not be included in 'hctl status' output

Output:
-bash-4.2$ hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x6   192.168.9.198@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   192.168.9.198@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   192.168.9.198@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  192.168.9.198@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  192.168.9.198@tcp:12345:4:2
Devices:
    localhost
    [M0_NC_UNKNOWN]  /dev/null
    [M0_NC_UNKNOWN]  /dev/loop1
    [M0_NC_UNKNOWN]  /dev/loop2
    [M0_NC_UNKNOWN]  /dev/loop3
    [M0_NC_UNKNOWN]  /dev/loop4
    [M0_NC_UNKNOWN]  /dev/loop5
    [M0_NC_UNKNOWN]  /dev/loop6
    [M0_NC_UNKNOWN]  /dev/loop7
    [M0_NC_UNKNOWN]  /dev/loop8
    [M0_NC_UNKNOWN]  /dev/loop9
    [M0_NC_UNKNOWN]  /dev/loop0
-bash-4.2$ hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x6   192.168.9.198@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   192.168.9.198@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   192.168.9.198@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  192.168.9.198@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  192.168.9.198@tcp:12345:4:2
-bash-4.2$ hctl status -d --json
{
  "pools": [
    {
      "fid": "0x6f00000000000001:0x2f",
      "name": "the pool"
    }
  ],
  "profiles": [
    {
      "fid": "0x7000000000000001:0x4f",
      "name": "default",
      "pools": [
        "the pool",
        null,
        null
      ]
    }
  ],
  "filesystem": {
    "stats": {
      "fs_free_seg": 8590389096,
      "fs_total_seg": 8590951472,
      "fs_free_disk": 104689827840,
      "fs_avail_disk": 104689827840,
      "fs_total_disk": 104689827840,
      "fs_svc_total": 2,
      "fs_svc_replied": 2
    },
    "timestamp": 1611841778.130103,
    "date": "2021-01-28T06:49:38.130103"
  },
  "nodes": [
    {
      "name": "localhost",
      "svcs": [
        {
          "name": "hax",
          "fid": "0x7200000000000001:0x6",
          "ep": "192.168.9.198@tcp:12345:1:1",
          "status": "started"
        },
        {
          "name": "confd",
          "fid": "0x7200000000000001:0x9",
          "ep": "192.168.9.198@tcp:12345:2:1",
          "status": "started"
        },
        {
          "name": "ioservice",
          "fid": "0x7200000000000001:0xc",
          "ep": "192.168.9.198@tcp:12345:2:2",
          "status": "started"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x29",
          "ep": "192.168.9.198@tcp:12345:4:1",
          "status": "unknown"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x2c",
          "ep": "192.168.9.198@tcp:12345:4:2",
          "status": "unknown"
        }
      ]
    }
  ],
  "devices": [
    {
      "node_name": "localhost",
      "devs": [
        {
          "name": "/dev/null",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop1",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop2",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop3",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop4",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop5",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop6",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop7",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop8",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop9",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop0",
          "status": "M0_NC_UNKNOWN"
        }
      ]
    }
  ]
}
-bash-4.2$ hctl status --json
{
  "pools": [
    {
      "fid": "0x6f00000000000001:0x2f",
      "name": "the pool"
    }
  ],
  "profiles": [
    {
      "fid": "0x7000000000000001:0x4f",
      "name": "default",
      "pools": [
        "the pool",
        null,
        null
      ]
    }
  ],
  "filesystem": {
    "stats": {
      "fs_free_seg": 8590389096,
      "fs_total_seg": 8590951472,
      "fs_free_disk": 104689827840,
      "fs_avail_disk": 104689827840,
      "fs_total_disk": 104689827840,
      "fs_svc_total": 2,
      "fs_svc_replied": 2
    },
    "timestamp": 1611841778.130103,
    "date": "2021-01-28T06:49:38.130103"
  },
  "nodes": [
    {
      "name": "localhost",
      "svcs": [
        {
          "name": "hax",
          "fid": "0x7200000000000001:0x6",
          "ep": "192.168.9.198@tcp:12345:1:1",
          "status": "started"
        },
        {
          "name": "confd",
          "fid": "0x7200000000000001:0x9",
          "ep": "192.168.9.198@tcp:12345:2:1",
          "status": "started"
        },
        {
          "name": "ioservice",
          "fid": "0x7200000000000001:0xc",
          "ep": "192.168.9.198@tcp:12345:2:2",
          "status": "started"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x29",
          "ep": "192.168.9.198@tcp:12345:4:1",
          "status": "unknown"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x2c",
          "ep": "192.168.9.198@tcp:12345:4:2",
          "status": "unknown"
        }
      ]
    }
  ]
}
-bash-4.2$ hctl status --devices --json
{
  "pools": [
    {
      "fid": "0x6f00000000000001:0x2f",
      "name": "the pool"
    }
  ],
  "profiles": [
    {
      "fid": "0x7000000000000001:0x4f",
      "name": "default",
      "pools": [
        "the pool",
        null,
        null
      ]
    }
  ],
  "filesystem": {
    "stats": {
      "fs_free_seg": 8590389096,
      "fs_total_seg": 8590951472,
      "fs_free_disk": 104689827840,
      "fs_avail_disk": 104689827840,
      "fs_total_disk": 104689827840,
      "fs_svc_total": 2,
      "fs_svc_replied": 2
    },
    "timestamp": 1611841778.130103,
    "date": "2021-01-28T06:49:38.130103"
  },
  "nodes": [
    {
      "name": "localhost",
      "svcs": [
        {
          "name": "hax",
          "fid": "0x7200000000000001:0x6",
          "ep": "192.168.9.198@tcp:12345:1:1",
          "status": "started"
        },
        {
          "name": "confd",
          "fid": "0x7200000000000001:0x9",
          "ep": "192.168.9.198@tcp:12345:2:1",
          "status": "started"
        },
        {
          "name": "ioservice",
          "fid": "0x7200000000000001:0xc",
          "ep": "192.168.9.198@tcp:12345:2:2",
          "status": "started"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x29",
          "ep": "192.168.9.198@tcp:12345:4:1",
          "status": "unknown"
        },
        {
          "name": "m0_client",
          "fid": "0x7200000000000001:0x2c",
          "ep": "192.168.9.198@tcp:12345:4:2",
          "status": "unknown"
        }
      ]
    }
  ],
  "devices": [
    {
      "node_name": "localhost",
      "devs": [
        {
          "name": "/dev/null",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop1",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop2",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop3",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop4",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop5",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop6",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop7",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop8",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop9",
          "status": "M0_NC_UNKNOWN"
        },
        {
          "name": "/dev/loop0",
          "status": "M0_NC_UNKNOWN"
        }
      ]
    }
  ]
}
-bash-4.2$ hctl status --devices
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x6   192.168.9.198@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   192.168.9.198@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   192.168.9.198@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  192.168.9.198@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  192.168.9.198@tcp:12345:4:2
Devices:
    localhost
    [M0_NC_UNKNOWN]  /dev/null
    [M0_NC_UNKNOWN]  /dev/loop1
    [M0_NC_UNKNOWN]  /dev/loop2
    [M0_NC_UNKNOWN]  /dev/loop3
    [M0_NC_UNKNOWN]  /dev/loop4
    [M0_NC_UNKNOWN]  /dev/loop5
    [M0_NC_UNKNOWN]  /dev/loop6
    [M0_NC_UNKNOWN]  /dev/loop7
    [M0_NC_UNKNOWN]  /dev/loop8
    [M0_NC_UNKNOWN]  /dev/loop9
    [M0_NC_UNKNOWN]  /dev/loop0