### PR TITLE
EOS-18434: mkfs panic: (!pver->pv_is_dirty) at m0_cs_dix_setup()

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -216,6 +216,7 @@ class ServiceHealth(Enum):
     FAILED = 0
     OK = 1
     UNKNOWN = 2
+    OFFLINE = 3
 
     def __repr__(self):
         """Return human-readable constant name (useful in log output)."""

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -625,6 +625,7 @@ class ConsulUtil:
             status = ServiceHealth.UNKNOWN
             for item in node_data:
                 if item['ServiceID'] == str(svc_id):
+                    LOG.debug('item.status %s', item['Status'])
                     if item['Status'] == 'passing':
                         status = ServiceHealth.OK
                     elif item['Status'] == 'warning':
@@ -648,6 +649,10 @@ class ConsulUtil:
                             # is failed, we will return OK or FAILED
                             # accordingly.
                             status = ServiceHealth.UNKNOWN
+                        elif (svc_consul_status in
+                                ('M0_CONF_HA_PROCESS_STOPPED',
+                                 'M0_CONF_HA_PROCESS_STOPPING')):
+                            status = ServiceHealth.OFFLINE
                         else:
                             status = ServiceHealth.FAILED
                     else:


### PR DESCRIPTION
The given crash occurs during dix setup of a motr io service when Hare
marks the data devices corresponding to an ioservice as failed. The crash
is mainly seen during mkfs. Hare starts a Consul watcher per io service,
which also monitors the motr-mkfs service (because both of them use the
same FIDs). Consul watcher keeps sending warning notifications for the
motr service until it is activating or when it is in inactive state.
In the former case (while ioservice is activating) Hare needs to handle
a race condition when Consul notifies a warning but Hare has already replied
to the entrpoint request, in such a scenario hare cannot notify the process
failure while it is actually starting as it leads to inconsistencies in halink
protocol. Along with this a case where motr-mkfs has stopped but m0d is starting
and Consul notifies a warning about the process to Hare, Hare needs to handle
the case such that the delay in Consul warning notification must not again lead
to inconsistencies where process is actually starting but it is notified as
failed along with its corresopnding devices to its peers.

Solution:
- Hare checks for following conditions and sends appropriate events,
  - Consul warning but Consul service status passing then,
    - Notify service health OK (ONLINE)
  - Consul warning, Consul service status as warning and process status in
    Consul KV is M0_CONF_HA_PROCESS_STARTING then,
    - Service health is UNKNOWN, do not send any notifications to anyone, recheck
       the service status.
  - Consul warning, Consul service status as failed then,
    - Notify service health FAILED, also notify corresponding devices as FAILED.
  - Consul warning, Consul service status as warning and process status in Consul
    KV is M0_CONF_HA_PROCESS_STARTED then,
    - Service health is UNKNOWN, do not send any notification yet, recheck Consul
      service status again.
  - Consul warning, Consul service status as warning and process status in Consul
    KV is M0_CONF_HA_PROCESS_STOPPING or M0_CONF_HA_PROCESS_STOPPED then,
    - Service health is OFFLINE, do not send any notification to peers. It is
      expected that FAILED notification for the process is already sent when process
      status was set to M0_CONF_HA_PROCESS_STOPPED.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>