### PR TITLE
Problem: hare_mp package doesn't pass flake8 and mypy checks

### DIFF
--- a/provisioning/miniprov/Makefile
+++ b/provisioning/miniprov/Makefile
@@ -88,11 +88,8 @@ clean:
 # Linters --------------------------------------------- {{{1
 #
 
-# TODO: resolve mypy issues (probably ConfStore should
-# be added to exceptions)
-# Note that mypy is disabled for now when building miniprov
 .PHONY: check
-check: flake8 test
+check: flake8 mypy test
 
 .PHONY: test
 test: $(PY_VENV_DIR) $(MP_SRC)

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -20,7 +20,6 @@
 # report unsupported features, etc.
 
 # TODO [KN] polish the code, resolve flake8 complaints
-# flake8: noqa
 import argparse
 import asyncio
 import json
@@ -29,8 +28,7 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import List
-
+from typing import Dict, List
 import yaml
 from cortx.utils.product_features import unsupported_features
 
@@ -74,6 +72,7 @@ def get_data_from_provisioner_cli(method, output_format='json') -> str:
         return 'unknown'
     res = stdout.decode('utf-8')
     return json.loads(res)['ret'] if res else 'unknown'
+
 
 def _report_unsupported_features(features_unavailable):
     uf_db = unsupported_features.UnsupportedFeaturesDB()
@@ -121,6 +120,7 @@ class PostInstall(argparse.Action):
     Approach: Will use 'rpm -qa | grep -q <rpm_name>' command to check if
     rpm is installed
     """
+
     def __call__(self, parser, namespace, values, option_string=None):
         try:
             if checkRpm('cortx-motr') != 0:
@@ -162,6 +162,7 @@ class Test(argparse.Action):
     Read CDF file and compare fields with output of 'hctl status'
     Will start the cluster(and shutdown before exiting) if not already started
     """
+
     def __call__(self, parser, namespace, values, option_string=None):
         try:
             rc = 0
@@ -237,7 +238,7 @@ def shutdown_cluster():
 def list2dict(nodes_data_hctl: list) -> dict:
     node_info_dict = {}
     for node in nodes_data_hctl:
-        node_svc_info = {}
+        node_svc_info: Dict[str, List[str]] = {}
         for service in node['svcs']:
             if not service['name'] in node_svc_info.keys():
                 node_svc_info[service['name']] = []
@@ -262,17 +263,16 @@ def check_cluster_status():
         m0ds = node.get('m0_servers', [])
         ios_cnt = 0
         for m0d in m0ds:
-            if ('runs_confd' in m0d.keys() and
-                (node_info_dict[node['hostname']]['confd'][0] != 'started')):
+            if 'runs_confd' in m0d.keys() and node_info_dict[
+                    node['hostname']]['confd'][0] != 'started':
                 return -1
             if m0d['io_disks']['data']:
                 if node_info_dict[
-                        node['hostname']]['ioservice'][ios_cnt] != 'started':
+                   node['hostname']]['ioservice'][ios_cnt] != 'started':
                     return -1
                 ios_cnt += 1
-        if (m0client_s3_cnt > 0
-                and len(node_info_dict[node['hostname']]['s3server']) !=
-                m0client_s3_cnt):
+        if (m0client_s3_cnt > 0 and len(node_info_dict[
+                node['hostname']]['s3server'] != m0client_s3_cnt)):
             return -1
 
     return 0


### PR DESCRIPTION
Solution: Modified code to address errors generated by flake8 and mypy

Note: flake8 still reporting some error but they looks false positive

```
[root@ssc-vm-c-1823 hare]# flake8 provisioning/miniprov/hare_mp --show-source
provisioning/miniprov/hare_mp/cdf.py:17:33: E901 SyntaxError: invalid syntax
    def __init__(self, provider: ValueProvider):
                                ^
provisioning/miniprov/hare_mp/cdf.py:28:20: E701 multiple statements on one line (colon)
        raw_content: bytes = pkg_resources.resource_string(
                   ^
provisioning/miniprov/hare_mp/cdf.py:33:14: E701 multiple statements on one line (colon)
        nodes: List[NodeDesc] = []
             ^
provisioning/miniprov/hare_mp/cdf.py:35:20: E701 multiple statements on one line (colon)
        server_dict: Dict[str, str] = conf.get('cluster>server_nodes')
                   ^
provisioning/miniprov/hare_mp/main.py:40:17: E901 SyntaxError: invalid syntax
def execute(cmd: List[str]) -> str:
                ^
provisioning/miniprov/hare_mp/main.py:240:22: E701 multiple statements on one line (colon)
        node_svc_info: dict = {}
                     ^
provisioning/miniprov/hare_mp/store.py:28:23: E901 SyntaxError: invalid syntax
    def get(self, key: str) -> Any:
                      ^
provisioning/miniprov/hare_mp/types.py:8:10: E701 multiple statements on one line (colon)
    value: Any
         ^
provisioning/miniprov/hare_mp/types.py:8:11: E901 SyntaxError: invalid syntax
    value: Any
          ^
provisioning/miniprov/hare_mp/types.py:9:12: E701 multiple statements on one line (colon)
    comment: str
           ^
provisioning/miniprov/hare_mp/types.py:20:10: E701 multiple statements on one line (colon)
    value: List[Any]
         ^
provisioning/miniprov/hare_mp/types.py:21:12: E701 multiple statements on one line (colon)
    comment: str
           ^
provisioning/miniprov/hare_mp/types.py:55:6: E701 multiple statements on one line (colon)
    s: str
     ^
provisioning/miniprov/hare_mp/types.py:66:7: E701 multiple statements on one line (colon)
    s3: int
      ^
provisioning/miniprov/hare_mp/types.py:67:10: E701 multiple statements on one line (colon)
    other: int
         ^
provisioning/miniprov/hare_mp/types.py:72:14: E701 multiple statements on one line (colon)
    meta_data: Maybe  # [str]
             ^
provisioning/miniprov/hare_mp/types.py:73:9: E701 multiple statements on one line (colon)
    data: DList
        ^
provisioning/miniprov/hare_mp/types.py:78:15: E701 multiple statements on one line (colon)
    runs_confd: Maybe  # [bool]
              ^
provisioning/miniprov/hare_mp/types.py:79:13: E701 multiple statements on one line (colon)
    io_disks: DisksDesc
            ^
provisioning/miniprov/hare_mp/types.py:84:13: E701 multiple statements on one line (colon)
    hostname: Text
            ^
provisioning/miniprov/hare_mp/types.py:85:15: E701 multiple statements on one line (colon)
    data_iface: Text
              ^
provisioning/miniprov/hare_mp/types.py:86:20: E701 multiple statements on one line (colon)
    data_iface_type: Maybe  # [Protocol]
                   ^
provisioning/miniprov/hare_mp/types.py:87:13: E701 multiple statements on one line (colon)
    io_disks: DList  # [str]
            ^
provisioning/miniprov/hare_mp/types.py:88:14: E701 multiple statements on one line (colon)
    meta_data: Text
             ^
provisioning/miniprov/hare_mp/types.py:89:17: E701 multiple statements on one line (colon)
    s3_instances: int
                ^
```
UT:
Tested miniprovisiner options such as --post_install, --test, --init etc

Closes: #1478