### PR TITLE
EOS-18485:All services not online while unboxing after max attempts

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -88,7 +88,7 @@ def main():
     # _run_qconsumer_thread function.
     #
     # [KN] Note: The server is launched in the main thread.
-    q = Queue(maxsize=32767)
+    q = Queue(maxsize=8191)
 
     util: ConsulUtil = ConsulUtil()
     cfg = _get_motr_fids(util)

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -88,7 +88,7 @@ def main():
     # _run_qconsumer_thread function.
     #
     # [KN] Note: The server is launched in the main thread.
-    q = Queue(maxsize=8)
+    q = Queue(maxsize=32767)
 
     util: ConsulUtil = ConsulUtil()
     cfg = _get_motr_fids(util)

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -88,7 +88,7 @@ def main():
     # _run_qconsumer_thread function.
     #
     # [KN] Note: The server is launched in the main thread.
-    q = Queue(maxsize=8191)
+    q = Queue(maxsize=8192)
 
     util: ConsulUtil = ConsulUtil()
     cfg = _get_motr_fids(util)


### PR DESCRIPTION
Problem:
All the pcs resources are not online within time limit.
Hence Unboxing process not successful. Confd's entrypoint request
was not replied in time and it timed out.
Solution:
Current queue length in hax is 8, because of which if the requests
overflow the queue, they may get dropped or not serviced due to
which motr process may end up timing out. So increasing the queue
length from 8 to 8192.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>