### PR TITLE
EOS-17098: Provide hctl start --node interface

### DIFF
--- a/hctl
+++ b/hctl
@@ -26,7 +26,7 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 # constants
 PROG=${0##*/}
 SRC_DIR="$(dirname $(readlink -f $0))"
-M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/motr}
+M0_SRC_DIR=${M0_SRC_DIR:-${SRC_DIR%/*}/cortx-motr}
 
 # Quick fix for EOS-10650
 CORTX_HA_BIN=/opt/seagate/cortx/ha/bin/

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -88,8 +88,8 @@ Stopped hare-consul-agent at ssc-vm-c-0553.colo.seagate.com
 Killing RC Leader at ssc-vm-c-0552.colo.seagate.com... **ERROR**
 ```
 
-## Cluster shutdown --node
-## Stops Hare, Motr and Consul processes on the local node only
+### Cluster shutdown --node
+#### Stops Hare, Motr and Consul processes on the local node only
 
 ```
 $ hctl shutdown --node
@@ -116,6 +116,18 @@ $ hctl start
 2020-09-18 07:00:12: Starting Motr (phase1, m0d)... OK
 2020-09-18 07:00:15: Starting Motr (phase2, m0d)... OK
 2020-09-18 07:00:18: Checking health of services... OK
+```
+
+### Cluster start --node
+#### Starts Hare, Motr and Consul processes on the current node only
+
+```
+$ hctl start --node
+2021-02-19 05:11:04: Starting Consul agent on this node.... OK
+2021-02-19 05:11:05: Starting Motr (phase1, m0d)... OK
+2021-02-19 05:11:09: Starting Motr (phase2, m0d)... OK
+2021-02-19 05:11:12: Checking health of services... OK
+OK
 ```
 
 ## Cluster status

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -112,7 +112,7 @@ EOF
     die "'motr-kernel' systemd service is not installed"
 fi
 
-. update-consul-conf --dry-run  # import CONFD_IDs, IOS_IDs, id2fid()
+. update-consul-conf --dry-run  # import CONFD_IDs, IOS_IDs, S3_IDs, id2fid()
 
 if [[ $do_mkfs ]] && [[ ! -e /etc/sysconfig/motr-kernel ]]; then
     # Auto-start of `motr-kernel` systemd unit will cause kernel panic

--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -17,7 +17,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-# help stop the cluster or local node
+# :help: stop the cluster or local node
 
 import getopt
 import logging

--- a/utils/hare-start
+++ b/utils/hare-start
@@ -21,7 +21,7 @@ set -eu -o pipefail
 # set -x
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
-# :help: start cluster
+# :help: start cluster or local node
 
 PROG=${0##*/}
 
@@ -30,7 +30,37 @@ die() {
     exit 1
 }
 
+usage() {
+    cat <<EOF
+Usage: $PROG [<option>]...
+
+Starts Hare and Motr services on local or all the nodes in the cluster.
+
+Options:
+  --node       Starts hare and motr services on current node only.
+  -h, --help   Shows this help and exit.
+EOF
+
+    exit 1;
+}
+
+TEMP=$(getopt --options h \
+              --longoptions help,node \
+              --name "$PROG" -- "$@" || true)
+
+eval set -- "$TEMP"
+
 conf_dir=/var/lib/hare
+node=false
+
+while true; do
+    case "$1" in
+        -h|--help)           usage ;;
+        --node)              node=true; shift ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
 
 if ! [[ -d $conf_dir ]]; then
     die 'Cluster is not configured on this node.'
@@ -40,4 +70,9 @@ if  hctl status > /dev/null 2>&1; then
     die 'Cluster is up and running.'
 fi
 
-hctl bootstrap -c $conf_dir
+if [[ $node ]]; then
+    hare-start-node
+else
+    hctl bootstrap -c $conf_dir
+fi
+

--- a/utils/hare-start-node
+++ b/utils/hare-start-node
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -eu -o pipefail
+# set -x
+export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
+
+PROG=${0##*/}
+
+. hare-utils # import utility functions
+
+die() {
+    echo "$PROG: $*" >&2
+    exit 1
+}
+
+say() {
+    echo -n "$(date '+%F %T'): $*"
+}
+
+is_server_node() {
+    get_server_nodes | grep -w $(node-name) > /dev/null
+}
+
+if sudo systemctl --quiet is-active hare-consul-agent; then
+    die 'hare-consul-agent is active ==> cluster is already running'
+fi
+
+say 'Starting Consul agent on this node...'
+sudo systemctl start hare-consul-agent
+
+# Wait for Consul's internal leader to be ready.
+# (Until then the KV store won't be accessible.)
+# Here we are checking if any of the peer nodes is already elected as the
+# leader. 
+while [[ ! $(get_leader) ]]; do
+    sleep 1
+    echo -n '.'
+done
+echo ' OK'
+
+if is_server_node; then
+    # Starting phase 1 (confd servers)
+    start_motr m0d phase1
+fi
+
+# Starting phase 2 (ios)
+start_motr m0d phase2
+
+. update-consul-conf --dry-run  # import S3_IDs
+if [[ -n $S3_IDs ]]; then
+    # Starting phase 3 (s3servers).
+    start_s3server
+fi
+
+say 'Checking health of services...'
+check_services
+
+echo ' OK'

--- a/utils/hare-utils
+++ b/utils/hare-utils
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+CONSUL_ADDR=127.0.0.1
+CONSUL_PORT=8500
+
+wait4() {
+    for pid in $*; do
+        wait $pid
+    done
+}
+
+get_server_nodes() {
+    curl -s http://$CONSUL_ADDR:$CONSUL_PORT/v1/catalog/nodes?service=confd |
+        jq -r .[].Node
+}
+
+get_leader() {
+    curl -sX GET http://$CONSUL_ADDR:$CONSUL_PORT/v1/kv/leader |
+        jq -r '.[].Value' | base64 -d
+}
+
+start_motr() {
+    local op=$1
+    local phase=$2
+
+    say "Starting Motr ($phase, $op)..."
+    [[ $op == 'mkfs' ]] && op='--mkfs-only' || op=
+    bootstrap-node $op --phase $phase &
+    pids=($!)
+    wait4 ${pids[@]}
+    echo ' OK'
+}
+
+start_s3server() {
+    say 'Starting S3 servers (phase3)...'
+    bootstrap-node --phase phase3 &
+    pids=($!)
+    wait4 ${pids[@]}
+    echo ' OK'
+}
+
+check_service() {
+    local svc=$1
+    curl -s http://127.0.0.1:8500/v1/health/service/$svc |
+        jq -r '.[] | "\(.Node.Node) \([.Checks[].Status]|unique)"' |
+        fgrep -v '["passing"]' || true
+}
+
+check_services() {
+    count=1
+
+    # Services to be checked
+    local svc_list=("confd" "ios" "s3service")
+    
+    for svc in "${svc_list[@]}"; do
+        svc_not_ready=$(check_service $svc)
+        while [[ $svc_not_ready ]]; do
+            if (( $count > 30 )); then
+                echo $svc_not_ready >&2
+                echo "Check '$svc' service on the node(s) listed above." >&2
+                exit 1
+            fi
+            (( count++ ))
+            sleep 1
+            svc_not_ready=$(check_service $svc)
+        done
+    done
+    echo ' OK'
+}


### PR DESCRIPTION
### Description:  
To provide hctl start --node interface which starts the services on a local node that is previously configured.

### Solution:
hare-start-node : This script starts all the services based on the already present configurations ( which were generated during bootstrap process).


### OUTPUT:

> $ hctl start --node
2021-02-19 03:06:55: Starting Consul agent on this node.... OK
2021-02-19 03:07:02: Starting Motr (phase1, m0d)... OK
2021-02-19 03:07:16: Starting Motr (phase2, m0d)... OK
2021-02-19 03:07:19: Checking health of services... OK
 OK

2. On 3 node cluster, node 1896 shutdown
> [root@ssc-vm-c-1899 ~]# hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x87 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xcf 'default': 'the pool' None None
Services:
    ssc-vm-c-1896.colo.seagate.com
    [unknown]  hax        0x7200000000000001:0x32  192.168.11.71@tcp:12345:1:1
    [unknown]  confd      0x7200000000000001:0x35  192.168.11.71@tcp:12345:2:1
    [unknown]  ioservice  0x7200000000000001:0x38  192.168.11.71@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x55  192.168.11.71@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x58  192.168.11.71@tcp:12345:4:2
    ssc-vm-c-1899.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   192.168.11.11@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   192.168.11.11@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   192.168.11.11@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  192.168.11.11@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  192.168.11.11@tcp:12345:4:2
    ssc-vm-c-1897.colo.seagate.com
    [started]  hax        0x7200000000000001:0x5e  192.168.8.190@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x61  192.168.8.190@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0x64  192.168.8.190@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x81  192.168.8.190@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x84  192.168.8.190@tcp:12345:4:2


> [root@ssc-vm-c-1896 hare]# hctl start --node
2021-02-19 05:11:04: Starting Consul agent on this node.... OK
2021-02-19 05:11:05: Starting Motr (phase1, m0d)... OK
2021-02-19 05:11:09: Starting Motr (phase2, m0d)... OK
2021-02-19 05:11:12: Checking health of services... OK
 OK


> [root@ssc-vm-c-1899 ~]# hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x87 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xcf 'default': 'the pool' None None
Services:
    ssc-vm-c-1896.colo.seagate.com
    [started]  hax        0x7200000000000001:0x32  192.168.11.71@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x35  192.168.11.71@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0x38  192.168.11.71@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x55  192.168.11.71@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x58  192.168.11.71@tcp:12345:4:2
    ssc-vm-c-1899.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   192.168.11.11@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   192.168.11.11@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   192.168.11.11@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  192.168.11.11@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  192.168.11.11@tcp:12345:4:2
    ssc-vm-c-1897.colo.seagate.com
    [started]  hax        0x7200000000000001:0x5e  192.168.8.190@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x61  192.168.8.190@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0x64  192.168.8.190@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x81  192.168.8.190@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x84  192.168.8.190@tcp:12345:4:2
