### PR TITLE
Problem: Hare miniprovisioner init, test section uses hardcoded path for CDF file, also arguments like '--config' or '--init' should be just 'config' and 'init' respectively

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -29,6 +29,7 @@ import shutil
 import subprocess
 import sys
 from typing import Dict, List
+
 import yaml
 from cortx.utils.product_features import unsupported_features
 
@@ -81,125 +82,114 @@ def _report_unsupported_features(features_unavailable):
         uf_db.store_unsupported_features('hare', features_unavailable))
 
 
-class Logrotate(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
+def logrotate():
+    try:
+        setup_info = get_data_from_provisioner_cli('get_setup_info')
+        if setup_info != 'unknown':
+            server_type = setup_info['server_type']
+            shutil.copyfile(
+                f'/opt/seagate/cortx/hare/conf/logrotate/{server_type}',
+                '/etc/logrotate.d/hare')
+    except Exception as error:
+        logging.error('Cannot configure logrotate for hare (%s)', error)
+
+
+def unsupported_feature():
+    try:
+        features_unavailable = []
+        path = '/opt/seagate/cortx/hare/conf/setup_info.json'
+        with open(path) as hare_features_info:
+            hare_unavailable_features = json.load(hare_features_info)
             setup_info = get_data_from_provisioner_cli('get_setup_info')
             if setup_info != 'unknown':
-                server_type = setup_info['server_type']
-                shutil.copyfile(
-                    f'/opt/seagate/cortx/hare/conf/logrotate/{server_type}',
-                    '/etc/logrotate.d/hare')
-        except Exception as error:
-            logging.error('Cannot configure logrotate for hare (%s)', error)
+                for setup in hare_unavailable_features['setup_types']:
+                    if setup['server_type'] == setup_info['server_type']:
+                        features_unavailable.extend(
+                            setup['unsupported_features'])
+                        _report_unsupported_features(features_unavailable)
+    except Exception as error:
+        logging.error('Error reporting hare unsupported features (%s)', error)
 
 
-class UnsupportedFeatures(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
-            features_unavailable = []
-            path = '/opt/seagate/cortx/hare/conf/setup_info.json'
-            with open(path) as hare_features_info:
-                hare_unavailable_features = json.load(hare_features_info)
-                setup_info = get_data_from_provisioner_cli('get_setup_info')
-                if setup_info != 'unknown':
-                    for setup in hare_unavailable_features['setup_types']:
-                        if setup['server_type'] == setup_info['server_type']:
-                            features_unavailable.extend(
-                                setup['unsupported_features'])
-                            _report_unsupported_features(features_unavailable)
-        except Exception as error:
-            logging.error('Error reporting hare unsupported features (%s)',
-                          error)
-
-
-class PostInstall(argparse.Action):
-    """
-    Assumption: motr, hare, consul, cortx-py-utils and cortx-s3server rpms
-    are already installed
-    Approach: Will use 'rpm -qa | grep -q <rpm_name>' command to check if
-    rpm is installed
-    """
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
-            if checkRpm('cortx-motr') != 0:
-                logging.error('\'cortx-motr\' is not installed')
-                exit(-1)
-            if checkRpm('consul') != 0:
-                logging.error('\'consul\' is not installed')
-                exit(-1)
-            if checkRpm('cortx-hare') != 0:
-                logging.error('\'cortx-hare\' is not installed')
-                exit(-1)
-            if checkRpm('cortx-py-utils') != 0:
-                logging.error('\'cortx-py-utils\' is not installed')
-                exit(-1)
-            if checkRpm('cortx-s3server') != 0:
-                logging.warning('\'cortx-s3server\' is not installed')
-        except Exception as error:
-            logging.error('Error while checking installed rpms (%s)', error)
+def post_install(args):
+    try:
+        if checkRpm('cortx-motr') != 0:
+            logging.error('\'cortx-motr\' is not installed')
             exit(-1)
-
-
-class Init(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
-            rc = 0
-            if not is_cluster_running() and bootstrap_cluster() != 0:
-                logging.error('Failed to bootstrap the custer')
-                rc = -1
-            shutdown_cluster()
-            exit(rc)
-        except Exception as error:
-            logging.error('Error while initializing the cluster (%s)', error)
-            shutdown_cluster()
+        if checkRpm('consul') != 0:
+            logging.error('\'consul\' is not installed')
             exit(-1)
-
-
-class Test(argparse.Action):
-    """
-    Read CDF file and compare fields with output of 'hctl status'
-    Will start the cluster(and shutdown before exiting) if not already started
-    """
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
-            rc = 0
-            if not is_cluster_running() and bootstrap_cluster() != 0:
-                logging.error('Failed to bootstrap the cluster')
-                rc = -1
-            cluster_status = check_cluster_status()
-            shutdown_cluster()
-            if cluster_status:
-                logging.error('Cluster status reports failure')
-                rc = -1
-            exit(rc)
-        except Exception as error:
-            logging.error('Error while checking cluster status (%s)', error)
-            shutdown_cluster()
+        if checkRpm('cortx-hare') != 0:
+            logging.error('\'cortx-hare\' is not installed')
             exit(-1)
-
-
-class SupportBundle(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
-            # Default target directory is /tmp/hare
-            if os.system('hctl reportbug') != 0:
-                logging.error('Failed to generate support bundle')
-                exit(-1)
-        except Exception as error:
-            logging.error('Error while generating support bundle (%s)', error)
+        if checkRpm('cortx-py-utils') != 0:
+            logging.error('\'cortx-py-utils\' is not installed')
             exit(-1)
+        if checkRpm('cortx-s3server') != 0:
+            logging.warning('\'cortx-s3server\' is not installed')
+
+        if args.report_unavailable_features:
+            unsupported_feature()
+
+        if args.configure_logrotate:
+            logrotate()
+
+    except Exception as error:
+        logging.error('Error while checking installed rpms (%s)', error)
+        exit(-1)
 
 
-class Cleanup(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        try:
-            exit(0)
-        except Exception as error:
-            logging.error('Failed to perform cleanup (%s)', error)
+def init(args):
+    try:
+        rc = 0
+        path_to_cdf = args.file[0]
+        if not is_cluster_running() and bootstrap_cluster(path_to_cdf) != 0:
+            logging.error('Failed to bootstrap the custer')
+            rc = -1
+        shutdown_cluster()
+        exit(rc)
+    except Exception as error:
+        logging.error('Error while initializing the cluster (%s)', error)
+        shutdown_cluster()
+        exit(-1)
+
+
+def test(args):
+    try:
+        rc = 0
+        path_to_cdf = args.file[0]
+        if not is_cluster_running() and bootstrap_cluster(path_to_cdf) != 0:
+            logging.error('Failed to bootstrap the cluster')
+            rc = -1
+        cluster_status = check_cluster_status(path_to_cdf)
+        shutdown_cluster()
+        if cluster_status:
+            logging.error('Cluster status reports failure')
+            rc = -1
+        exit(rc)
+    except Exception as error:
+        logging.error('Error while checking cluster status (%s)', error)
+        shutdown_cluster()
+        exit(-1)
+
+
+def generate_support_bundle(args):
+    try:
+        # Default target directory is /tmp/hare
+        if os.system('hctl reportbug') != 0:
+            logging.error('Failed to generate support bundle')
             exit(-1)
+    except Exception as error:
+        logging.error('Error while generating support bundle (%s)', error)
+        exit(-1)
+
+
+def cleanup(args):
+    try:
+        exit(0)
+    except Exception as error:
+        logging.error('Failed to perform cleanup (%s)', error)
+        exit(-1)
 
 
 def checkRpm(rpm_name):
@@ -226,8 +216,8 @@ def is_cluster_running() -> bool:
     return os.system('hctl status >/dev/null') == 0
 
 
-def bootstrap_cluster():
-    return os.system('hctl bootstrap --mkfs /var/lib/hare/cluster.yaml')
+def bootstrap_cluster(path_to_cdf: str):
+    return os.system('hctl bootstrap --mkfs ' + path_to_cdf)
 
 
 def shutdown_cluster():
@@ -249,9 +239,9 @@ def list2dict(nodes_data_hctl: list) -> dict:
     return node_info_dict
 
 
-def check_cluster_status():
+def check_cluster_status(path_to_cdf: str):
     cluster_desc = None
-    with open("/var/lib/hare/cluster.yaml", 'r') as stream:
+    with open(path_to_cdf, 'r') as stream:
         cluster_desc = yaml.safe_load(stream)
     cmd = ['hctl', 'status', '--json']
     cluster_info = json.loads(execute(cmd))
@@ -263,16 +253,17 @@ def check_cluster_status():
         m0ds = node.get('m0_servers', [])
         ios_cnt = 0
         for m0d in m0ds:
-            if 'runs_confd' in m0d.keys() and node_info_dict[
-                    node['hostname']]['confd'][0] != 'started':
+            if 'runs_confd' in m0d.keys(
+            ) and node_info_dict[node['hostname']]['confd'][0] != 'started':
                 return -1
             if m0d['io_disks']['data']:
                 if node_info_dict[
-                   node['hostname']]['ioservice'][ios_cnt] != 'started':
+                        node['hostname']]['ioservice'][ios_cnt] != 'started':
                     return -1
                 ios_cnt += 1
-        if (m0client_s3_cnt > 0 and len(node_info_dict[
-                node['hostname']]['s3server']) != m0client_s3_cnt):
+        if (m0client_s3_cnt > 0
+                and len(node_info_dict[node['hostname']]['s3server']) !=
+                m0client_s3_cnt):
             return -1
 
     return 0
@@ -288,60 +279,83 @@ def save(filename: str, contents: str) -> None:
         f.write(contents)
 
 
+def config(args):
+    try:
+        url = args.config[0]
+        filename = args.file[0] or '/var/lib/hare/cluster.yaml'
+        save(filename, generate_cdf(url))
+    except Exception as error:
+        logging.error('Error performing configuration (%s)', error)
+
+
 def main():
     p = argparse.ArgumentParser(description='Configure hare settings')
-    p.add_argument('--report-unavailable-features',
-                   nargs=0,
-                   help='Report unsupported features according to setup type',
-                   action=UnsupportedFeatures)
-    p.add_argument('--configure-logrotate',
-                   nargs=0,
-                   help='Configure logrotate for hare',
-                   action=Logrotate)
-    p.add_argument('--post_install',
-                   nargs=0,
-                   help='Perform post installation checks',
-                   action=PostInstall)
-    p.add_argument('--init',
-                   nargs=0,
-                   help='Perform component initialization',
-                   action=Init)
-    p.add_argument('--test',
-                   nargs=0,
-                   help='Testing cluster status',
-                   action=Test)
-    p.add_argument('--support_bundle',
-                   nargs=0,
-                   help='Testing cluster status',
-                   action=SupportBundle)
-    p.add_argument('--reset',
-                   '--cleanup',
-                   nargs=0,
-                   help='Reset/cleanup step',
-                   action=Cleanup)
-    p.add_argument('--filename',
-                   help='Full path to the CDF file to generate at this stage.',
-                   nargs=1,
-                   default='/var/lib/hare/cluster.yaml',
-                   type=str,
-                   action='store')
-    p.add_argument('--config',
-                   help='Configure Hare',
-                   nargs=1,
-                   type=str,
-                   default='',
-                   dest='config_url',
-                   action='store')
+    subparser = p.add_subparsers()
+
+    parser = subparser.add_parser('post_install',
+                                  help='Perform post installation checks')
+    parser.set_defaults(func=post_install)
+    parser.add_argument(
+        '--report-unavailable-features',
+        help='Report unsupported features according to setup type',
+        action='store_true')
+    parser.add_argument('--configure-logrotate',
+                        help='Configure logrotate for hare',
+                        action='store_true')
+
+    parser = subparser.add_parser('config', help='Configure Hare')
+    parser.set_defaults(func=config)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
+    parser.add_argument(
+        '--file',
+        help='Full path to the CDF file to generate at this stage.',
+        nargs=1,
+        default=['/var/lib/hare/cluster.yaml'],
+        type=str,
+        action='store')
+
+    parser = subparser.add_parser('init',
+                                  help='Perform component initialization')
+    parser.set_defaults(func=init)
+    parser.add_argument('--file',
+                        help='Full path to the CDF file.',
+                        nargs=1,
+                        default=['/var/lib/hare/cluster.yaml'],
+                        type=str,
+                        action='store')
+
+    parser = subparser.add_parser('test', help='Testing cluster status')
+    parser.set_defaults(func=test)
+    parser.add_argument('--file',
+                        help='Full path to the CDF file.',
+                        nargs=1,
+                        default=['/var/lib/hare/cluster.yaml'],
+                        type=str,
+                        action='store')
+
+    parser = subparser.add_parser('support_bundle',
+                                  help='Generating support bundle')
+    parser.set_defaults(func=generate_support_bundle)
+
+    parser = subparser.add_parser('reset', help='Reset/cleanup step')
+    parser.set_defaults(func=cleanup)
+    parser = subparser.add_parser('cleanup', help='Reset/cleanup step')
+    parser.set_defaults(func=cleanup)
+
     setup_logging()
 
     parsed = p.parse_args(sys.argv[1:])
-    if parsed.config_url:
-        # --config also depends on optional parameter --filename,
-        # that is why the approach with putting the whole confi
-        # logic into the ConfigAction class will not work.
-        url = parsed.config_url[0]
-        filename = parsed.filename[0] or '/var/lib/hare/cluster.yaml'
-        save(filename, generate_cdf(url))
+
+    if not hasattr(parsed, 'func'):
+        logging.error('Error: No valid command passed. Please check "--help"')
+        exit(1)
+
+    parsed.func(parsed)
 
 
 if __name__ == '__main__':

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -1,22 +1,22 @@
 hare:
   post_install:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --report-unavailable-features --configure-logrotate --post_install
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup post_install
+    args: --report-unavailable-features --configure-logrotate
   init:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --init
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup init
+    args:
   config:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --config $URL --filename '/var/lib/hare/cluster.yaml'
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup config
+    args: --config $URL --file '/var/lib/hare/cluster.yaml'
   test:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --test
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup test
+    args:
   support_bundle:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --support_bundle
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup support_bundle
+    args:
   reset:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --reset
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup reset
+    args:
   cleanup:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup
-    args: --cleanup
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup cleanup
+    args:


### PR DESCRIPTION
I have addressed https://github.com/Seagate/cortx-hare/issues/1482 and https://jts.seagate.com/browse/EOS-17172
Solution: Support added for init and test to take cdf file path as input and modified code to use sub-commands to handle miniprovisioner related commands
