### PR TITLE
hare.spec: fix consul version requirement

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -45,7 +45,7 @@ BuildRequires: python36-devel
 BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
-Requires: consul = 1.7.8
+Requires: consul >= 1.7.0, consul < 1.10.0
 Requires: facter
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}


### PR DESCRIPTION
Currently, the requirement allows only 1.7.8 version of Consul which is very strict. Hare is known to work fine with a much wider range of Consul versions.

Solution: fix the requirement to allow versions of Consul from 1.7.x to 1.9.x.