### PR TITLE
Problem: private data interface template variable names mismatch

### DIFF
--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
@@ -32,8 +32,8 @@
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
           "private_interfaces": [
-            "TMPL_DATA_PRIVATE_INTERFACE_1",
-            "TMPL_DATA_PRIVATE_INTERFACE_2"
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
@@ -86,7 +86,7 @@
       "name": "TMPL_SERVER_NODE_NAME",
       "network": {
         "data": {
-          "interface_type": "TEMPL_DATA_INTERFACE_TYPE",
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -32,8 +32,8 @@
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
           "private_interfaces": [
-            "TMPL_DATA_PRIVATE_INTERFACE_1",
-            "TMPL_DATA_PRIVATE_INTERFACE_2"
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
@@ -86,7 +86,7 @@
       "name": "TMPL_SERVER_NODE_NAME",
       "network": {
         "data": {
-          "interface_type": "TEMPL_DATA_INTERFACE_TYPE",
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -32,8 +32,8 @@
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
           "private_interfaces": [
-            "TMPL_DATA_PRIVATE_INTERFACE_1",
-            "TMPL_DATA_PRIVATE_INTERFACE_2"
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
@@ -86,7 +86,7 @@
       "name": "TMPL_SERVER_NODE_NAME",
       "network": {
         "data": {
-          "interface_type": "TEMPL_DATA_INTERFACE_TYPE",
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"


### PR DESCRIPTION
Private data interface names for node 1 in the 3-node conf store template files
are not the same as for other nodes.

Solution:
Match the private data interface variable name for node 1 with other nodes.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>