### PR TITLE
EOS-18936: Provisioning: invoke cfgen in config phase of hare mini provisioner

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -283,11 +283,22 @@ def save(filename: str, contents: str) -> None:
         f.write(contents)
 
 
+def generate_config(url: str, path_to_cdf: str) -> None:
+    conf_dir = '/var/lib/hare'
+    os.environ['PATH'] += os.pathsep + '/opt/seagate/cortx/hare/bin/'
+    cmd = ['cfgen', '-o', conf_dir, path_to_cdf]
+    execute(cmd)
+    conf = ConfStoreProvider(url)
+    hostname = conf.get_hostname()
+    save(f'{conf_dir}/node-name', hostname)
+
+
 def config(args):
     try:
         url = args.config[0]
         filename = args.file[0] or '/var/lib/hare/cluster.yaml'
         save(filename, generate_cdf(url))
+        generate_config(url, filename)
     except Exception as error:
         logging.error('Error performing configuration (%s)', error)
         exit(-1)

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -67,3 +67,8 @@ class ConfStoreProvider(ValueProvider):
         storage_set_id = self._raw_get((f'server_node>{machine_id}>'
                                         f'storage_set_id'))
         return int(storage_set_id)
+
+    def get_hostname(self) -> str:
+        machine_id = self.get_machine_id()
+        hostname = self._raw_get(f'server_node>{machine_id}>hostname')
+        return hostname


### PR DESCRIPTION
### Description:  
jira ticket- https://jts.seagate.com/browse/EOS-18936

In order to hctl fetch-fids be working on all the nodes of the cluster, consul-kv.json must be present on every node in the cluster. Presently cfgen is invoked in the init phase of the hare mini provisioner which generates consul-kv.json.

**Note:** File : `utils/hare-fetch-fids ` had some linter warnings regarding formatting. **No code changes done.**

### Solution:
1. Invoking cfgen in config phase of hare mini provisioner.
2. hctl fetch-fids works on every node of the cluster post config phase execution of hare mini provisioner.
```
$ hctl fetch-fids -n ssc-vm-c-1813.colo.seagate.com
[
  {
    "name": "confd",
    "fid": "0x7200000000000001:0x9"
  },
  {
    "name": "ioservice",
    "fid": "0x7200000000000001:0xc"
  }
]
```
(Issue observed while running `hctl fetch-fids`, after the config stage. For fetching the **default node-name** (name as specified in the CDF file), we need node-name file . This file gets generated in the init phase. User has to explicitly specify nodename of local node.)
Addressed the issue, and creating the file `node-name`.

### Testing:

1. Ran /opt/seagate/cortx/hare/bin/hare_setup **config** --config
2. checked the files (consul-kv.json, consul-agents.json, confd.dhall ) being generated at `/var/lib/hare`.
3. Ran /opt/seagate/cortx/hare/bin/hare_setup **init**--config 
4. Ran /opt/seagate/cortx/hare/bin/hare_setup **test**--config 
All successfully.


Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>