### PR TITLE
EOS: 18914

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -242,6 +242,10 @@ EOF
     while read node _; do
         if is_localhost $node; then
             echo $node > $conf_dir/node-name
+            if [ $? -ne 0 ]
+                then
+                    echo "Permission Denied at" $node "for /var/lib/hare/node-name"
+            fi
         else
             # Redirect stdin to /dev/null (`-n`) to prevent
             # accidental stealing of `get_all_nodes` output.


### PR DESCRIPTION
Issue: In a Cluster, Hare doesn't show for which node access is being denied while writing the node-name to the conf-dir.
Solution: Printng  out name of node where permission is denied for /var/lib/hare/node-name.

Signed-off-by: SUPRIT SHINDE <suprit.shinde@seagate.com>