### PR TITLE
EOS-18846: shutdown uses redundant ssh to local host (cortx-1.0)

### DIFF
--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -95,9 +95,23 @@ def processes_by_consul_svc_name(cns: Consul) -> Dict[str, List[Process]]:
             from e
 
 
+def get_node_name() -> str:
+    with open('/var/lib/hare/node-name') as f:
+        return f.readline().strip('\n')
+
+
 def is_localhost(hostname: str) -> bool:
-    name = gethostname()
-    return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
+    def match_node_file() -> bool:
+        try:
+            return hostname == get_node_name()
+        except OSError:
+            return False
+
+    def match_localhost() -> bool:
+        name = gethostname()
+        return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
+
+    return match_node_file() or match_localhost()
 
 
 def is_fake_leader_name(leader: str) -> bool:


### PR DESCRIPTION
Solution: reuse the approach from hare-bootstrap script - compare the
hostname with /var/lib/hare/node-name. If the file doesn't exist, then
fallback to older logic.

This is a backport PR to cortx-1.0 branch.
Source PR: #1553 