### PR TITLE
Added build dependencies to Motr installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ and health-checking mechanisms.
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git motr
     cd motr
-
+    
+    sudo ./scripts/install-build-deps
+    
     scripts/m0 make
     sudo scripts/install-motr-service --link
 


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

Problem: Motr build dependencies are not present in this Motr installation

Solution: Added command to build install dependencies

-----
[View rendered README.md](https://github.com/hessio/cortx-hare/blob/patch-3/README.md)