### PR TITLE
EOS-19092 Problem : Makefile doesn't run linters against some of utils/hare-* scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ uninstall:
 # Linters --------------------------------------------- {{{1
 #
 
-PYTHON_SCRIPTS := utils/hare-shutdown utils/hare-status utils/gen-uuid utils/utils.py
+PYTHON_SCRIPTS := $(shell grep 'python3' -n utils/* 2>/dev/null | grep ':1:' | sed 's/^\([^:]*\):.*$$/\1/g')
 
 .PHONY: check
 check: check-cfgen check-hax flake8 mypy


### PR DESCRIPTION
Solution : The list of python scripts in utils/ is a kind of hard-coded in Makefile. So once somebody adds a script, the script will most probably be forgotten and not added to PYTHON_SCRIPTS in the makefile. This is error-prone.
So we try to make Makefile to fetch the filenames automatically or make that list of scripts be a kind of dynamic.

Signed-off-by: Supriya Chavan <supriya.s.chavan@seagate.com>