### PR TITLE
EOS-18846: shutdown uses redundant ssh to local host

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -142,9 +142,18 @@ def processes_by_consul_svc_name(cns: Consul) -> Dict[str, List[Process]]:
             from e
 
 
+def get_node_name() -> str:
+    with open('/var/lib/hare/node-name') as f:
+        return f.readline().strip('\n')
+
+
 def is_localhost(hostname: str) -> bool:
-    name = gethostname()
-    return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
+    try:
+        return hostname == get_node_name()
+    except OSError:
+        # If the node-name file doesn't exist, then fallback to default logic
+        name = gethostname()
+        return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
 
 
 def get_local_nodename() -> str:


### PR DESCRIPTION
Solution: reuse the approach from hare-bootstrap script - compare the
hostname with /var/lib/hare/node-name. If the file doesn't exist, then
fallback to older logic.
