### PR TITLE
EOS-18751: hctl shutdown reports ERROR on VM

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -81,7 +81,8 @@ def shutdown_cluster():
     if leader_node and not utils.is_fake_leader_name(leader_node):
         logging.info(f'Shutting down RC Leader at {leader_node}... ')
         pkill: str = 'sudo pkill --exact -KILL consul &> /dev/null'
-        utils.exec_custom(utils.ssh_prefix(leader_node) + pkill)
+        utils.exec_custom(utils.ssh_prefix(leader_node) + pkill,
+                          show_err=False)
 
 
 def node_shutdown():

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -188,12 +188,17 @@ def exec_silent(cmd: str) -> bool:
     return subprocess.call(cmd, shell=True) == 0
 
 
-def exec_custom(cmd: str) -> None:
+def exec_custom(cmd: str, show_err: bool = True) -> None:
     assert cmd
-    if exec_silent(cmd):
-        logging.info('OK')
-    else:
-        logging.error('**ERROR**')
+
+    def handle(result: bool) -> None:
+        if not show_err:
+            return
+        if result:
+            logging.info('OK')
+        else:
+            logging.error('**ERROR**')
+    handle(exec_silent(cmd))
 
 
 def process_stop(proc: Process) -> None:


### PR DESCRIPTION
Description: The **ERROR** message was logged onto the console due to a wrong exit code check. Re-initiating the killing of consul returned wrong exit code as consul is already being killed. And to ensure that in the end, all the processes containing "consul" as a pattern must be killed, we still have the "sudo pkill --exact -KILL consul &> /dev/null" command present.

Signed-off-by: SUPRIT SHINDE <suprit.shinde@seagate.com>