### PR TITLE
Problem: Number of s3 servers is not taken from ConfStore

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 import pkg_resources
 
 from hare_mp.store import ValueProvider
-from hare_mp.types import DList, Maybe, NodeDesc, Text, Protocol
+from hare_mp.types import DList, Maybe, NodeDesc, Protocol, Text
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
 DHALL_EXE = '/opt/seagate/cortx/hare/bin/dhall'
@@ -97,4 +97,5 @@ class CdfGenerator:
             # [KN] This is a hotfix for singlenode deployment
             # TODO in the future the value must be taken from a correct
             # ConfStore key (it doesn't exist now).
-            meta_data=Text('/dev/vg_metadata_srvnode-1/lv_raw_metadata'))
+            meta_data=Text('/dev/vg_metadata_srvnode-1/lv_raw_metadata'),
+            s3_instances=int(store.get(f'cluster>{name}>s3_instances')))

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -9,6 +9,7 @@ let NodeInfo =
       , data_iface_type : Optional T.Protocol
       , io_disks : List Text
       , meta_data : Text
+      , s3_instances : Natural
       }
 
 let toNodeDesc
@@ -17,7 +18,7 @@ let toNodeDesc
       ->  { hostname = n.hostname
           , data_iface = n.data_iface
           , data_iface_type = n.data_iface_type
-          , m0_clients = { other = 3, s3 = 11 }
+          , m0_clients = { other = 3, s3 = n.s3_instances }
           , m0_servers =
               Some
               [ { io_disks = { data = [] : List Text, meta_data = Some n.meta_data }

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -86,3 +86,4 @@ class NodeDesc(DhallTuple):
     data_iface_type: Maybe  # [Protocol]
     io_disks: DList  # [str]
     meta_data: Text
+    s3_instances: int

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -76,7 +76,9 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'cluster>srvnode_1>storage>data_devices': ['/dev/sdb'],
                 'cluster>srvnode_1>network>data>private_interfaces':
-                ['eth1', 'eno2']
+                ['eth1', 'eno2'],
+                'cluster>srvnode_1>storage>metadata_devices': ['/dev/meta'],
+                'cluster>srvnode_1>s3_instances': 1,
             }
             return data[value]
 
@@ -96,7 +98,9 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'cluster>srvnode_1>storage>data_devices': ['/dev/sdb'],
                 'cluster>srvnode_1>network>data>private_interfaces':
-                ['eth1', 'eno2']
+                ['eth1', 'eno2'],
+                'cluster>srvnode_1>storage>metadata_devices': ['/dev/meta'],
+                'cluster>srvnode_1>s3_instances': 1,
             }
             return data[value]
 
@@ -107,6 +111,7 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('myhost'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
+        self.assertEqual(1, ret[0].s3_instances)
 
     def test_metadata_is_hardcoded(self):
         store = ValueProvider()
@@ -120,7 +125,8 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'cluster>srvnode_1>storage>data_devices': ['/dev/sdb'],
                 'cluster>srvnode_1>network>data>private_interfaces':
-                ['eth1', 'eno2']
+                ['eth1', 'eno2'],
+                'cluster>srvnode_1>s3_instances': 1,
             }
             return data[value]
 
@@ -149,7 +155,13 @@ class TestCDF(unittest.TestCase):
                 'cluster>srvnode_2>hostname':
                 'host-2',
                 'cluster>srvnode_2>network>data>private_interfaces': ['eno1'],
-                'cluster>srvnode_2>storage>data_devices': ['/dev/sdb']
+                'cluster>srvnode_2>storage>data_devices': ['/dev/sdb'],
+                'cluster>srvnode_1>storage>metadata_devices': ['/dev/meta'],
+                'cluster>srvnode_1>s3_instances': 1,
+                'cluster>srvnode_2>hostname': 'host-2',
+                'cluster>srvnode_2>storage>data_devices': ['/dev/sdb'],
+                'cluster>srvnode_2>storage>metadata_devices': ['/dev/meta'],
+                'cluster>srvnode_2>s3_instances': 5,
             }
             return data[value]
 
@@ -160,5 +172,7 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(2, len(ret))
         self.assertEqual(Text('myhost'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
+        self.assertEqual(1, ret[0].s3_instances)
         self.assertEqual(Text('host-2'), ret[1].hostname)
         self.assertEqual(Text('eno1'), ret[1].data_iface)
+        self.assertEqual(5, ret[1].s3_instances)


### PR DESCRIPTION
JIRA: https://jts.seagate.com/browse/EOS-17250

Solution:
1. take the number of s3 servers from `cluster>{node-name}>s3_instances` value.
2. update failing unit tests.

Resolves one of the items specified in #1477