### PR TITLE
Problem: Hare mini provisioner build fails

### DIFF
--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -120,5 +120,6 @@ class ClusterDesc(DhallTuple):
 @dataclass(repr=False)
 class MissingKeyError(Exception):
     key: str
+
     def __str__(self):
         return f"Required key '{self.key}' not found"


### PR DESCRIPTION
hare_mp/types.py:123:5: E301 expected 1 blank line, found 0
make[2]: *** [flake8] Error 1
make[1]: *** [check-miniprov] Error 2
make: *** [build] Error 2

Solution:
Add a blank line to make flake8 happy.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>