### PR TITLE
Problem: logrotate configuration is not optional

### DIFF
--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -1,7 +1,7 @@
 hare:
   post_install:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --report-unavailable-features --post_install
+    script: /opt/seagate/cortx/hare/bin/hare_setup
+    args: --report-unavailable-features --configure-logrotate --post_install
   init:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup
     args: --init


### PR DESCRIPTION
hare_setup utility by default tries to install logrotate configuration which
requires provisioner cli to be installed. It is possible that on some dev setups
provisioner is not installed, in which case hare_setup throws an error that may
mislead user to assume that hare_setup command itself failed.
Also it is not required logrotate to be configured in context of every command
execution.

Solution:
Provide an explicit option to hare_setup utility to configure hare logrotate
values.