### PR TITLE
Problem: make install is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ $(HAX_EGG_LINK) $(HAX_EXE): $(HAX_WHL)
 	@cd hax && $(HAX_INSTALL_CMD)
 
 .PHONY: install-miniprov
-install-miniprov: MP_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(MP_WHL)
+install-miniprov: MP_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(MP_WHL:provisioning/miniprov/%=%)
 install-miniprov: $(MP_EXE)
 
 $(MP_EGG_LINK) $(MP_EXE): $(MP_WHL)


### PR DESCRIPTION
JIRA: [EOS-18559](https://jts.seagate.com/browse/EOS-18559)

## Reason:
Fix https://github.com/Seagate/cortx-hare/pull/1524 has brought a
regression to make install which was not foreseen and tested in time.
The problem was brought by this change:

```diff
@@ -311,7 +312,7 @@ install-miniprov: $(MP_EXE)

 $(MP_EGG_LINK) $(MP_EXE): $(MP_WHL)
 	@$(call _info,Installing miniprov with '$(MP_INSTALL_CMD)')
-	@$(MP_INSTALL_CMD)
+	@cd provisioning/miniprov && $(MP_INSTALL_CMD)

 .PHONY: install-vendor
 install-vendor:
```

Target `install-miniprov` used by `install` doesn't expect that the
curernt directory is changed to provisioning/miniprov and thus the path
to hare_mp.whl file should be adjusted.

## Solution
- Fix relative path to hare_mp.whl file in `install-miniprov` target.
