### PR TITLE
Problem: Hare mini provisioner sets default values for some keys in CDF

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -6,7 +6,8 @@ from typing import Dict, List, Optional
 import pkg_resources
 
 from hare_mp.store import ValueProvider
-from hare_mp.types import DList, Maybe, NodeDesc, Protocol, Text
+from hare_mp.types import (DList, Maybe, DiskRef, PoolDesc, ProfileDesc,
+                           NodeDesc, ClusterDesc, Protocol, Text)
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
 DHALL_EXE = '/opt/seagate/cortx/hare/bin/dhall'
@@ -29,6 +30,15 @@ class CdfGenerator:
             'hare_mp', resource_path)
         return raw_content.decode('utf-8')
 
+    def _get_cluster_id(self) -> str:
+        conf = self.provider
+
+        # We will read 'cluster_id' of 1st 'machine_id' present in server_node
+        server_node = conf.get('server_node')
+        machine_id = list(server_node.keys())[0]
+        cluster_id = server_node[machine_id]['cluster_id']
+        return cluster_id
+
     def _create_node_descriptions(self) -> List[NodeDesc]:
         nodes: List[NodeDesc] = []
         conf = self.provider
@@ -37,11 +47,70 @@ class CdfGenerator:
             nodes.append(self._create_node(node))
         return nodes
 
+    def _create_pool_descriptions(self) -> List[PoolDesc]:
+        pools: List[PoolDesc] = []
+        conf = self.provider
+        cluster_id = self._get_cluster_id()
+        storage_set_count = int(
+            conf.get(f'cluster>{cluster_id}>site>storage_set_count'))
+
+        for x in range(storage_set_count):
+            storage_set_name = conf.get(
+                f'cluster>{cluster_id}>storage_set{x+1}>name')
+
+            data_devices_count: int = 0
+            for node in conf.get(
+                    f'cluster>{cluster_id}>storage_set{x+1}>server_nodes'):
+                data_devices_count += len(
+                    conf.get(f'cluster>{node}>storage>data_devices'))
+
+            data_units_count = int(conf.get(
+                f'cluster>{cluster_id}>storage_set{x+1}>durability>data'))
+            parity_units_count = int(conf.get(
+                f'cluster>{cluster_id}>storage_set{x+1}>durability>parity'))
+            spare_units_count = int(conf.get(
+                f'cluster>{cluster_id}>storage_set{x+1}>durability>spare'))
+
+            if (data_devices_count != 0
+                and not data_devices_count >=
+                    data_units_count + parity_units_count + spare_units_count):
+                raise RuntimeError('Invalid storage set configuration')
+
+            pools.append(PoolDesc(
+                name=Text(storage_set_name),
+                disk_refs=Maybe(DList([
+                    DiskRef(path=Text(device), node=Maybe(Text(node), 'Text'))
+                    for node in conf.get(
+                        f'cluster>{cluster_id}>storage_set{x+1}>server_nodes')
+                    for device in conf.get(
+                        f'cluster>{node}>storage>data_devices')
+                ], 'List DiskRef'), 'List DiskRef'),
+                data_units=data_units_count,
+                parity_units=parity_units_count))
+
+        return pools
+
+    def _create_profile_descriptions(
+        self, pool_desc: List[PoolDesc]
+    ) -> List[ProfileDesc]:
+        profiles: List[ProfileDesc] = []
+
+        profiles.append(ProfileDesc(
+            name=Text('Profile_the_pool'),
+            pools=DList([pool.name
+                         for pool in pool_desc
+                         ], 'List Text')))
+
+        return profiles
+
     def _get_cdf_dhall(self) -> str:
         dhall_path = self._get_dhall_path()
         nodes = self._create_node_descriptions()
+        pools = self._create_pool_descriptions()
+        profiles = self._create_profile_descriptions(pools)
 
-        params_text = str(nodes)
+        params_text = str(ClusterDesc(
+            node_info=nodes, pool_info=pools, profile_info=profiles))
         gencdf = Template(self._gencdf()).substitute(path=dhall_path,
                                                      params=params_text)
         return gencdf
@@ -68,7 +137,6 @@ class CdfGenerator:
         yaml_out, err = to_yaml.communicate(input=dhall_out)
         if to_yaml.returncode:
             raise RuntimeError(f'dhall-to-yaml binary failed: {err}')
-
         return yaml_out
 
     def _get_iface(self, nodename: str) -> str:

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -2,6 +2,7 @@ let Prelude = $path/Prelude.dhall
 
 let T = $path/types.dhall
 let P = T.Protocol
+let DiskRef = T.DiskRef
 
 let NodeInfo =
       { hostname : Text
@@ -10,6 +11,24 @@ let NodeInfo =
       , io_disks : List Text
       , meta_data : Text
       , s3_instances : Natural
+      }
+
+let PoolInfo =
+      { name : Text
+      , disk_refs : Optional (List T.DiskRef)
+      , data_units : Natural
+      , parity_units : Natural
+      }
+
+let ProfileInfo =
+      { name : Text
+      , pools : List Text
+      }
+
+let ClusterInfo =
+      { node_info: List NodeInfo
+      , pool_info: List PoolInfo
+      , profile_info: List ProfileInfo
       }
 
 let toNodeDesc
@@ -30,12 +49,15 @@ let toNodeDesc
               ]
           }
 
-let genCdf
-    : List NodeInfo -> T.ClusterDesc
-    =     \(nodes : List NodeInfo)
-      ->  { nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc nodes
-          , pools =
-              [ { allowed_failures =
+let toPoolDesc
+    : PoolInfo -> T.PoolDesc
+    =     \(p : PoolInfo)
+      ->  { name = p.name
+          , type = Some T.PoolType.sns
+          , data_units = p.data_units
+          , disk_refs = p.disk_refs
+          , parity_units = p.parity_units
+          , allowed_failures =
                     None
                       { ctrl : Natural
                       , disk : Natural
@@ -43,14 +65,14 @@ let genCdf
                       , rack : Natural
                       , site : Natural
                       }
-                , data_units = 1
-                , disk_refs = None (List { node : Optional Text, path : Text })
-                , name = "the pool"
-                , parity_units = 0
-                , type = Some T.PoolType.sns
-                }
-              ]
-          , profiles = Some [ { name = "Profile_the_pool", pools = [ "the pool" ] } ]
+          }
+
+let genCdf
+    : ClusterInfo -> T.ClusterDesc
+    =     \(cluster_info : ClusterInfo)
+      ->  { nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
+          , pools = Prelude.List.map PoolInfo T.PoolDesc toPoolDesc cluster_info.pool_info
+          , profiles = Some cluster_info.profile_info
           }
 
 in  genCdf

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -12,7 +12,7 @@ class Maybe:
         if self.value is None:
             return f'None {self.comment}'
 
-        return f'Some {self.value}'
+        return f'Some ({self.value})'
 
 
 @dataclass
@@ -87,3 +87,30 @@ class NodeDesc(DhallTuple):
     io_disks: DList  # [str]
     meta_data: Text
     s3_instances: int
+
+
+@dataclass(repr=False)
+class DiskRef(DhallTuple):
+    path: Text
+    node: Maybe
+
+
+@dataclass(repr=False)
+class PoolDesc(DhallTuple):
+    name: Text
+    disk_refs: Maybe  # [DList]
+    data_units: int
+    parity_units: int
+
+
+@dataclass(repr=False)
+class ProfileDesc(DhallTuple):
+    name: Text
+    pools: DList  # [str]
+
+
+@dataclass(repr=False)
+class ClusterDesc(DhallTuple):
+    node_info: List[NodeDesc]
+    pool_info: List[PoolDesc]
+    profile_info: List[ProfileDesc]


### PR DESCRIPTION
Solution: Reading values for pools and profiles from ConfStore

UT: Tested config, init, test sections for singlenode, execution is completes successful.
Sample CDF:
pools:
- allowed_failures: null
  name: StorageSet-1
  data_units: 1
  parity_units: 0
  disk_refs:
  - path: /dev/sdc
    node: ssc-vm-c-1822.colo.seagate.com
  type: sns
profiles:
- pools:
  - StorageSet-1
  name: Profile_the_pool
nodes:
- m0_servers:
  - io_disks:
      data: []
      meta_data: /dev/vg_metadata_srvnode-1/lv_raw_metadata
    runs_confd: true
  - io_disks:
      data:
      - /dev/sdc
      meta_data: /dev/vg_metadata_srvnode-1/lv_raw_metadata
    runs_confd: null
  data_iface: eth1
  hostname: ssc-vm-c-1822.colo.seagate.com
  m0_clients:
    other: 3
    s3: 0
  data_iface_type: tcp

Snippet from sample confstore file:
"cluster": {
    "cluster_id": "92f444df-87cc-4137-b680-aab3b35d1695",

"92f444df-87cc-4137-b680-aab3b35d1695": {
      "site": {
        "storage_set_count": "1"
      },
      "storage_set1": {
        "name": "StorageSet-1",
        "server_nodes": ["srvnode-1"],
        "durability": {
          "data": "1",
          "parity": "0",
          "spare": "0"
        }
      }
    }
