### PR TITLE
Problem: mini provisioner doesn't work at stable

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -295,6 +295,12 @@ def main():
     parser = subparser.add_parser('post_install',
                                   help='Perform post installation checks')
     parser.set_defaults(func=post_install)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
     parser.add_argument(
         '--report-unavailable-features',
         help='Report unsupported features according to setup type',
@@ -322,6 +328,12 @@ def main():
     parser = subparser.add_parser('init',
                                   help='Perform component initialization')
     parser.set_defaults(func=init)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
     parser.add_argument('--file',
                         help='Full path to the CDF file.',
                         nargs=1,
@@ -331,6 +343,12 @@ def main():
 
     parser = subparser.add_parser('test', help='Testing cluster status')
     parser.set_defaults(func=test)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
     parser.add_argument('--file',
                         help='Full path to the CDF file.',
                         nargs=1,
@@ -341,11 +359,29 @@ def main():
     parser = subparser.add_parser('support_bundle',
                                   help='Generating support bundle')
     parser.set_defaults(func=generate_support_bundle)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
 
     parser = subparser.add_parser('reset', help='Reset/cleanup step')
     parser.set_defaults(func=cleanup)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
     parser = subparser.add_parser('cleanup', help='Reset/cleanup step')
     parser.set_defaults(func=cleanup)
+    parser.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=True,
+                        nargs=1,
+                        type=str,
+                        action='store')
 
     setup_logging()
 

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -1,22 +1,22 @@
 hare:
   post_install:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup post_install
-    args: --report-unavailable-features --configure-logrotate
+    args: --config $URL --report-unavailable-features --configure-logrotate
   init:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup init
-    args:
+    args: --config $URL
   config:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup config
     args: --config $URL --file '/var/lib/hare/cluster.yaml'
   test:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup test
-    args:
+    args: --config $URL
   support_bundle:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup support_bundle
-    args:
+    args: --config $URL
   reset:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup reset
-    args:
+    args: --config $URL
   cleanup:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup cleanup
-    args:
+    args: --config $URL


### PR DESCRIPTION
It turned out that setup.yaml file, --config option is mandatory for all commands otherwise provisioner code will fail.

Solution: Add --config option for all commands in hare setup.yaml
