### PR TITLE
EOS-18353: [Mini Provisioner] hare_setup fails to run with 'hare_mp' …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,11 +308,13 @@ $(HAX_EGG_LINK) $(HAX_EXE): $(HAX_WHL)
 
 .PHONY: install-miniprov
 install-miniprov: MP_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(MP_WHL)
+install-miniprov: MP_SETUP_PY_CMD = python ./setup.py install
 install-miniprov: $(MP_EXE)
+	@$(PY_VENV); cd /root/cortx-hare/provisioning/miniprov && $(MP_SETUP_PY_CMD)
 
 $(MP_EGG_LINK) $(MP_EXE): $(MP_WHL)
 	@$(call _info,Installing miniprov with '$(MP_INSTALL_CMD)')
-	@cd provisioning/miniprov && $(MP_INSTALL_CMD)
+	@$(MP_INSTALL_CMD)
 
 .PHONY: install-vendor
 install-vendor:


### PR DESCRIPTION
…ModuleNotFoundError

Description: Package imports issue after running make install command. hare_setup was not able to locate hare_mp package and its relative modules

Solution: Makefile alterations.

Signed-off-by: SUPRIT SHINDE <suprit.shinde@seagate.com>