### PR TITLE
EOS-18645: evaluate execution of mini provisioner setup command

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -71,9 +71,10 @@ class CdfGenerator:
             spare_units_count = int(conf.get(
                 f'cluster>{cluster_id}>storage_set{x+1}>durability>spare'))
 
-            if (data_devices_count != 0
-                and not data_devices_count >=
-                    data_units_count + parity_units_count + spare_units_count):
+            min_pool_width = data_units_count + parity_units_count \
+                + spare_units_count
+            if (data_devices_count != 0) and not (
+                    data_devices_count >= min_pool_width):
                 raise RuntimeError('Invalid storage set configuration')
 
             pools.append(PoolDesc(

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -28,10 +28,16 @@ class ValueProvider:
             raise RuntimeError(f'ConfStore key {key} not found')
         return ret
 
+    def _raw_get(self, key: str) -> str:
+        raise NotImplementedError()
+
     def get_machine_id(self) -> str:
         raise NotImplementedError()
 
-    def _raw_get(self, key: str) -> str:
+    def get_cluster_id(self) -> str:
+        raise NotImplementedError()
+
+    def get_storage_set_id(self) -> int:
         raise NotImplementedError()
 
 
@@ -42,10 +48,21 @@ class ConfStoreProvider(ValueProvider):
         conf.load('hare', url)
         self.conf = conf
 
+    def _raw_get(self, key: str) -> str:
+        return self.conf.get('hare', key)
+
     def get_machine_id(self) -> str:
-        with open('/etc/machine_id', 'r') as f:
+        with open('/etc/machine-id', 'r') as f:
             machine_id = f.readline().strip('\n')
             return machine_id
 
-    def _raw_get(self, key: str) -> str:
-        return self.conf.get('hare', key)
+    def get_cluster_id(self) -> str:
+        machine_id = self.get_machine_id()
+        cluster_id = self._raw_get(f'server_node>{machine_id}>cluster_id')
+        return cluster_id
+
+    def get_storage_set_id(self) -> int:
+        machine_id = self.get_machine_id()
+        storage_set_id = self._raw_get((f'server_node>{machine_id}>'
+                                        f'storage_set_id'))
+        return int(storage_set_id)

--- a/provisioning/miniprov/hare_mp/validator.py
+++ b/provisioning/miniprov/hare_mp/validator.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
+# report unsupported features, etc.
+
+import socket
+from hare_mp.store import ValueProvider
+
+
+class Validator:
+    def __init__(self, provider: ValueProvider):
+        super().__init__()
+        self.provider = provider
+
+    def _get_machine_id(self) -> str:
+        machine_id = self.provider.get_machine_id()
+        if not self.is_local_machine_id_valid(machine_id):
+            raise RuntimeError(f'invalid machine id {machine_id}')
+        return machine_id
+
+    def is_first_node_in_storage_set(self) -> bool:
+        machine_id = self._get_machine_id()
+        cluster_id = self.provider.get_cluster_id()
+        storage_set_id = self.provider.get_storage_set_id()
+        server_nodes_key: str = (f'cluster>{cluster_id}>'
+                                 f'storage_set[{storage_set_id}]>server_nodes')
+        server_nodes = self.provider.get(server_nodes_key)
+        return server_nodes[0] == machine_id
+
+    def is_first_node_in_cluster(self) -> bool:
+        machine_id = self._get_machine_id()
+        cluster_id = self.provider.get_cluster_id()
+        server_nodes_key: str = (f'cluster>{cluster_id}>'
+                                 f'storage_set[0]>server_nodes')
+        server_nodes = self.provider.get(server_nodes_key)
+        return server_nodes[0] == machine_id
+
+    def is_local_machine_id_valid(self, machine_id: str) -> bool:
+        hostname = self.provider.get(f'server_node>{machine_id}>hostname')
+        return hostname == socket.gethostname()

--- a/provisioning/miniprov/test/test_validator.py
+++ b/provisioning/miniprov/test/test_validator.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
+# report unsupported features, etc.
+
+# flake8: noqa
+import unittest
+import json
+import socket
+
+from hare_mp.store import ConfStoreProvider
+from hare_mp.validator import Validator
+
+
+URL = "json:///tmp/test-conf-store.json"
+
+conf_store_data = {
+  "provisioner": {
+    "cluster_info": {
+      "pillar_dir": "/opt/seagate/cortx/provisioner/pillar/groups/all/",
+      "num_of_nodes": 1
+    },
+    "cluster": {
+      "num_of_nodes": "1"
+    }
+  },
+  "storage": {
+  },
+  "system": {
+  },
+  "server_node": {
+    "srvmachine-1": {
+      "name": "srvnode-1",
+      "hostname": "ssc-vm-1623.colo.seagate.com",
+      "cluster_id": "e766bd52-c19c-45b6-9c91-663fd8203c2e",
+      "storage_set_id": 0
+    }
+  },
+  "cluster": {
+    "e766bd52-c19c-45b6-9c91-663fd8203c2e": {
+      "name": "cortx-cluster",
+      "storage_set": [
+          { "name": "StorageSet-1",
+           "server_nodes": [ "srvmachine-1" ]
+          }
+       ]
+    },
+    "storage_sets": {
+      "storage-set-1": [
+        "srvnode-1"
+      ]
+    },
+    "server_nodes": {
+      "7c4fd75dfedd7662e6a39b0a53274922": "srvnode-1"
+    },
+    "cluster_id": "e766bd52-c19c-45b6-9c91-663fd8203c2e",
+    "srvnode-1": {
+      "storage_set_id": 0,
+      "hostname": "ssc-vm-1623.colo.seagate.com",
+      "node_type": "VM",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "kafka_server"
+      ],
+      "is_primary": "true",
+      "bmc": {
+      },
+      "network": {
+        "mgmt": {
+          "interfaces": [
+            "eth0"
+          ],
+        },
+        "data": {
+          "public_interfaces": [
+            "eth0"
+          ],
+          "private_interfaces": [
+            "eth0"
+          ],
+          "interface_type": "tcp",
+          "transport_type": "lnet",
+          "private_ip": "",
+          "roaming_ip": "127.0.0.1"
+        }
+      },
+      "storage": {
+        "enclosure_id": "enclosure-1",
+        "metadata_devices": [
+          "/dev/sdb"
+        ],
+        "data_devices": [
+          "/dev/sdd",
+          "/dev/sde",
+          "/dev/sdf",
+          "/dev/sdg"
+        ]
+      },
+      "s3_instances": 1
+    }
+  }}
+
+
+def update_machine(machine_id: str, hostname: str):
+    with open ("/tmp/test-conf-store.json", "w+") as conf_store:
+        json.dump(conf_store_data, conf_store)
+
+    with open("/tmp/test-conf-store.json", "r+") as jf:
+        data = json.load(jf)
+        new_machine = {"server_node": {
+                                       f'{machine_id}': {
+                                         "name": "srvnode-1",
+                                         "hostname": f'{hostname}',
+                                         "cluster_id": "e766bd52-c19c-45b6-9c91-663fd8203c2e",
+                                         "storage_set_id": 0
+                                       }
+                                      }
+                      }
+        data.update(new_machine)
+        data['cluster']['e766bd52-c19c-45b6-9c91-663fd8203c2e']['storage_set'][0]['server_nodes'] = [f'{machine_id}']
+        with open("/tmp/temp-test-conf-store.json", "w+") as ujf:
+            json.dump(data, ujf)
+
+class TestValidator(unittest.TestCase):
+    def test_is_cluster_first_node(self):
+        conf = ConfStoreProvider(URL)
+        hostname = socket.gethostname()
+        machine_id = conf.get_machine_id()
+        update_machine(machine_id, hostname)
+        validator = Validator(
+                        ConfStoreProvider("json:///tmp/temp-test-conf-store.json"))
+        self.assertEqual(True, validator.is_first_node_in_cluster())
+
+    def test_invalid_machine_id(self):
+        conf = ConfStoreProvider(URL)
+        hostname = 'invalid-hostname'
+        machine_id = conf.get_machine_id()
+        update_machine(machine_id, hostname)
+        validator = Validator(
+                        ConfStoreProvider("json:///tmp/temp-test-conf-store.json"))
+        with self.assertRaises(RuntimeError):
+            validator._get_machine_id()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -146,12 +146,13 @@ def is_localhost(hostname: str) -> bool:
     name = gethostname()
     return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
 
+
 def get_local_nodename() -> str:
-    process = subprocess.run("node-name",
-                            check=True,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.run("node-name", check=True,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     node_name = process.stdout.strip()
     return node_name.decode('utf-8')
+
 
 def is_fake_leader_name(leader: str) -> bool:
     return re.match(r'^elect[0-9]+$', leader) is not None


### PR DESCRIPTION
Component mini-provisioning section, e.g. post-install, config, init, etc,
are expected to be executed on every node in the cluster. Thus it is
component's responsibility to evaluate if the command must do anything or
nothing on that node.
Hare needs to evaluate if the mini-provisioner init and test section
executions must be a no-op on a given node or not.

Solution:
- Check if the node is the first node of the first storage set in the
  cluster using information from the comf-store.
- Add a validator class to encapsulate common routines with respect to
  validations.
- Add routines to ConfStoreProvider for frequently fetched conf-store keys.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>