### PR TITLE
EOS 18914: The node for which conf_dir access is denied is unknown

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -241,11 +241,17 @@ EOF
 
     while read node _; do
         if is_localhost $node; then
-            echo $node > $conf_dir/node-name
+            echo $node > $conf_dir/node-name || {
+                echo "Permission Denied at $node for $conf_dir/node-name"
+                exit 1
+            }
         else
             # Redirect stdin to /dev/null (`-n`) to prevent
             # accidental stealing of `get_all_nodes` output.
-	    ssh -n $node "echo $node > $conf_dir/node-name"
+	    ssh -n $node "echo $node > $conf_dir/node-name" || {
+                echo "Permission Denied at $node for $conf_dir/node-name"
+                exit 1
+            } 
         fi
     done < <(get_all_nodes)
 


### PR DESCRIPTION
Solution: Displaying the node-name of those nodes for which /var/lib/hare/node-name is not accessible

Signed-off-by: SUPRIT SHINDE <suprit.shinde@seagate.com>