### PR TITLE
Problem: cfgen doesn't show which node has the problem with IP config

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -14,8 +14,8 @@ import re
 import socket
 import subprocess
 import sys
-from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional, \
-    Set, Tuple
+from typing import (Any, Callable, Dict, Iterable, Iterator, List, NamedTuple,
+                    Optional, Set, Tuple)
 import yaml
 
 
@@ -154,6 +154,15 @@ def die(msg: str, status: int = 1):
     sys.exit(status)
 
 
+def all_not_none(xs: Iterable) -> bool:
+    """Returns True iff the iterable contains no None elements.
+    """
+    for t in xs:
+        if t is None:
+            return False
+    return True
+
+
 def all_unique(xs) -> bool:
     """Returns True iff all entries of the sequence are unique.
     """
@@ -243,9 +252,17 @@ def validate_nodes_desc(nodes_desc: List[Dict[str, Any]]) -> None:
     nodes = [Node(name=x['hostname'],
                   ipaddr=x['facts'][ipaddr_key(x['data_iface'])])
              for x in nodes_desc]
+    assert all_not_none(
+        x.name
+        for x in nodes), f'Unexpected None hostname found in list: {nodes}\n' \
+                         f'Full context: {nodes_desc}'
     assert all_unique(x.name for x in nodes), \
         "Node names ('hostname' values in the CDF) are not unique:\n" + \
         '\n'.join('  ' + x.name for x in nodes)
+    assert all_not_none(
+        x.ipaddr
+        for x in nodes), f'Unexpected None ipaddr found in list: {nodes}\n' \
+                         f'Full context: {nodes_desc}'
     assert all_unique(x.ipaddr for x in nodes), \
         'IP addresses are not unique:\n' + \
         '\n'.join('  ' + x.ipaddr for x in nodes)


### PR DESCRIPTION
It seems like python is unable to build the proper message when assert
is triggered: an NPE happens while building the explanatory string.

Solution:
1. Add more asserts to catch the problem with missing (None) fields in
node_desc
2. Print more context so that the caller can understand the root cause.

Closes #1487
cc @andriytk 
