### PR TITLE
Problem: config command of mini-provisioning failing infrequently which is causing deployment failure

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -55,22 +55,21 @@ class CdfGenerator:
                         stderr=S.PIPE,
                         encoding='utf8')
 
+        dhall_out, err_d = dhall.communicate(input=gencdf)
+        if dhall.returncode:
+            raise RuntimeError(f'dhall binary failed: {err_d}')
+
         to_yaml = S.Popen([DHALL_TO_YAML_EXE],
-                          stdin=dhall.stdout,
+                          stdin=S.PIPE,
                           stdout=S.PIPE,
                           stderr=S.PIPE,
                           encoding='utf8')
 
-        _, err_d = dhall.communicate(input=gencdf)
-        to_yaml.wait()
-        out, err = to_yaml.communicate()
-        if dhall.returncode:
-            raise RuntimeError(f'dhall binary failed: {err_d}')
-
+        yaml_out, err = to_yaml.communicate(input=dhall_out)
         if to_yaml.returncode:
             raise RuntimeError(f'dhall-to-yaml binary failed: {err}')
 
-        return out
+        return yaml_out
 
     def _get_iface(self, nodename: str) -> str:
         ifaces = self.provider.get(


### PR DESCRIPTION
Solution: dhall-t-yaml will be called after previous process execution completes

UT:
-bash-4.2$ sudo /opt/seagate/cortx/hare/bin/hare_setup --config 'json:///home/754021/EOS-17172/hare/provisioner_cluster1.json' --filename '/var/lib/hare/cluster3rr.yaml'

-bash-4.2$ sudo /opt/seagate/cortx/hare/bin/hare_setup --init
Cluster is not running
2021-02-23 21:40:24: Generating cluster configuration... OK
2021-02-23 21:40:25: Starting Consul server on this node........ OK
2021-02-23 21:40:30: Importing configuration into the KV store... OK
2021-02-23 21:40:30: Starting Consul on other nodes... OK
2021-02-23 21:40:31: Updating Consul configuraton from the KV store... OK
2021-02-23 21:40:31: Waiting for the RC Leader to get elected....... OK
2021-02-23 21:40:36: Starting Motr (phase1, mkfs)... OK
2021-02-23 21:40:43: Starting Motr (phase1, m0d)... OK
2021-02-23 21:40:56: Starting Motr (phase2, mkfs)... OK
2021-02-23 21:41:02: Starting Motr (phase2, m0d)... OK
2021-02-23 21:41:17: Checking health of services... OK
Stopping m0d@0x7200000000000001:0xc (ios) at localhost...
Stopped m0d@0x7200000000000001:0xc (ios) at localhost
Stopping m0d@0x7200000000000001:0x9 (confd) at localhost...
Stopped m0d@0x7200000000000001:0x9 (confd) at localhost
Stopping hare-hax at localhost...
Stopped hare-hax at localhost
Stopping hare-consul-agent at localhost...
Stopped hare-consul-agent at localhost
Shutting down RC Leader at localhost...
**ERROR**
Cluster is not running
