### PR TITLE
EOS-19637: node-start never works cluster-wise

### DIFF
--- a/utils/hare-start
+++ b/utils/hare-start
@@ -70,7 +70,7 @@ if  hctl status > /dev/null 2>&1; then
     die 'Cluster is up and running.'
 fi
 
-if [[ $node ]]; then
+if $node; then
     start-node
 else
     hctl bootstrap -c $conf_dir


### PR DESCRIPTION
JIRA issue: [EOS-19637](https://jts.seagate.com/browse/EOS-19637)

Due to a mistake in bash script the script always thinks that it is
invoked with `--node` flag.

The problem is that in bash there is no boolean types so node=true and
node=false are understood in the same way (as a string with non-zero
length) - that turns out to be semantics of [[ ]] in bash.

Solution:
1. Don't evaulate true/false within double brackets.
