### PR TITLE
Problem: init and test mini provisioning phases fail

### DIFF
--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -11,24 +11,24 @@
           "spare": "2",
           "name": "storage1",
           "server_nodes": [
-            "SERVER_NODE_0_MACHINE_ID",
-            "SERVER_NODE_1_MACHINE_ID",
-            "SERVER_NODE_2_MACHINE_ID",
+            "1114a50a6bf6f9c93ebd3c49d07d3fd4",
+            "9ec5de3a8b57493e8fc7bfae67ecd3b3",
+            "846fd26885f8423a8da0626538ed47bc"
           ]
         }
       ]
     }
   },
   "server_node": {
-    "SERVER_NODE_0_MACHINE_ID": {
+    "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1623.colo.seagate.com",
+      "name": "srvnode-1",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -38,25 +38,31 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]
       }
     },
-    "SERVER_NODE_1_MACHINE_ID": {
+    "9ec5de3a8b57493e8fc7bfae67ecd3b3": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1624.colo.seagate.com",
+      "name": "srvnode-2",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -66,25 +72,31 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]
       }
     },
-    "SERVER_NODE_2_MACHINE_ID": {
+    "846fd26885f8423a8da0626538ed47bc": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1625.colo.seagate.com",
+      "name": "srvnode-3",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -94,11 +106,17 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
@@ -1,1 +1,50 @@
-{}
+{
+  "cluster": {
+    "my-cluster": {
+      "site": {
+        "storage_set_count": "1"
+      },
+      "storage_set": [
+        {
+          "data": "1",
+          "parity": "0",
+          "spare": "0",
+          "name": "storage1",
+          "server_nodes": [
+            "SOME_MACHINE_ID"
+          ]
+        }
+      ]
+    }
+  },
+  "server_node": {
+    "SOME_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -1,1 +1,108 @@
-{}
+{
+  "cluster": {
+    "my-cluster": {
+      "site": {
+        "storage_set_count": "1"
+      },
+      "storage_set": [
+        {
+          "data": "4",
+          "parity": "2",
+          "spare": "2",
+          "name": "storage1",
+          "server_nodes": [
+            "SERVER_NODE_0_MACHINE_ID",
+            "SERVER_NODE_1_MACHINE_ID",
+            "SERVER_NODE_2_MACHINE_ID",
+          ]
+        }
+      ]
+    }
+  },
+  "server_node": {
+    "SERVER_NODE_0_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    },
+    "SERVER_NODE_1_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    },
+    "SERVER_NODE_2_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node.sample
@@ -11,24 +11,24 @@
           "spare": "2",
           "name": "storage1",
           "server_nodes": [
-            "SERVER_NODE_0_MACHINE_ID",
-            "SERVER_NODE_1_MACHINE_ID",
-            "SERVER_NODE_2_MACHINE_ID",
+            "1114a50a6bf6f9c93ebd3c49d07d3fd4",
+            "9ec5de3a8b57493e8fc7bfae67ecd3b3",
+            "846fd26885f8423a8da0626538ed47bc"
           ]
         }
       ]
     }
   },
   "server_node": {
-    "SERVER_NODE_0_MACHINE_ID": {
+    "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1623.colo.seagate.com",
+      "name": "srvnode-1",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -38,25 +38,31 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]
       }
     },
-    "SERVER_NODE_1_MACHINE_ID": {
+    "9ec5de3a8b57493e8fc7bfae67ecd3b3": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1624.colo.seagate.com",
+      "name": "srvnode-2",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -66,25 +72,31 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]
       }
     },
-    "SERVER_NODE_2_MACHINE_ID": {
+    "846fd26885f8423a8da0626538ed47bc": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1625.colo.seagate.com",
+      "name": "srvnode-3",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -94,11 +106,17 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
@@ -1,1 +1,50 @@
-{}
+{
+  "cluster": {
+    "my-cluster": {
+      "site": {
+        "storage_set_count": "1"
+      },
+      "storage_set": [
+        {
+          "data": "1",
+          "parity": "0",
+          "spare": "0",
+          "name": "storage1",
+          "server_nodes": [
+            "SOME_MACHINE_ID"
+          ]
+        }
+      ]
+    }
+  },
+  "server_node": {
+    "SOME_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -1,1 +1,108 @@
-{}
+{
+  "cluster": {
+    "my-cluster": {
+      "site": {
+        "storage_set_count": "1"
+      },
+      "storage_set": [
+        {
+          "data": "4",
+          "parity": "2",
+          "spare": "2",
+          "name": "storage1",
+          "server_nodes": [
+            "SERVER_NODE_0_MACHINE_ID",
+            "SERVER_NODE_1_MACHINE_ID",
+            "SERVER_NODE_2_MACHINE_ID",
+          ]
+        }
+      ]
+    }
+  },
+  "server_node": {
+    "SERVER_NODE_0_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    },
+    "SERVER_NODE_1_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    },
+    "SERVER_NODE_2_MACHINE_ID": {
+      "cluster_id": "my-cluster",
+      "hostname": "myhost",
+      "name": "mynodename",
+      "network": {
+        "data": {
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth1",
+            "eno2"
+          ]
+        }
+      },
+      "s3_instances": "1",
+      "storage": {
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sda",
+              "/dev/sdb"
+            ],
+            "metadata_devices": [
+              "/dev/meta"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
@@ -11,24 +11,24 @@
           "spare": "2",
           "name": "storage1",
           "server_nodes": [
-            "SERVER_NODE_0_MACHINE_ID",
-            "SERVER_NODE_1_MACHINE_ID",
-            "SERVER_NODE_2_MACHINE_ID",
+            "1114a50a6bf6f9c93ebd3c49d07d3fd4",
+            "9ec5de3a8b57493e8fc7bfae67ecd3b3",
+            "846fd26885f8423a8da0626538ed47bc"
           ]
         }
       ]
     }
   },
   "server_node": {
-    "SERVER_NODE_0_MACHINE_ID": {
+    "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1623.colo.seagate.com",
+      "name": "srvnode-1",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -38,25 +38,31 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]
       }
     },
-    "SERVER_NODE_1_MACHINE_ID": {
+    "9ec5de3a8b57493e8fc7bfae67ecd3b3": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1624.colo.seagate.com",
+      "name": "srvnode-2",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -66,25 +72,31 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]
       }
     },
-    "SERVER_NODE_2_MACHINE_ID": {
+    "846fd26885f8423a8da0626538ed47bc": {
       "cluster_id": "my-cluster",
-      "hostname": "myhost",
-      "name": "mynodename",
+      "hostname": "ssc-vm-1625.colo.seagate.com",
+      "name": "srvnode-3",
       "network": {
         "data": {
           "interface_type": "tcp",
           "private_interfaces": [
-            "eth1",
+            "eth0",
             "eno2"
           ]
         }
@@ -94,11 +106,17 @@
         "cvg": [
           {
             "data_devices": [
-              "/dev/sda",
-              "/dev/sdb"
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde",
+              "/dev/sdf",
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
             ],
             "metadata_devices": [
-              "/dev/meta"
+              "/dev/sdj"
             ]
           }
         ]


### PR DESCRIPTION
Because of newly added validation checks in init and test sections of Hare mini
provisioner, some conf-store keys are required in init and test sections too.
Present templates for init and test sections do not contain any keys with respect
to this.

Solution:
- Update init and test section conf-store templates.
- Add more nodes information in 3 node config section template.
- Add populated sample conf-store files for config, init and test sections.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>