### PR TITLE
EOS-17407: hare-shutdown can leave the cluster in non-stoppable state

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -209,8 +209,8 @@ class ConsulKVBasic:
 
 
 class ConsulUtil:
-    def __init__(self):
-        self.cns: Consul = Consul()
+    def __init__(self, raw_client: Optional[Consul] = None):
+        self.cns: Consul = raw_client or Consul()
         self.kv = ConsulKVBasic(cns=self.cns)
 
     def _catalog_service_names(self) -> List[str]:

--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -20,13 +20,14 @@
 # help stop the cluster or local node
 
 import getopt
-import sys
 import logging
-import utils
-from socket import gethostname
+import sys
+from typing import Dict, List, Tuple
+
 from consul import Consul
-from hax.util import repeat_if_fails
-from typing import Dict, List
+from hax.util import ConsulUtil, repeat_if_fails
+
+import utils
 
 
 def check_cluster():
@@ -38,7 +39,7 @@ def check_cluster():
 
 
 @repeat_if_fails()
-def _get_processes_for_cluster():
+def _get_processes_for_cluster() -> Tuple[Dict[str, List[utils.Process]], str]:
     cns = Consul()
     processes = utils.processes_by_consul_svc_name(cns)
     leader_node = utils.get_kv(cns, 'leader')
@@ -46,17 +47,30 @@ def _get_processes_for_cluster():
 
 
 @repeat_if_fails()
-def _get_processes_for_node():
+def _get_processes_for_node() -> Dict[str, List[utils.Process]]:
     cns = Consul()
-    node = gethostname()
+    cns_util = ConsulUtil(raw_client=cns)
+    node = cns_util.get_local_nodename()
     processes = utils.processes_node(cns, node)
     return processes
 
 
 def stop_process(processes: Dict[str, List[utils.Process]]):
     for svc in utils.shutdown_sequence:
-        if svc in processes:
+        if svc not in processes:
+            continue
+        if svc != 'consul':
             utils.stop_parallel([proc for proc in processes[svc]])
+        else:
+            # Consul process at the current node must stopped the last.
+            # Reason: if something goes wrong and the user will want to
+            # shutdown the cluster again, local Consul must be available.
+            remote_procs = [
+                proc for proc in processes[svc] if not proc.is_local
+            ]
+            utils.stop_parallel(remote_procs)
+            local_procs = [proc for proc in processes[svc] if proc.is_local]
+            utils.stop_parallel(local_procs)
 
 
 def shutdown_cluster():
@@ -78,9 +92,7 @@ def node_shutdown():
 
 def main() -> None:
     try:
-        opts, args = getopt.getopt(sys.argv[1:],
-                                   "v",
-                                   ["verbose", "node"])
+        opts, args = getopt.getopt(sys.argv[1:], "v", ["verbose", "node"])
     except getopt.GetoptError as err:
         sys.exit(err)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -30,10 +30,11 @@ from consul import Consul, ConsulException
 from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
 from hax.exception import HAConsistencyException
+from hax.util import ConsulUtil
 
 Process = NamedTuple('Process', [('node', str), ('consul_name', str),
                                  ('systemd_name', str), ('fidk', int),
-                                 ('status', str)])
+                                 ('status', str), ('is_local', bool)])
 shutdown_sequence = ('s3service', 'ios', 'confd', 'hax', 'consul')
 
 
@@ -74,9 +75,13 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
     """Processes grouped by Consul service name."""
     try:
         processes: Dict[str, List[Process]] = {}
+        cns_util = ConsulUtil(raw_client=cns)
+        is_local = node_name == cns_util.get_local_nodename()
+
         for node in cns.catalog.nodes()[1]:
             if node_name != node['Node']:
                 continue
+
             for svc in cns.health.node(node['Node'])[1]:
                 svc_name = svc['ServiceName']
                 if svc_name:
@@ -86,6 +91,7 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
                                 consul_name=svc_name,
                                 systemd_name=get_systemd_name(fidk, svc_name),
                                 fidk=fidk,
+                                is_local=is_local,
                                 status=svc['Status']))
             consul_status = 'passing' if consul_is_active_at(node['Node']) \
                 else 'offline'
@@ -94,6 +100,7 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
                         consul_name='consul',
                         systemd_name='hare-consul-agent',
                         fidk=0,
+                        is_local=is_local,
                         status=consul_status))
         return processes
     except (ConsulException, HTTPError, RequestException) as e:
@@ -104,8 +111,11 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
 def processes_by_consul_svc_name(cns: Consul) -> Dict[str, List[Process]]:
     """Processes grouped by Consul service name."""
     try:
+        cns_util = ConsulUtil(raw_client=cns)
+
         processes: Dict[str, List[Process]] = {}
         for node in cns.catalog.nodes()[1]:
+            is_local = node['Node'] == cns_util.get_local_nodename()
             for svc in cns.health.node(node['Node'])[1]:
                 svc_name = svc['ServiceName']
                 if svc_name:
@@ -115,6 +125,7 @@ def processes_by_consul_svc_name(cns: Consul) -> Dict[str, List[Process]]:
                                 consul_name=svc_name,
                                 systemd_name=get_systemd_name(fidk, svc_name),
                                 fidk=fidk,
+                                is_local=is_local,
                                 status=svc['Status']))
             consul_status = 'passing' if consul_is_active_at(node['Node']) \
                 else 'offline'
@@ -123,6 +134,7 @@ def processes_by_consul_svc_name(cns: Consul) -> Dict[str, List[Process]]:
                         consul_name='consul',
                         systemd_name='hare-consul-agent',
                         fidk=0,
+                        is_local=is_local,
                         status=consul_status))
         return processes
     except (ConsulException, HTTPError, RequestException) as e:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -194,7 +194,11 @@ class QuitMessage:
 
 class Worker(threading.Thread):
     def __init__(self, queue: Queue):
-        super().__init__(target=self._do_work, args=(queue, ))
+        # [KN] We mark the thread as daemonic to make sure it will
+        # exit as soon as the main thread exits.
+        # That will make sure that the application shuts down on
+        # SIGINT event (Ctrl-C)
+        super().__init__(target=self._do_work, args=(queue, ), daemon=True)
 
     def _do_work(self, queue: Queue):
         logging.debug('Started thread')


### PR DESCRIPTION
Problems:
1. SIGKILL doesn't stop hare-shutdown script properly. There is a chance that local consul will be killed and thus hare-shutdown will not work next time.
2. There is a chance that local consul will be stopped not the last. If an error occurs after that, hare-shutdown will not work next time.
