### PR TITLE
Problem: No module named 'cortx' when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ $(MP_WHL): $(PY_VENV_DIR) $(HAX_SRC)
 
 $(PY_VENV_DIR): $(patsubst %,%/requirements.txt,cfgen hax provisioning/miniprov)
 	@$(call _info,Initializing virtual env in $(PY_VENV_DIR))
-	@$(PYTHON) -m venv $@
+	@$(PYTHON) -m venv --system-site-packages $@
 	@$(call _info,Installing pip modules in virtual env)
 	@for f in $^; do \
 	     $(call _log,processing $$f); \
-	     $(PIP) install -r $$f; \
+	     $(PIP) install --ignore-installed -r $$f; \
 	 done
 
 # Clean ----------------------------------------------- {{{1

--- a/provisioning/miniprov/Makefile
+++ b/provisioning/miniprov/Makefile
@@ -47,9 +47,9 @@ $(MP_WHL): $(PY_VENV_DIR) $(MP_SRC)
 
 $(PY_VENV_DIR): requirements.txt
 	@$(call _info,Initializing virtual env in $(PY_VENV_DIR))
-	@$(PYTHON) -m venv $@
+	@$(PYTHON) -m venv --system-site-packages $@
 	@$(call _info,Installing pip modules in virtual env)
-	@$(PIP) install -r ./requirements.txt
+	@$(PIP) install --ignore-installed -r ./requirements.txt
 
 # Install ----------------------------------------------- {{{1
 #

--- a/provisioning/miniprov/requirements.txt
+++ b/provisioning/miniprov/requirements.txt
@@ -2,6 +2,8 @@
 flake8
 mypy
 pkgconfig
+setuptools
+wheel
 
 #:runtime-requirements:
 setuptools

--- a/provisioning/miniprov/setup.py
+++ b/provisioning/miniprov/setup.py
@@ -40,5 +40,5 @@ setup(name='hare_mp',
       packages=find_packages(),
       setup_requires=['flake8', 'mypy', 'pkgconfig'],
       install_requires=['setuptools', 'dataclasses'],
-      package_data={'': '*.dhall'},
+      package_data={'': ['*.dhall']},
       entry_points={'console_scripts': ['hare_setup=hare_mp.main:main']})


### PR DESCRIPTION
Mini Provisioner depends on ConfStore which is imported from
cortx.utils.

The problem is that Hare build pipeline runs in a separate virtual
environment (a.k.a. virtualenv). By default virtualenv doesn't inherit
system-wide packages from `/usr/lib/python3.6/site-packages`. It means
that even though cortx-py-utils RPM is installed, its Python packages
are not visible from Hare virtualenv.

## Solution
1. Create virtualenv with `--system-site-packages` flag.
2. After that local requirements.txt must be processed with
`--ignore-installed` flag to force pip to overwrite the packages in the
local site-packages.

