### PR TITLE
EOS-19409: motr-mkfs fails with Motr panic: !rep->hae_disconnected_previously

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -70,8 +70,10 @@ class ConsumerThread(StoppableThread):
         # intermittent error gets resolved.
         self.consul.update_process_status(event)
         svc_status = m0HaProcessEvent.event_to_svchealth(event.chp_event)
-        motr.broadcast_ha_states([HAState(fid=event.fid,
-                                          status=svc_status)])
+        if event.chp_event in (m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
+                               m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED):
+            motr.broadcast_ha_states([HAState(fid=event.fid,
+                                              status=svc_status)])
 
     @repeat_if_fails(wait_seconds=1)
     def update_process_failure(self, q: Queue,


### PR DESCRIPTION
This was fixed by https://github.com/Seagate/cortx-hare/pull/1400, but a recent patch for https://jts.seagate.com/browse/EOS-18434 seems to have re-introduced the issue. Presently when a Motr process notifies M0_CONF_HA_PROCESS_STARTING or M0_CONF_HA_PROCESS_STARTED, hax broadcasts M0_NC_ONLINE and when Motr process notifiy M0_CONF_HA_PROCESS_STOPPING and M0_CONF_HA_PROCESS_STOPPED, hax broadcasts M0_NC_FAILED for that process as part of halink protocol. The correponding status is also updated in the Consul.
But when say motr process is stopping and hax broadcasts M0_NC_FAILED to motr processes and to itself, the halink is disconnected and rconfc from motr process may request entrypoint again. This may lead to such a panic which means that hax as already decided that the motr process has FAILED and thus motr process cannot do anything to fix this.

Solution:
Broadcast M0_NC_ONLINE or M0_NC_FAILED only for M0_CONF_HA_PROCESS_STARTED and
M0_CONF_HA_PROCESS_STOPPED respectively.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>