### PR TITLE
Problem: cfgen fails to parse CDF generated by mini provisioner

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -331,11 +331,13 @@ Pools of {t!r} type can only have 1 data unit."""
         assert t is PoolT.sns, \
             f"{name}: disk_refs are only supported for pools of 'sns' type"
         disk_refs = pool['disk_refs']
-        assert disk_refs, \
-            f'Pool {name!r}: disk_refs must not be empty' \
-            ' (it can be omitted though)'
-        assert all_unique(repr(x) for x in disk_refs), \
-            f'Pool {name!r}: disk_refs must be unique'
+        # Allowing diskrefs to be empty until the CDF generation is fixed.
+        if disk_refs:
+            assert disk_refs, \
+                f'Pool {name!r}: disk_refs must not be empty' \
+                ' (it can be omitted though)'
+            assert all_unique(repr(x) for x in disk_refs), \
+                f'Pool {name!r}: disk_refs must be unique'
 
     assert PoolT.sns in pool_types, \
         "At least one pool of 'sns' type must be defined"

--- a/provisioning/hare_setup.py
+++ b/provisioning/hare_setup.py
@@ -226,7 +226,7 @@ def list2dict(nodes_data_hctl: list) -> dict:
     for node in nodes_data_hctl:
         node_svc_info = {}
         for service in node['svcs']:
-            if not service['name'] in node_svc_info.keys(): 
+            if not service['name'] in node_svc_info.keys():
                 node_svc_info[service['name']] = []
             if (service['status'] == 'started'):
                 node_svc_info[service['name']].append(service['status'])

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 import pkg_resources
 
 from hare_mp.store import ValueProvider
-from hare_mp.types import DList, Maybe, NodeDesc, Text
+from hare_mp.types import DList, Maybe, NodeDesc, Text, Protocol
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
 DHALL_EXE = '/opt/seagate/cortx/hare/bin/dhall'
@@ -88,8 +88,9 @@ class CdfGenerator:
             data_iface=Text(iface),
 
             # data iface is not yet provided by ConfStore
-            data_iface_type=Maybe(None, 'P'),
+            data_iface_type=Maybe(Protocol.tcp, 'P'),
             io_disks=DList([
                 Text(device)
                 for device in store.get(f'cluster>{name}>storage>data_devices')
-            ], 'List Text'))
+            ], 'List Text'),
+            meta_data=Text(store.get(f'cluster>{name}>storage>metadata_devices')[0]))

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -8,6 +8,7 @@ let NodeInfo =
       , data_iface : Text
       , data_iface_type : Optional T.Protocol
       , io_disks : List Text
+      , meta_data : Text
       }
 
 let toNodeDesc
@@ -19,10 +20,10 @@ let toNodeDesc
           , m0_clients = { other = 3, s3 = 11 }
           , m0_servers =
               Some
-              [ { io_disks = { data = [] : List Text, meta_data = None Text }
+              [ { io_disks = { data = [] : List Text, meta_data = Some n.meta_data }
                 , runs_confd = Some True
                 }
-              , { io_disks = { data = n.io_disks, meta_data = None Text }
+              , { io_disks = { data = n.io_disks, meta_data = Some n.meta_data }
                 , runs_confd = None Bool
                 }
               ]
@@ -45,10 +46,10 @@ let genCdf
                 , disk_refs = None (List { node : Optional Text, path : Text })
                 , name = "the pool"
                 , parity_units = 0
-                , type = None < dix | md | sns >
+                , type = Some T.PoolType.sns
                 }
               ]
-          , profiles = None (List { name : Text, pools : List Text })
+          , profiles = Some [ { name = "Profile_the_pool", pools = [ "the pool" ] } ]
           }
 
 in  genCdf

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -85,3 +85,4 @@ class NodeDesc(DhallTuple):
     data_iface: Text
     data_iface_type: Maybe  # [Protocol]
     io_disks: DList  # [str]
+    meta_data: Text

--- a/provisioning/miniprov/requirements.txt
+++ b/provisioning/miniprov/requirements.txt
@@ -6,4 +6,3 @@ pkgconfig
 #:runtime-requirements:
 setuptools
 dataclasses
-

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -7,7 +7,7 @@ hare:
     args: --init
   config:
     script: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --config $URL
+    args: --config $URL --filename '/var/lib/hare/cluster.yaml'
   test:
     script: /opt/seagate/cortx/hare/bin/hare_setup
     args: --test


### PR DESCRIPTION
Mini provisioner CDF generator adds few default values for some of the
configuration keys. But hare cfgen utility that parses the generated
CDF does not allow some of the defined keys to have no values.
cfgen does not allow,
- meta-data devices to be None
- diskrefs must node be empty
- pool type cannot be null
- List of profiles must not be empty
- data_iface_type cannot be null

Solution:
- Fetch meta data devices from cortx-py-utils:conf-store and
  pass the values to Hare mini provisioner.
- Allowed diskrefs to be empty, but this needs to be fixed properly.
- Set default pool type to be sns.
- Set default non-empty list of profiles.
- Passed tcp as a default network interface type to mini provisioner.
- Add --filename option along with with config in setup.yaml

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>