### PR TITLE
EOS-17487 "make devinstall" is broken: pip doesn't handle transitive dependencies well

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ and health-checking mechanisms.
 
   * .. or from sources
     ```sh
-    git clone --recursive https://github.com/Seagate/cortx-motr.git motr
-    cd motr
+    git clone --recursive https://github.com/Seagate/cortx-motr.git
+    cd cortx-motr
 
     scripts/m0 make
     sudo scripts/install-motr-service --link

--- a/cfgen/requirements.txt
+++ b/cfgen/requirements.txt
@@ -1,2 +1,3 @@
+idna<3,>=2.5
 PyYAML
 ply  # cfgen tests execute `m0confgen`, which depends on `ply`

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -126,7 +126,8 @@ setup(
     packages=find_packages(),
     setup_requires=['flake8', 'mypy', 'pkgconfig'],
     install_requires=[
-        'python-consul>=1.1.0', 'simplejson', 'aiohttp', 'click', 'dataclasses'
+        'python-consul>=1.1.0', 'simplejson', 'aiohttp', 'click', 
+        'dataclasses', 'idna<3,>=2.5'
     ],
     entry_points={
         'console_scripts': ['hax=hax.hax:main', 'q=hax.queue.cli:main']


### PR DESCRIPTION
Problem: Transitive dependency issue (here due to idna)
Solution: Specifying the required version requirement in cfgen/requirement.txt and setup.py file so it resolves the dependency issues.


-----
[View rendered README.md](https://github.com/supritshinde/cortx-hare/blob/main/README.md)