### PR TITLE
Problem: Hare CI: cortx-motr installation fails

### DIFF
--- a/jenkins/prepare-yum-repos
+++ b/jenkins/prepare-yum-repos
@@ -33,6 +33,14 @@ name=motr-dev
 enabled=1
 EOF
 
+cat <<EOF > /etc/yum.repos.d/motr_uploads.repo
+[motr-uploads]
+baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.8.2003-2.0.0-latest/motr_uploads/
+gpgcheck=0
+name=motr-uploads
+enabled=1
+EOF
+
 cat <<EOF > /etc/yum.repos.d/lustre_release.repo
 [lustre]
 baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.8.2003-2.0.0-latest/lustre/custom/tcp/


### PR DESCRIPTION
Solution: Add motr_upload repo for dependency package installation

Hare CI is failing to install cortx-motr package as now this requires installation of dependency package named isa-l.
This package is available in motr_upload of third-party-deps repo. 
Adding motr_upload repo path in yum for motr package dependency installation.

Signed-off-by: Parikshit Dharmale <parikshit.dharmale@seagate.com>