### PR TITLE
EOS-18353: Hare Miniprovisioner package imports issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,7 @@ $(HAX_EGG_LINK) $(HAX_EXE): $(HAX_WHL)
 .PHONY: install-miniprov
 install-miniprov: MP_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(MP_WHL:provisioning/miniprov/%=%)
 install-miniprov: $(MP_EXE)
+	@cd provisioning/miniprov && $(SETUP_PY) install
 
 $(MP_EGG_LINK) $(MP_EXE): $(MP_WHL)
 	@$(call _info,Installing miniprov with '$(MP_INSTALL_CMD)')


### PR DESCRIPTION
Description: Package imports issue after running make install command. hare_setup was not able to locate hare_mp package and its relative modules

Solution: Makefile alterations. (Installing setup.py file from provisioning/miniprov in python virtual environment)

Signed-off-by: Suprit Shinde <suprit.shinde@seagate.com>