### PR TITLE
Problem: Config section is not implemented in setup.yaml file

### DIFF
--- a/provisioning/hare_setup.py
+++ b/provisioning/hare_setup.py
@@ -189,6 +189,13 @@ class Cleanup(argparse.Action):
                           error)
             exit(-1)
 
+class Config(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            return os.system('cp /opt/seagate/cortx/hare/share/cfgen/examples/singlenode.yaml /var/lib/hare/cluster.yaml') == 0
+        except Exception as error:
+            logging.error('Failed to perform configuration (%s)',
+                          error)
 def checkRpm(rpm_name):
     rpm_list = subprocess.Popen(["rpm", "-qa"],
                                 stdin=subprocess.PIPE,
@@ -277,6 +284,10 @@ def main():
                    nargs=0,
                    help='Perform component initialization',
                    action=Init)
+    p.add_argument('--config',
+                   nargs=0,
+                   help='Perform component configuration',
+                   action=Config)
     p.add_argument('--test',
                    nargs=0,
                    help='Testing cluster status',

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -6,8 +6,8 @@ hare:
     script: /opt/seagate/cortx/hare/conf/hare_setup.py
     args: --init
   config:
-    script: null
-    args: null
+    script: /opt/seagate/cortx/hare/conf/hare_setup.py
+    args: --config
   test:
     script: /opt/seagate/cortx/hare/conf/hare_setup.py
     args: --test


### PR DESCRIPTION
Solution: Implement config section in setup.yaml
Please note that this is temp solution(using singlenode.yaml as it is) until final version of config is ready
Prerequisite is that loop devices mentioned in singlenode.yaml are already created as below,
sudo mkdir -p /var/motr
```
for i in {0..9}; do
    sudo dd if=/dev/zero of=/var/motr/disk$i.img bs=1M seek=9999 count=1
    sudo losetup /dev/loop$i /var/motr/disk$i.img
done
```

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>

UT: 
-bash-4.2$ sudo provisioning/hare_setup.py --config
Failed to fetch data from provisioner ([Errno 2] No such file or directory: 'provisioner': 'provisioner')
-bash-4.2$ echo $?
0

Also tested init after above step

-bash-4.2$ sudo provisioning/hare_setup.py --init
Cluster is not running
2021-01-28 05:53:05: Generating cluster configuration... OK
2021-01-28 05:53:06: Starting Consul server on this node............. OK
2021-01-28 05:53:17: Importing configuration into the KV store... OK
2021-01-28 05:53:17: Starting Consul on other nodes... OK
2021-01-28 05:53:18: Updating Consul configuraton from the KV store... OK
2021-01-28 05:53:18: Waiting for the RC Leader to get elected........... OK
2021-01-28 05:53:27: Starting Motr (phase1, mkfs)... OK
2021-01-28 05:53:34: Starting Motr (phase1, m0d)... OK
2021-01-28 05:53:47: Starting Motr (phase2, mkfs)... OK
2021-01-28 05:53:53: Starting Motr (phase2, m0d)... OK
2021-01-28 05:54:07: Checking health of services... OK
Stopping m0d@0x7200000000000001:0xc (ios) at localhost...
Stopped m0d@0x7200000000000001:0xc (ios) at localhost
Stopping m0d@0x7200000000000001:0x9 (confd) at localhost...
Stopped m0d@0x7200000000000001:0x9 (confd) at localhost
Stopping hare-hax at localhost...
Stopped hare-hax at localhost
Stopping hare-consul-agent at localhost...
Stopped hare-consul-agent at localhost
Shutting down RC Leader at localhost... **ERROR**
Cluster is not running
Failed to fetch data from provisioner ([Errno 2] No such file or directory: 'provisioner': 'provisioner')
-bash-4.2$ echo $?
0
