### PR TITLE
EOS-18485: Not all the services are online during unboxing after max attempts

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -53,8 +53,9 @@ def _setup_logging():
     logging.getLogger('consul').setLevel(logging.WARN)
 
 
-def _run_qconsumer_thread(queue: Queue, motr: Motr) -> ConsumerThread:
-    thread = ConsumerThread(queue, motr)
+def _run_qconsumer_thread(queue: Queue, motr: Motr,
+                          herald: DeliveryHerald) -> ConsumerThread:
+    thread = ConsumerThread(queue, motr, herald)
     thread.start()
     return thread
 
@@ -106,7 +107,7 @@ def main():
     # Note that consumer thread must be started before we invoke motr.start(..)
     # Reason: hax process will send entrypoint request and somebody needs
     # to reply it.
-    consumer = _run_qconsumer_thread(q, motr)
+    consumer = _run_qconsumer_thread(q, motr, herald)
 
     try:
         motr.start(cfg.hax_ep,

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -40,6 +40,17 @@ class EntrypointRequest(BaseMessage):
 
 
 @dataclass
+class FirstEntrypointRequest(BaseMessage):
+    reply_context: Any
+    req_id: Uint128
+    remote_rpc_endpoint: str
+    process_fid: Fid
+    git_rev: str
+    pid: int
+    is_first_request: bool
+
+
+@dataclass
 class ProcessEvent(BaseMessage):
     evt: Any
 

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -78,6 +78,8 @@ class DeliveryHerald:
 
         Raises NotDelivered exception when timeout_sec exceeds.
         """
+        i = len(promise._ids)
+
         for msg in promise._ids:
             condition = Condition()
             with self.lock:
@@ -94,6 +96,10 @@ class DeliveryHerald:
                                        '  were delivered to Motr')
                 LOG.debug('Thread unblocked - %s just received',
                           self.recently_delivered[promise])
+                i -= 1
+                if i == 0:
+                    del self.waiting_clients[promise]
+                    del self.recently_delivered[promise]
 
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -82,6 +82,7 @@ class DeliveryHerald:
             condition = Condition()
             with self.lock:
                 self.waiting_clients[promise] = condition
+                LOG.debug('waiting clients %s', self.waiting_clients)
 
             with condition:
                 LOG.debug('Blocking until %s is confirmed', promise)
@@ -91,12 +92,8 @@ class DeliveryHerald:
                     raise NotDelivered('None of message tags =' +
                                        str(promise) +
                                        '  were delivered to Motr')
-                msgid = self.recently_delivered[promise]
-                if msgid in promise:
-                    promise._ids.remove(msgid)
                 LOG.debug('Thread unblocked - %s just received',
                           self.recently_delivered[promise])
-                del self.recently_delivered[promise]
 
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.
@@ -104,6 +101,8 @@ class DeliveryHerald:
             LOG.debug('notify waiting clients %s',
                       self.waiting_clients.items())
             for promise, client in self.waiting_clients.items():
+                LOG.debug('received msg id %s, waiting promise %s',
+                          message_id, promise)
                 if message_id in promise:
                     LOG.debug('Found a waiting client for %s: %s', message_id,
                               promise)

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -18,7 +18,7 @@
 
 import logging
 from threading import Condition, Lock
-from typing import Dict
+from typing import Dict, List
 
 from hax.exception import NotDelivered
 from hax.types import HaLinkMessagePromise, MessageId
@@ -39,9 +39,11 @@ class DeliveryHerald:
         delivery_herald.wait_for_any(HaLinkMessagePromise(tag_list))
         # if we are here then the delivery was confirmed
     """
-    recently_delivered: Dict[HaLinkMessagePromise, MessageId] = {}
-    waiting_clients: Dict[HaLinkMessagePromise, Condition] = {}
-    lock = Lock()
+    def __init__(self):
+        self.recently_delivered: Dict[HaLinkMessagePromise,
+                                      List[MessageId]] = {}
+        self.waiting_clients: Dict[HaLinkMessagePromise, Condition] = {}
+        self.lock = Lock()
 
     def wait_for_any(self,
                      promise: HaLinkMessagePromise,
@@ -78,14 +80,13 @@ class DeliveryHerald:
 
         Raises NotDelivered exception when timeout_sec exceeds.
         """
-        i = len(promise._ids)
 
-        for msg in promise._ids:
-            condition = Condition()
-            with self.lock:
-                self.waiting_clients[promise] = condition
-                LOG.debug('waiting clients %s', self.waiting_clients)
+        condition = Condition()
+        with self.lock:
+            self.waiting_clients[promise] = condition
+            LOG.debug('waiting clients %s', self.waiting_clients)
 
+        while not promise.is_empty():
             with condition:
                 LOG.debug('Blocking until %s is confirmed', promise)
                 condition.wait(timeout=timeout_sec)
@@ -94,12 +95,14 @@ class DeliveryHerald:
                     raise NotDelivered('None of message tags =' +
                                        str(promise) +
                                        '  were delivered to Motr')
+                confirmed_msgs = self.recently_delivered.pop(promise)
                 LOG.debug('Thread unblocked - %s just received',
-                          self.recently_delivered[promise])
-                i -= 1
-                if i == 0:
-                    del self.waiting_clients[promise]
-                    del self.recently_delivered[promise]
+                          confirmed_msgs)
+                del self.waiting_clients[promise]
+                promise.exclude_ids(confirmed_msgs)
+                LOG.debug('After exclusion: %s', promise)
+                if not promise.is_empty():
+                    self.waiting_clients[promise] = condition
 
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.
@@ -107,12 +110,14 @@ class DeliveryHerald:
             LOG.debug('notify waiting clients %s',
                       self.waiting_clients.items())
             for promise, client in self.waiting_clients.items():
-                LOG.debug('received msg id %s, waiting promise %s',
-                          message_id, promise)
+                LOG.debug('received msg id %s, waiting promise %s', message_id,
+                          promise)
                 if message_id in promise:
                     LOG.debug('Found a waiting client for %s: %s', message_id,
                               promise)
-                    self.recently_delivered[promise] = message_id
+                    old_list = self.recently_delivered.get(promise, [])
+                    old_list.append(message_id)
+                    self.recently_delivered[promise] = old_list
                     with client:
                         client.notify()
                     return

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -534,7 +534,6 @@ static void msg_is_delivered_cb(struct m0_halon_interface *hi,
 	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
 			    tag, hl);
-			    /* hl->hln_tag_broadcast_delivery, hl);*/
 	Py_DECREF(py_fid);
 	PyGILState_Release(gstate);
 }
@@ -554,7 +553,7 @@ static void msg_is_not_delivered_cb(struct m0_halon_interface *hi,
 	PyObject *py_fid = toFid(proc_fid);
 	PyObject_CallMethod(hc0->hc_handler, "_msg_not_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
-			    hl->hln_tag_broadcast_delivery, hl);
+			    tag, hl);
 	Py_DECREF(py_fid);
 	PyGILState_Release(gstate);
 }

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -533,7 +533,8 @@ static void msg_is_delivered_cb(struct m0_halon_interface *hi,
 	PyObject *py_fid = toFid(proc_fid);
 	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
-			    hl->hln_tag_broadcast_delivery, hl);
+			    tag, hl);
+			    /* hl->hln_tag_broadcast_delivery, hl);*/
 	Py_DECREF(py_fid);
 	PyGILState_Release(gstate);
 }
@@ -551,7 +552,7 @@ static void msg_is_not_delivered_cb(struct m0_halon_interface *hi,
 		hl->hln_tag_broadcast_delivery);
 
 	PyObject *py_fid = toFid(proc_fid);
-	PyObject_CallMethod(hc0->hc_handler, "_msg_delivered_cb", "(OsKK)",
+	PyObject_CallMethod(hc0->hc_handler, "_msg_not_delivered_cb", "(OsKK)",
 			    py_fid, hl->hln_conn_cfg.hlcc_rpc_endpoint,
 			    hl->hln_tag_broadcast_delivery, hl);
 	Py_DECREF(py_fid);

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -17,7 +17,7 @@
 #
 
 import ctypes as c
-from enum import Enum
+from enum import Enum, IntEnum
 from threading import Thread
 from typing import List, NamedTuple, Set
 
@@ -218,21 +218,22 @@ class ServiceHealth(Enum):
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])
 
 
-class m0HaProcessEvent(Enum):
+class m0HaProcessEvent(IntEnum):
     M0_CONF_HA_PROCESS_STARTING = 0
     M0_CONF_HA_PROCESS_STARTED = 1
     M0_CONF_HA_PROCESS_STOPPING = 2
     M0_CONF_HA_PROCESS_STOPPED = 3
 
-    def str_to_Enum(self, evt):
+    @staticmethod
+    def str_to_Enum(evt: str):
         events = {'M0_CONF_HA_PROCESS_STARTING':
-                  self.M0_CONF_HA_PROCESS_STARTING,
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTING,
                   'M0_CONF_HA_PROCESS_STARTED':
-                  self.M0_CONF_HA_PROCESS_STARTED,
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
                   'M0_CONF_HA_PROCESS_STOPPING':
-                  self.M0_CONF_HA_PROCESS_STOPPING,
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING,
                   'M0_CONF_HA_PROCESS_STOPPED':
-                  self.M0_CONF_HA_PROCESS_STOPPED}
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED}
         return events[evt]
 
     def __repr__(self):

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -198,6 +198,13 @@ class HaLinkMessagePromise:
     def __init__(self, message_ids: List[MessageId]):
         self._ids: Set[MessageId] = set(message_ids)
 
+    def exclude_ids(self, ids: List[MessageId]) -> None:
+        for message_id in ids:
+            self._ids.discard(message_id)
+
+    def is_empty(self) -> bool:
+        return not self._ids
+
     def __contains__(self, message_id: MessageId) -> bool:
         return message_id in self._ids
 

--- a/hax/test/test_delivery_herald.py
+++ b/hax/test/test_delivery_herald.py
@@ -24,11 +24,15 @@ from threading import Thread
 from time import sleep
 
 from hax.exception import NotDelivered
+from hax.motr import log_exception
 from hax.motr.delivery import DeliveryHerald
 from hax.types import HaLinkMessagePromise, MessageId
 
 
-class TestDeliveryHerald(unittest.TestCase):
+class TestDeliveryHeraldAny(unittest.TestCase):
+    """
+    Tests wait_for_any() functionality.
+    """
     @classmethod
     def setUpClass(cls):
         logging.basicConfig(
@@ -54,7 +58,7 @@ class TestDeliveryHerald(unittest.TestCase):
         m = MessageId
         herald.wait_for_any(HaLinkMessagePromise(
             [m(100, 1), m(100, 3), m(100, 4)]),
-                            timeout_sec=5)
+                            timeout_sec=10)
         t.join()
         self.assertTrue(notified_ok,
                         'Unexpected exception appeared in notifier thread')
@@ -75,11 +79,13 @@ class TestDeliveryHerald(unittest.TestCase):
         t.start()
 
         m = MessageId
-        with self.assertRaises(NotDelivered):
-            herald.wait_for_any(HaLinkMessagePromise(
-                [m(42, 1), m(42, 3), m(42, 4)]),
-                                timeout_sec=5)
-        t.join()
+        try:
+            with self.assertRaises(NotDelivered):
+                herald.wait_for_any(HaLinkMessagePromise(
+                    [m(42, 1), m(42, 3), m(42, 4)]),
+                                    timeout_sec=5)
+        finally:
+            t.join()
         self.assertTrue(notified_ok,
                         'Unexpected exception appeared in notifier thread')
 
@@ -95,13 +101,140 @@ class TestDeliveryHerald(unittest.TestCase):
                 logging.exception('*** ERROR ***')
                 notified_ok = False
 
-        threads = [Thread(target=fn, args=(MessageId(100, i), )) for i in range(1, 32)]
+        threads = [
+            Thread(target=fn, args=(MessageId(100, i), ))
+            for i in range(1, 32)
+        ]
         for t in threads:
             t.start()
 
-        m = lambda x: MessageId(halink_ctx=100, tag = x)
-        herald.wait_for_any(HaLinkMessagePromise([m(99), m(25), m(28), m(31)]), timeout_sec=5)
-        for t in threads:
+        def m(x):
+            return MessageId(halink_ctx=100, tag=x)
+
+        try:
+            herald.wait_for_any(HaLinkMessagePromise(
+                [m(99), m(25), m(28), m(31)]),
+                                timeout_sec=5)
+        finally:
+            for t in threads:
+                t.join()
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+
+class TestDeliveryHeraldAll(unittest.TestCase):
+    """
+    Tests wait_for_all() functionality.
+    """
+    @classmethod
+    def setUpClass(cls):
+        logging.basicConfig(
+            level=logging.DEBUG,
+            stream=sys.stdout,
+            format='%(asctime)s {%(threadName)s} [%(levelname)s] %(message)s')
+
+    def test_it_works(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn():
+            try:
+                sleep(1.5)
+                herald.notify_delivered(MessageId(halink_ctx=100, tag=1))
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        t = Thread(target=fn)
+        t.start()
+
+        m = MessageId
+        herald.wait_for_all(HaLinkMessagePromise([m(100, 1)]), timeout_sec=5)
+        t.join()
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+    def test_exception_raised_if_not_all_delivered(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn():
+            try:
+                sleep(1.5)
+                herald.notify_delivered(MessageId(halink_ctx=42, tag=3))
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        t = Thread(target=fn)
+        t.start()
+
+        m = MessageId
+        try:
+            with self.assertRaises(NotDelivered):
+                herald.wait_for_all(HaLinkMessagePromise([m(42, 1),
+                                                          m(42, 3)]),
+                                    timeout_sec=5)
+        finally:
             t.join()
+
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+    def test_works_if_all_messages_confirmed(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn():
+            try:
+                sleep(1.5)
+                herald.notify_delivered(MessageId(halink_ctx=42, tag=3))
+                herald.notify_delivered(MessageId(halink_ctx=42, tag=1))
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        t = Thread(target=fn)
+        t.start()
+
+        m = MessageId
+        try:
+            herald.wait_for_all(HaLinkMessagePromise([m(42, 1),
+                                                      m(42, 3)]),
+                                timeout_sec=5)
+        finally:
+            t.join()
+        self.assertTrue(notified_ok,
+                        'Unexpected exception appeared in notifier thread')
+
+    def test_works_under_load(self):
+        herald = DeliveryHerald()
+        notified_ok = True
+
+        def fn(msg: MessageId):
+            try:
+                sleep(1.5)
+                herald.notify_delivered(msg)
+            except:
+                logging.exception('*** ERROR ***')
+                notified_ok = False
+
+        threads = [
+            Thread(target=fn, args=(MessageId(100, i), ))
+            for i in range(1, 32)
+        ]
+        for t in threads:
+            t.start()
+
+        def m(x):
+            return MessageId(halink_ctx=100, tag=x)
+
+        try:
+            herald.wait_for_all(HaLinkMessagePromise(
+                [m(5), m(25), m(28), m(31)]),
+                                timeout_sec=5)
+        finally:
+            for t in threads:
+                t.join()
         self.assertTrue(notified_ok,
                         'Unexpected exception appeared in notifier thread')


### PR DESCRIPTION
As part of fix (a354d38) to EOS-14988, Hare implemented a protocol fix with respect to motr communication. The fix introduced a problem of blocking motr thread in hax, that lead to delay in processing of motr events posted internally by Hare.
The pulled in commits from main mainly fix 2 problems,
1. Unblock in coming motr thread in hax corresponding to the entrypoint request.
2. Fix the wrong tag used in the halink message delivered call back in hax motr land.

The patch with these commits reduces the overall starting time of motr processes thus resolving the issues that are seen during cluster start/stop, standby/unstandby and boxing/unboxing.

Hare team has tested this patch by running at least 7 iterations of boxing/unboxing.