### PR TITLE
cfgen: improve assert msg at pool drives check

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1092,6 +1092,7 @@ def pool_drives(m0conf: Dict[Oid, Any],
                        for drive_id, node_id in all_drives
                        if ref['path'] == m0conf[m0conf[drive_id].sdev].filename
                        and ref.get('node') in (None, m0conf[node_id].name)]
+            # XXX Improve validate_pools_desc() to catch this error.
             assert len(targets) == 1, 'Check {} config line'.format(ref)
             drives.extend(targets)
         assert all_unique(drives), \

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1092,7 +1092,7 @@ def pool_drives(m0conf: Dict[Oid, Any],
                        for drive_id, node_id in all_drives
                        if ref['path'] == m0conf[m0conf[drive_id].sdev].filename
                        and ref.get('node') in (None, m0conf[node_id].name)]
-            assert len(targets) == 1  # guaranteed by validate_pools_desc()
+            assert len(targets) == 1, 'Check {} config line'.format(ref)
             drives.extend(targets)
         assert all_unique(drives), \
             'Pool {!r}: some of disk_refs refer to the same disk'.format(


### PR DESCRIPTION
Currently, the assert msg looks like this:

    File "/opt/seagate/cortx/hare/bin/../bin/cfgen", line 1094, in pool_drives
      assert len(targets) == 1  # guaranteed by validate_pools_desc()
    AssertionError

which gives no clue about what's wrong with the pool configuration.

Solution: print config line which fails the assertion.