### PR TITLE
EOS-19522: bundle-id and dest-dir arguments are missing from hare_setup

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -184,9 +184,12 @@ def test(args):
 def generate_support_bundle(args):
     try:
         # Default target directory is /tmp/hare
-        if os.system('hctl reportbug') != 0:
-            logging.error('Failed to generate support bundle')
-            exit(-1)
+        cmd = ['hctl', 'reportbug']
+        if args.bundleid:
+            cmd.append(args.bundleid)
+        if args.destdir:
+            cmd.append(args.destdir)
+        execute(cmd)
     except Exception as error:
         logging.error('Error while generating support bundle (%s)', error)
         exit(-1)
@@ -369,11 +372,21 @@ def main():
                        help_str='Tests Hare sanity',
                        handler_fn=test))
 
-    add_subcommand(subparser,
-                   'support_bundle',
-                   help_str='Generates support bundle',
-                   handler_fn=generate_support_bundle,
-                   config_required=False)
+    sb_sub_parser = add_subcommand(subparser,
+                                   'support_bundle',
+                                   help_str='Generates support bundle',
+                                   handler_fn=generate_support_bundle,
+                                   config_required=False)
+
+    sb_sub_parser.add_argument(
+        'bundleid', metavar='bundle-id', type=str,
+        nargs='?',
+        help='Support bundle ID; defaults to the local host name.')
+
+    sb_sub_parser.add_argument(
+        'destdir', metavar='dest-dir', type=str,
+        nargs='?',
+        help='Target directory; defaults to /tmp/hare.')
 
     add_subcommand(subparser,
                    'reset',

--- a/rfc/20/README.md
+++ b/rfc/20/README.md
@@ -98,7 +98,7 @@ Hare component must implement Mini-Provisioner API (see the [specification docum
 | [upgrade](#upgrade)  | Perform the upgrade of the component (3rd-party components included). | TBD | TBD |
 | [backup](#backup)  | Save and export component's state so that it is state can be reproduced at another machine (TBD is it feasible?) | TBD | TBD |
 | [restore](#restore)  | An action opposite to `backup`. Must ingest the exported backup and apply it. | TBD | TBD |
-| [support_bundle](#support_bundle)  | Prepare component-specific support bundle (TBD how will Provisioner Framework find all the files generated this way?) | TBD | TBD |
+| [support_bundle](#support_bundle)  | Generates support bundle using `hare_setup support_bundle` command | Destination directory must be writable | None (bundle generation may pass or fail) |
 
 
 ## Communication with ConfStore
@@ -165,4 +165,13 @@ Exit codes: 0 if no issues found (so Hare cluster running), 1 otherwise.
 Run functional tests against a running singlenode cluster (TBD).
 Runs 'hctl status --json' and compares output with info extracted from CDF used during bootstrap to check if all the services are running correctly.
 
+### support bundle
 
+```
+[root@ssc-vm-1623:root] /opt/seagate/cortx/hare/bin/hare_setup support_bundle
+[root@ssc-vm-1623:root] ls /tmp/hare
+hare_ssc-vm-1623.tar.gz
+[root@ssc-vm-1623:root] /opt/seagate/cortx/hare/bin/hare_setup support_bundle SB12345 /root
+[root@ssc-vm-1623:root] ls hare
+hare_SB12345.tar.gz
+```


### PR DESCRIPTION
Positional arguments to accept bundle-id and destination directory path are
available for `hctl reportbug` command but are missing from `hare_setup`
command.

Solution:
Add positional arguments to accept `bundle-id` and destination dir to hare-setup
interface and pass them to `hctl reportbug` command.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>