### PR TITLE
Problem: README.md references RPM private Seagate repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and health-checking mechanisms.
 
 ### Building from source
 
-* Download Hare.
+* Download hare.
   ```sh
   git clone https://github.com/Seagate/cortx-hare.git hare
   cd hare
@@ -61,7 +61,7 @@ and health-checking mechanisms.
 
 * Build and Install Motr.
 
-  *  from sources use [this](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) link to build Motr from source. Once you built Motr continue with the steps listed below.
+  *  Follow [Motr quick start guide](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) to build Motr from source. After compiling Motr sources, please continue with the below steps to build Hare using Motr sources.
     
     ```sh
     sudo scripts/install-motr-service --link
@@ -70,24 +70,24 @@ and health-checking mechanisms.
     cd -
     ```
 
-* Build and install Hare.
+* Build and install hare.
   ```sh
   make
   sudo make install
   ```
 
-* Add current user to `hare` group.
+* Add current user to hare group.
   ```sh
   sudo usermod --append --groups hare $USER
   ```
   Log out and log back in.
 
 
-### Build and install `hare` rpm from source.
-**NOTE: If you have built Motr and HARE from source you will not need to generate RPM packages below**
-* Build `Motr` RPMs.
+### Build and install rpms from source.
+**NOTE: If you have built Motr and HARE from sources you need not generate RPM packages as below, however, it might be more convenient to build and install rpms on a multinode setup sometimes**
+* Build Motr RPMs.
 
-  * from sources
+  * From sources
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git
     cd cortx-motr
@@ -96,15 +96,15 @@ and health-checking mechanisms.
     sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
     ```
 
-* Build `hare` rpm.
+* Build hare RPMs.
 
-  Download hare source as mentioned above.
-  ```sh
-  cd hare
+  * Download hare source as mentioned above.
+    ```sh
+    cd hare
 
-  make rpm
-  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-hare-*.rpm
-  ```
+    make rpm
+    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-hare-*.rpm
+    ```
 
 
 <!------------------------------------------------------------------->

--- a/README.md
+++ b/README.md
@@ -71,14 +71,12 @@ and health-checking mechanisms.
      ```
 
 * Build and install `hare`
-
   ```sh
   make
   sudo make install
   ```
 
 * Add current user to `hare` group
-
   ```sh
   sudo usermod --append --groups hare $USER
   ```
@@ -91,7 +89,6 @@ and health-checking mechanisms.
 * Build Motr RPMs
 
   * From sources
-  
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git
     cd cortx-motr
@@ -103,10 +100,8 @@ and health-checking mechanisms.
 * Build `hare` RPMs
 
   * Download `hare` source as mentioned above
-  
     ```sh
     cd hare
-
     make rpm
     sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-hare-*.rpm
     ```

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ and health-checking mechanisms.
      cd -
      ```
 
-* Build and install `hare`
+* Build and install `hare`  
   ```sh
   make
   sudo make install
   ```
 
-* Add current user to `hare` group
+* Add current user to `hare` group  
   ```sh
   sudo usermod --append --groups hare $USER
   ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and health-checking mechanisms.
 
 ### Building from source
 
-* Download hare.
+* Download `hare`.
   ```sh
   git clone https://github.com/Seagate/cortx-hare.git hare
   cd hare
@@ -70,14 +70,14 @@ and health-checking mechanisms.
      cd -
      ```
 
-* Build and install hare.
+* Build and install `hare`.
 
   ```sh
   make
   sudo make install
   ```
 
-* Add current user to hare group.
+* Add current user to `hare` group.
 
   ```sh
   sudo usermod --append --groups hare $USER
@@ -100,9 +100,9 @@ and health-checking mechanisms.
     sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
     ```
 
-* Build hare RPMs.
+* Build `hare` RPMs.
 
-  * Download hare source as mentioned above.
+  * Download `hare` source as mentioned above.
   
     ```sh
     cd hare

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ and health-checking mechanisms.
      cd -
      ```
 
-* Build and install `hare`.
+* Build and install `hare`
 
   ```sh
   make
   sudo make install
   ```
 
-* Add current user to `hare` group.
+* Add current user to `hare` group
 
   ```sh
   sudo usermod --append --groups hare $USER
@@ -88,7 +88,7 @@ and health-checking mechanisms.
 
 **NOTE: If you have built Motr and HARE from sources you need not generate RPM packages as below, however, it might be more convenient to build and install rpms on a multinode setup sometimes**
 
-* Build Motr RPMs.
+* Build Motr RPMs
 
   * From sources
   
@@ -100,9 +100,9 @@ and health-checking mechanisms.
     sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
     ```
 
-* Build `hare` RPMs.
+* Build `hare` RPMs
 
-  * Download `hare` source as mentioned above.
+  * Download `hare` source as mentioned above
   
     ```sh
     cd hare

--- a/README.md
+++ b/README.md
@@ -59,14 +59,9 @@ and health-checking mechanisms.
   sudo yum -y install consul-1.9.1
   ```
 
-* Install Motr.
+* Build and Install Motr.
 
-  * .. from RPMs
-    ```sh
-    sudo yum -y install cortx-motr cortx-motr-devel
-    ```
-
-  * .. or from [sources](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) use this link to build Motr from source. Once you built Motr continue with the steps listed below.
+  *  from sources use [this](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) link to build Motr from source. Once you built Motr continue with the steps listed below.
     
     ```sh
     sudo scripts/install-motr-service --link
@@ -90,14 +85,9 @@ and health-checking mechanisms.
 
 ### Build and install `hare` rpm from source.
 **NOTE: If you have built Motr and HARE from source you will not need to generate RPM packages below**
-* Install Motr.
+* Build `Motr` RPMs.
 
-  * .. from RPMS
-    ```sh
-    sudo yum -y install cortx-motr cortx-motr-devel
-    ```
-
-  * .. or
+  * from sources
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git
     cd cortx-motr

--- a/README.md
+++ b/README.md
@@ -63,31 +63,35 @@ and health-checking mechanisms.
 
   *  Follow [Motr quick start guide](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) to build Motr from source. After compiling Motr sources, please continue with the below steps to build Hare using Motr sources.
     
-    ```sh
-    sudo scripts/install-motr-service --link
-
-    export M0_SRC_DIR=$PWD
-    cd -
-    ```
+     ```sh
+     sudo scripts/install-motr-service --link
+ 
+     export M0_SRC_DIR=$PWD
+     cd -
+     ```
 
 * Build and install hare.
+
   ```sh
   make
   sudo make install
   ```
 
 * Add current user to hare group.
+
   ```sh
   sudo usermod --append --groups hare $USER
   ```
   Log out and log back in.
 
+### Build and install rpms from source
 
-### Build and install rpms from source.
 **NOTE: If you have built Motr and HARE from sources you need not generate RPM packages as below, however, it might be more convenient to build and install rpms on a multinode setup sometimes**
+
 * Build Motr RPMs.
 
   * From sources
+  
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git
     cd cortx-motr
@@ -99,6 +103,7 @@ and health-checking mechanisms.
 * Build hare RPMs.
 
   * Download hare source as mentioned above.
+  
     ```sh
     cd hare
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ and health-checking mechanisms.
      cd -
      ```
 
-* Build and install `hare`  
+* Build and install `hare`.
   ```sh
   make
   sudo make install
   ```
 
-* Add current user to `hare` group  
+* Add current user to `hare` group.
   ```sh
   sudo usermod --append --groups hare $USER
   ```


### PR DESCRIPTION
README file instructs to download the RPMs using private Seagate URLs which are obviously unavailable to external users.

Solution: remove misleading instructions from README file

Closes  #1589 