### PR TITLE
Problem: NvecGet may get no reply in case of Consul issue

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -457,6 +457,7 @@ class ConsulUtil:
                 return True
         return False
 
+    @repeat_if_fails()
     def get_conf_obj_status(self, obj_t: ObjT, fidk: int) -> str:
         # 'node/<node_name>/process/<process_fidk>/service/type'
         node_items = self.kv.kv_get('m0conf/nodes', recurse=True)


### PR DESCRIPTION
consul_util.get_conf_obj_status() requires `@repeat_if_fail` decorator.
Otherwise, in case of some intermittent Consul issue, no reply will be
sent.

```
hax/hax/motr/__init__.py
279-    @log_exception
280-    def ha_nvec_get_reply(self, event: HaNvecGetEvent) -> None:
281-        LOG.debug('Preparing the reply for HaNvecGetEvent (nvec size = %s)',
282-                  len(event.nvec))
283-        notes: List[HaNoteStruct] = []
284-        for n in event.nvec:
285-            n.note.no_state = HaNoteStruct.M0_NC_ONLINE
286-            if (n.obj_t in (ObjT.PROCESS.name, ObjT.SERVICE.name)
287:                    and self.consul_util.get_conf_obj_status(
288-                        ObjT[n.obj_t], n.note.no_id.f_key) != 'passing'):
289-                n.note.no_state = HaNoteStruct.M0_NC_FAILED
290-            notes.append(n.note)
291-

```

Solution: use `@repeat_if_fail` decorator.

