### PR TITLE
Problem: cortx-py-utils dependency is not declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,15 @@ and health-checking mechanisms.
   sudo yum -y install consul-1.9.1
   ```
 
+* Install py-utils.
+  ```sh
+  sudo yum -y install cortx-py-utils
+  ```
+
 * Build and Install Motr.
 
   *  Follow [Motr quick start guide](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) to build Motr from source. After compiling Motr sources, please continue with the below steps to build Hare using Motr sources.
-    
+
      ```sh
      sudo scripts/install-motr-service --link
  
@@ -70,7 +75,7 @@ and health-checking mechanisms.
      cd -
      ```
 
-* Build and install `hare`.
+* Build and install Hare.
   ```sh
   make
   sudo make install
@@ -270,6 +275,24 @@ hctl shutdown
 sudo systemctl reset-failed hare-hax
 ```
 and bootstrap again.
+
+### `make install` fails because of mypy issues
+
+Symptoms:
+1. `make` or `make install` or `make devinstall` command fails
+2. The command output contains the output like this (perhaps this is not the latest lines in the output):
+    ```
+    19:58:19  running mypy
+    19:58:20  hare_mp/store.py:21: error: Cannot find implementation or library stub for module named 'cortx.utils.conf_store'
+    19:58:20  Success: no issues found in 1 source file
+    19:58:20  make[4]: Leaving directory `/root/rpmbuild/BUILD/cortx-hare/cfgen'
+    19:58:21  hare_mp/main.py:34: error: Cannot find implementation or library stub for module named 'cortx.utils.product_features'
+    19:58:21  hare_mp/main.py:34: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
+    19:58:21  Found 2 errors in 2 files (checked 8 source files)
+    19:58:21  make[4]: *** [mypy] Error 1
+    ```
+
+Solution: install cortx-py-utils RPM and retry.
 
 <!------------------------------------------------------------------->
 ## See also

--- a/hare.spec
+++ b/hare.spec
@@ -37,9 +37,10 @@ Group: System Environment/Daemons
 Source: %{name}-%{h_version}.tar.gz
 
 BuildRequires: binutils-devel
-BuildRequires: git
 BuildRequires: cortx-motr
 BuildRequires: cortx-motr-devel
+BuildRequires: cortx-py-utils
+BuildRequires: git
 BuildRequires: python36
 BuildRequires: python36-devel
 BuildRequires: python36-pip
@@ -49,6 +50,7 @@ Requires: consul >= 1.7.0, consul < 1.10.0
 Requires: facter >= 3.14.8
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}
+Requires: cortx-py-utils
 Requires: python36
 
 Conflicts: halon


### PR DESCRIPTION
There are two issues:
1. The Hare README file doesn't specify that cortx-py-utils is required
to build Hare nowadays.
2. hare.spec doesn't declare dependency on cortx-py-utils RPM.

## Solution:
1. Improve README
2. Add cortx-py-utils to both Requires and BuildRequires sections.


-----
[View rendered README.md](https://github.com/knekrasov/cortx-hare/blob/declare-py-utils-deps/README.md)