### PR TITLE
Problem: hare shutdown still requires password while shuting down

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -148,12 +148,17 @@ def get_node_name() -> str:
 
 
 def is_localhost(hostname: str) -> bool:
-    try:
-        return hostname == get_node_name()
-    except OSError:
-        # If the node-name file doesn't exist, then fallback to default logic
+    def match_node_file() -> bool:
+        try:
+            return hostname == get_node_name()
+        except OSError:
+            return False
+
+    def match_localhost() -> bool:
         name = gethostname()
         return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
+
+    return match_node_file() or match_localhost()
 
 
 def get_local_nodename() -> str:


### PR DESCRIPTION
JIRA ticket: [EOS-18846](https://jts.seagate.com/browse/EOS-18846)

This PR cleans up the fix made in #1553 


The problem is that hare-shutdown script checks whether the cluster is running by using this code:

```python
def check_cluster():
    if not utils.consul_is_active_at('localhost'):
        if utils.pcs_consul_is_active_at('localhost'):
            exit("Cluster is run by Pacemaker, try `pcs cluster stop --all'")
        else:
            exit('Cluster is not running')
```

The intention is that Consul should be running at the current node. The
problem is that 'localhost' node will not be used in multinode
configurations (and even singlenode configuration may refer the current
node by some other name).

# Solution:
Check BOTH criteria:
1. whether the given name matches /var/lib/hare/node-name
2. whether the given name looks like localhost (e.g. 127.0.0.1 or
*.local).

If any of the checks return true, then the node is local.
