### PR TITLE
EOS-19399: Create design RFC for AUX multipools layout generation

### DIFF
--- a/rfc/README.md
+++ b/rfc/README.md
@@ -23,6 +23,8 @@ processes.
   * [17/CICD](17/README.md) — Continuous Integration and Continuous Deployment
   * [19/EVERULES](19/README.md) — Events and Rules
   * [21/EVERULES](21/README.md) — HA Event Subscription
+  * [22/PARHAX](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/178421786/22+PARHAX+Parallel+message+processing+in+HaX) - Parallel message processing in HaX
+  * [23/MPAUX](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/184746420/23+MPAUX+Multipool+Auxiliary+Layout+Parameters+Generation) - Multipool Auxiliary Layout Parameters Generation
 * Draft
   * [4/KV](4/README.md) — Consul KV Schema
   * [5/HAX](5/README.md) — HAlink eXchange


### PR DESCRIPTION
Need to create design document RFC, for generation of layout parameters
for auxiliary (AUX) pools, during multipools cluster bootstrap.
This PR is used to update the RFC indexes only.
Detailed document is published at confluence at link :
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/184746420/23+MPAUX+Multipool+Auxiliary+Layout+Parameters+Generation
It addresses the comments from PR:
https://github.com/Seagate/cortx-hare/pull/1585/

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>

-----
[View rendered rfc/README.md](https://github.com/suvratjoshi/cortx-hare/blob/new_e19399/rfc/README.md)