### PR TITLE
EOS-19373 Parallel message processing in Hax

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -17,8 +17,6 @@
 #
 
 import logging
-import time
-from queue import Empty, Queue
 from typing import List
 
 from hax.message import (BroadcastHAStates, EntrypointRequest,
@@ -30,6 +28,7 @@ from hax.message import (BroadcastHAStates, EntrypointRequest,
                          StobIoqError)
 from hax.motr import Motr
 from hax.motr.delivery import DeliveryHerald
+from hax.motr.planner import WorkPlanner
 from hax.queue.publish import EQPublisher
 from hax.types import (ConfHaProcess, HaLinkMessagePromise, HAState, MessageId,
                        ObjT, ServiceHealth, StoppableThread, m0HaProcessEvent,
@@ -48,11 +47,11 @@ class ConsumerThread(StoppableThread):
     The thread exits gracefully when it receives message of type Die (i.e.
     it is a 'poison pill').
     """
-    def __init__(self, q: Queue, motr: Motr, herald: DeliveryHerald,
-                 consul: ConsulUtil):
+    def __init__(self, planner: WorkPlanner, motr: Motr,
+                 herald: DeliveryHerald, consul: ConsulUtil):
         super().__init__(target=self._do_work,
                          name='qconsumer',
-                         args=(q, motr))
+                         args=(planner, motr))
         self.is_stopped = False
         self.consul = consul
         self.eq_publisher = EQPublisher()
@@ -62,7 +61,7 @@ class ConsumerThread(StoppableThread):
         self.is_stopped = True
 
     @repeat_if_fails(wait_seconds=1)
-    def _update_process_status(self, q: Queue, motr: Motr,
+    def _update_process_status(self, p: WorkPlanner, motr: Motr,
                                event: ConfHaProcess) -> None:
         # If a consul-related exception appears, it will
         # be processed by repeat_if_fails.
@@ -78,7 +77,7 @@ class ConsumerThread(StoppableThread):
                 notify_devices=False)
 
     @repeat_if_fails(wait_seconds=1)
-    def update_process_failure(self, q: Queue,
+    def update_process_failure(self, planner: WorkPlanner,
                                ha_states: List[HAState]) -> List[HAState]:
         new_ha_states: List[HAState] = []
         for state in ha_states:
@@ -118,7 +117,7 @@ class ConsumerThread(StoppableThread):
                     # the real time status of the process before
                     # broadcasting failure.
                     current_status = ServiceHealth.UNKNOWN
-                    q.put(
+                    planner.add_command(
                         BroadcastHAStates(states=[
                             HAState(fid=state.fid, status=ServiceHealth.FAILED)
                         ],
@@ -147,29 +146,19 @@ class ConsumerThread(StoppableThread):
                 new_ha_states.append(state)
         return new_ha_states
 
-    def _do_work(self, q: Queue, motr: Motr):
+    def _do_work(self, planner: WorkPlanner, motr: Motr):
         LOG.info('Handler thread has started')
         motr.adopt_motr_thread()
-
-        def pull_msg():
-            try:
-                return q.get(block=False)
-            except Empty:
-                return None
 
         try:
             while True:
                 try:
                     LOG.debug('Waiting for the next message')
 
-                    item = pull_msg()
-                    while item is None:
-                        time.sleep(0.2)
-                        if self.is_stopped:
-                            raise StopIteration()
-                        item = pull_msg()
+                    item = planner.get_next_command()
+                    planner.ensure_allowed(item)
 
-                    LOG.debug('Got %s message from queue', item)
+                    LOG.debug('Got %s message from planner', item)
                     if isinstance(item, FirstEntrypointRequest):
                         LOG.debug('first entrypoint request, broadcast FAILED')
                         ids: List[MessageId] = motr.broadcast_ha_states(
@@ -197,7 +186,7 @@ class ConsumerThread(StoppableThread):
                         # hence will need to make new attempt by itself
                         motr.send_entrypoint_request_reply(item)
                     elif isinstance(item, ProcessEvent):
-                        self._update_process_status(q, motr, item.evt)
+                        self._update_process_status(planner, motr, item.evt)
                     elif isinstance(item, HaNvecGetEvent):
                         fn = motr.ha_nvec_get_reply
                         # If a consul-related exception appears, it will
@@ -209,7 +198,8 @@ class ConsumerThread(StoppableThread):
                         decorated(item)
                     elif isinstance(item, BroadcastHAStates):
                         LOG.info('HA states: %s', item.states)
-                        ha_states = self.update_process_failure(q, item.states)
+                        ha_states = self.update_process_failure(
+                            planner, item.states)
                         result: List[MessageId] = motr.broadcast_ha_states(
                             ha_states)
                         if item.reply_to:
@@ -264,6 +254,8 @@ class ConsumerThread(StoppableThread):
                 except Exception:
                     # no op, swallow the exception
                     LOG.exception('**ERROR**')
+                finally:
+                    planner.notify_finished(item)
         except StopIteration:
             LOG.info('Consumer Stopped')
             motr.stop()

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -48,9 +48,9 @@ class ConsumerThread(StoppableThread):
     it is a 'poison pill').
     """
     def __init__(self, planner: WorkPlanner, motr: Motr,
-                 herald: DeliveryHerald, consul: ConsulUtil):
+                 herald: DeliveryHerald, consul: ConsulUtil, idx: int):
         super().__init__(target=self._do_work,
-                         name='qconsumer',
+                         name=f'qconsumer-{idx}',
                          args=(planner, motr))
         self.is_stopped = False
         self.consul = consul

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -156,9 +156,6 @@ class ConsumerThread(StoppableThread):
                     LOG.debug('Waiting for the next message')
 
                     item = planner.get_next_command()
-                    # TODO maybe it makes sense to move ensure_allowed() into
-                    # get_next_command()?
-                    item = planner.ensure_allowed(item)
 
                     LOG.debug('Got %s message from planner', item)
                     if isinstance(item, FirstEntrypointRequest):

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -21,18 +21,19 @@ import time
 from queue import Empty, Queue
 from typing import List
 
-from hax.message import (BroadcastHAStates, FirstEntrypointRequest,
-                         EntrypointRequest, HaNvecGetEvent,
-                         ProcessEvent, SnsRebalancePause, SnsRebalanceResume,
+from hax.message import (BroadcastHAStates, EntrypointRequest,
+                         FirstEntrypointRequest, HaNvecGetEvent, ProcessEvent,
+                         SnsRebalancePause, SnsRebalanceResume,
                          SnsRebalanceStart, SnsRebalanceStatus,
                          SnsRebalanceStop, SnsRepairPause, SnsRepairResume,
-                         SnsRepairStart, SnsRepairStatus, SnsRepairStop)
+                         SnsRepairStart, SnsRepairStatus, SnsRepairStop,
+                         StobIoqError)
 from hax.motr import Motr
 from hax.motr.delivery import DeliveryHerald
 from hax.queue.publish import EQPublisher
-from hax.types import (ConfHaProcess, HAState, MessageId, StobIoqError,
-                       ServiceHealth, m0HaProcessEvent, m0HaProcessType,
-                       StoppableThread, HaLinkMessagePromise, ObjT)
+from hax.types import (ConfHaProcess, HaLinkMessagePromise, HAState, MessageId,
+                       ObjT, ServiceHealth, StoppableThread, m0HaProcessEvent,
+                       m0HaProcessType)
 from hax.util import ConsulUtil, dump_json, repeat_if_fails
 
 LOG = logging.getLogger('hax')
@@ -72,9 +73,9 @@ class ConsumerThread(StoppableThread):
         svc_status = m0HaProcessEvent.event_to_svchealth(event.chp_event)
         if event.chp_event in (m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
                                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED):
-            motr.broadcast_ha_states([HAState(fid=event.fid,
-                                              status=svc_status)],
-                                     notify_devices=False)
+            motr.broadcast_ha_states(
+                [HAState(fid=event.fid, status=svc_status)],
+                notify_devices=False)
 
     @repeat_if_fails(wait_seconds=1)
     def update_process_failure(self, q: Queue,
@@ -84,15 +85,15 @@ class ConsumerThread(StoppableThread):
             # We are only concerned with process statuses.
             if state.fid.container == ObjT.PROCESS.value:
                 current_status = self.consul.get_process_current_status(
-                                     state.status, state.fid)
+                    state.status, state.fid)
                 if current_status == ServiceHealth.OK:
-                    if (self.consul.get_process_local_status(state.fid) ==
-                            'M0_CONF_HA_PROCESS_STARTED'):
+                    if (self.consul.get_process_local_status(
+                            state.fid) == 'M0_CONF_HA_PROCESS_STARTED'):
                         continue
                 if current_status in (ServiceHealth.FAILED,
                                       ServiceHealth.STOPPED):
-                    if (self.consul.get_process_local_status(state.fid) ==
-                            'M0_CONF_HA_PROCESS_STOPPED'):
+                    if (self.consul.get_process_local_status(
+                            state.fid) == 'M0_CONF_HA_PROCESS_STOPPED'):
                         # Consul may report failure of a process multiple
                         # times, so we don't want to send duplicate failure
                         # notifications, it may cause delay in cleanup
@@ -117,10 +118,11 @@ class ConsumerThread(StoppableThread):
                     # the real time status of the process before
                     # broadcasting failure.
                     current_status = ServiceHealth.UNKNOWN
-                    q.put(BroadcastHAStates(
-                          states=[HAState(fid=state.fid,
-                                          status=ServiceHealth.FAILED)],
-                          reply_to=None))
+                    q.put(
+                        BroadcastHAStates(states=[
+                            HAState(fid=state.fid, status=ServiceHealth.FAILED)
+                        ],
+                                          reply_to=None))
                 if current_status not in (ServiceHealth.UNKNOWN,
                                           ServiceHealth.OFFLINE):
                     # We also need to account and report the failure of remote
@@ -133,13 +135,14 @@ class ConsumerThread(StoppableThread):
                         event = m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED
                     else:
                         event = m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED
-                    self.consul.update_process_status(ConfHaProcess(
-                        chp_event=event,
-                        chp_type=m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
-                        chp_pid=0,
-                        fid=state.fid))
-                new_ha_states.append(HAState(fid=state.fid,
-                                             status=current_status))
+                    self.consul.update_process_status(
+                        ConfHaProcess(
+                            chp_event=event,
+                            chp_type=m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                            chp_pid=0,
+                            fid=state.fid))
+                new_ha_states.append(
+                    HAState(fid=state.fid, status=current_status))
             else:
                 new_ha_states.append(state)
         return new_ha_states
@@ -170,8 +173,10 @@ class ConsumerThread(StoppableThread):
                     if isinstance(item, FirstEntrypointRequest):
                         LOG.debug('first entrypoint request, broadcast FAILED')
                         ids: List[MessageId] = motr.broadcast_ha_states(
-                            [HAState(fid=item.process_fid,
-                                     status=ServiceHealth.FAILED)],
+                            [
+                                HAState(fid=item.process_fid,
+                                        status=ServiceHealth.FAILED)
+                            ],
                             notify_devices=False)
                         LOG.debug('waiting for broadcast of %s for ep: %s',
                                   ids, item.remote_rpc_endpoint)

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -19,7 +19,7 @@
 import logging
 from typing import List
 
-from hax.message import (BroadcastHAStates, EntrypointRequest,
+from hax.message import (BroadcastHAStates, Die, EntrypointRequest,
                          FirstEntrypointRequest, HaNvecGetEvent, ProcessEvent,
                          SnsRebalancePause, SnsRebalanceResume,
                          SnsRebalanceStart, SnsRebalanceStatus,
@@ -156,7 +156,9 @@ class ConsumerThread(StoppableThread):
                     LOG.debug('Waiting for the next message')
 
                     item = planner.get_next_command()
-                    planner.ensure_allowed(item)
+                    # TODO maybe it makes sense to move ensure_allowed() into
+                    # get_next_command()?
+                    item = planner.ensure_allowed(item)
 
                     LOG.debug('Got %s message from planner', item)
                     if isinstance(item, FirstEntrypointRequest):
@@ -245,7 +247,8 @@ class ConsumerThread(StoppableThread):
                     elif isinstance(item, SnsRepairResume):
                         LOG.info('Requesting SNS repair resume')
                         motr.resume_repair(item.fid)
-
+                    elif isinstance(item, Die):
+                        raise StopIteration()
                     else:
                         LOG.warning('Unsupported event type received: %s',
                                     item)

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from queue import Queue
 from typing import Any, List, Optional
 
-from hax.types import Fid, HaNote, HAState, Uint128
+from hax.types import Fid, HaNote, HAState, StobId, Uint128
 
 
 @dataclass(unsafe_hash=True)
@@ -123,6 +123,19 @@ class SnsRepairStatus(SnsOperation):
 class SnsRebalanceStatus(SnsOperation):
     fid: Fid
     reply_to: q.Queue
+
+
+@dataclass
+class StobIoqError(BaseMessage):
+    fid: Fid
+    conf_sdev: Fid
+    stob_id: StobId
+    fd: int
+    opcode: int
+    rc: int
+    offset: int
+    size: int
+    bshift: int
 
 
 class Die(BaseMessage):

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -17,37 +17,38 @@
 #
 
 import queue as q
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from queue import Queue
 from typing import Any, List, Optional
 
 from hax.types import Fid, HaNote, HAState, Uint128
-from queue import Queue
 
 
+@dataclass(unsafe_hash=True)
 class BaseMessage:
+    # The group id used internally by WorkPlanner
+    group: Optional[int] = field(default=None, init=False)
+
+
+@dataclass(unsafe_hash=True)
+class AnyEntrypointRequest(BaseMessage):
+    reply_context: Any
+    req_id: Uint128
+    remote_rpc_endpoint: str
+    process_fid: Fid
+    git_rev: str
+    pid: int
+    is_first_request: bool
+
+
+@dataclass(unsafe_hash=True)
+class EntrypointRequest(AnyEntrypointRequest):
     pass
 
 
 @dataclass
-class EntrypointRequest(BaseMessage):
-    reply_context: Any
-    req_id: Uint128
-    remote_rpc_endpoint: str
-    process_fid: Fid
-    git_rev: str
-    pid: int
-    is_first_request: bool
-
-
-@dataclass
-class FirstEntrypointRequest(BaseMessage):
-    reply_context: Any
-    req_id: Uint128
-    remote_rpc_endpoint: str
-    process_fid: Fid
-    git_rev: str
-    pid: int
-    is_first_request: bool
+class FirstEntrypointRequest(AnyEntrypointRequest):
+    pass
 
 
 @dataclass
@@ -113,13 +114,13 @@ class SnsDiskDetach(SnsOperation):
 
 
 @dataclass
-class SnsRepairStatus:
+class SnsRepairStatus(SnsOperation):
     fid: Fid
     reply_to: q.Queue
 
 
 @dataclass
-class SnsRebalanceStatus:
+class SnsRebalanceStatus(SnsOperation):
     fid: Fid
     reply_to: q.Queue
 

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -22,14 +22,14 @@ from errno import EAGAIN
 from typing import Any, List
 
 from hax.exception import ConfdQuorumException, RepairRebalanceException
-from hax.message import (EntrypointRequest,
-                         FirstEntrypointRequest, HaNvecGetEvent, ProcessEvent)
+from hax.message import (EntrypointRequest, FirstEntrypointRequest,
+                         HaNvecGetEvent, ProcessEvent, StobIoqError)
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
-from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats, HaNote,
-                       HaNoteStruct, HAState, MessageId, ObjT, Profile,
-                       ReprebStatus, ServiceHealth, StobIoqError,
-                       m0HaProcessEvent, HaLinkMessagePromise)
+from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats,
+                       HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
+                       MessageId, ObjT, Profile, ReprebStatus, ServiceHealth,
+                       m0HaProcessEvent)
 from hax.util import ConsulUtil, repeat_if_fails
 
 LOG = logging.getLogger('hax')
@@ -245,8 +245,7 @@ class Motr:
             self._ffi.entrypoint_reply(reply_context, req_id.to_c(), e_rc, 0,
                                        make_array(FidStruct, []),
                                        make_array(c.c_char_p, []), 0,
-                                       Fid(0, 0).to_c(),
-                                       None)
+                                       Fid(0, 0).to_c(), None)
             LOG.debug('Reply sent')
             return
 
@@ -259,11 +258,11 @@ class Motr:
                                    make_array(FidStruct, confd_fids),
                                    make_array(c.c_char_p,
                                               confd_eps), rc_quorum,
-                                   rm_fid.to_c(),
-                                   make_c_str(rm_eps))
+                                   rm_fid.to_c(), make_c_str(rm_eps))
         LOG.debug('Entrypoint request has been replied to')
 
-    def broadcast_ha_states(self, ha_states: List[HAState],
+    def broadcast_ha_states(self,
+                            ha_states: List[HAState],
                             notify_devices=True) -> List[MessageId]:
         LOG.debug('Broadcasting HA states %s over ha_link', ha_states)
 
@@ -277,8 +276,8 @@ class Motr:
                 continue
             note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st))
             notes.append(note)
-            if (st.fid.container == ObjT.PROCESS.value and
-                    st.status == ServiceHealth.STOPPED):
+            if (st.fid.container == ObjT.PROCESS.value
+                    and st.status == ServiceHealth.STOPPED):
                 notify_devices = False
             notes += self._generate_sub_services(note, self.consul_util,
                                                  notify_devices)
@@ -344,14 +343,15 @@ class Motr:
             n.note.no_state = HaNoteStruct.M0_NC_ONLINE
             if (n.obj_t in (ObjT.PROCESS.name, ObjT.SERVICE.name)):
                 n.note.no_state = self.consul_util.get_conf_obj_status(
-                                      ObjT[n.obj_t], n.note.no_id.f_key)
+                    ObjT[n.obj_t], n.note.no_id.f_key)
             notes.append(n.note)
 
         LOG.debug('Replying ha nvec of length ' + str(len(event.nvec)))
         self._ffi.ha_nvec_reply(event.hax_msg, make_array(HaNoteStruct, notes),
                                 len(notes))
 
-    def _generate_sub_services(self, note: HaNoteStruct,
+    def _generate_sub_services(self,
+                               note: HaNoteStruct,
                                cns: ConsulUtil,
                                notify_devices=True) -> List[HaNoteStruct]:
         new_state = note.no_state
@@ -359,15 +359,16 @@ class Motr:
         service_list = cns.get_services_by_parent_process(fid)
         LOG.debug('Process fid=%s encloses %s services as follows: %s', fid,
                   len(service_list), service_list)
-        service_notes = [HaNoteStruct(no_id=x.fid.to_c(), no_state=new_state)
-                         for x in service_list]
+        service_notes = [
+            HaNoteStruct(no_id=x.fid.to_c(), no_state=new_state)
+            for x in service_list
+        ]
         if notify_devices:
             service_notes += self._generate_sub_disks(note, service_list, cns)
 
         return service_notes
 
-    def _generate_sub_disks(self, note: HaNoteStruct,
-                            services: List,
+    def _generate_sub_disks(self, note: HaNoteStruct, services: List,
                             cns: ConsulUtil) -> List[HaNoteStruct]:
         disk_list = []
         new_state = note.no_state
@@ -377,8 +378,7 @@ class Motr:
         LOG.debug('proc fid=%s encloses %d disks with state %d as follows: %s',
                   proc_fid, len(disk_list), int(new_state), disk_list)
         return [
-            HaNoteStruct(no_id=x.to_c(), no_state=new_state)
-            for x in disk_list
+            HaNoteStruct(no_id=x.to_c(), no_state=new_state) for x in disk_list
         ]
 
     def notify_hax_stop(self):

--- a/hax/hax/motr/planner.py
+++ b/hax/hax/motr/planner.py
@@ -20,7 +20,7 @@ import logging
 from collections import deque
 from dataclasses import dataclass
 from threading import Condition
-from typing import Callable, Deque, Optional, Type
+from typing import Callable, Deque, Optional, Set, Type
 
 from hax.log import TRACE
 from hax.message import (AnyEntrypointRequest, BaseMessage, BroadcastHAStates,
@@ -60,7 +60,7 @@ class State:
     # the command type being added and check which command types are already
     # there in the next_group_id group. If there is no logical conflict, the
     # next_group_id remains the same, otherwise a new group is formed.
-    next_group_commands: LinkedSet[Type[BaseMessage]]
+    next_group_commands: Set[Type[BaseMessage]]
     #
     # If WorkPlanner is in shutting down mode.
     # Shutting down mode is a special mode when WorkPlanner starts issuing
@@ -116,7 +116,7 @@ class WorkPlanner:
                      active_commands=LinkedList(),
                      taken_commands=LinkedList(),
                      current_group_id=0,
-                     next_group_commands=LinkedSet(),
+                     next_group_commands=set(),
                      is_shutdown=False)
 
     def _create_poison(self) -> BaseMessage:
@@ -222,7 +222,7 @@ class WorkPlanner:
 
         if change_next_group:
             state.next_group_id = state.current_group_id
-            state.next_group_commands = LinkedSet()
+            state.next_group_commands = set()
 
     def notify_finished(self, command: BaseMessage) -> None:
         ''' The method must be invoked by the worker thread when the command
@@ -307,7 +307,7 @@ class WorkPlanner:
             return cmd
 
         def next_group() -> None:
-            self.state.next_group_commands = LinkedSet()
+            self.state.next_group_commands = set()
             self.state.next_group_id = self._get_increased_group(
                 self.state.next_group_id)
 

--- a/hax/hax/motr/planner.py
+++ b/hax/hax/motr/planner.py
@@ -24,7 +24,7 @@ from typing import Callable, Deque, Optional, Set, Type
 
 from hax.log import TRACE
 from hax.message import (AnyEntrypointRequest, BaseMessage, BroadcastHAStates,
-                         Die, HaNvecGetEvent, SnsOperation)
+                         Die, HaNvecGetEvent, ProcessEvent, SnsOperation)
 from hax.motr.util import LinkedList
 
 LOG = logging.getLogger('hax')
@@ -295,6 +295,12 @@ class WorkPlanner:
             # Start new group if there is another SNS operation within the
             # current group.
             return has(SnsOperation)
+        if isinstance(cmd, ProcessEvent):
+            # Two process events (like STARTING or STARTED) can't be performed
+            # in parallel.
+            # So if there is one ProcessEvent already in the group, then the
+            # new one should go to another group.
+            return has(ProcessEvent)
         return False
 
     def _assign_group(self, cmd: BaseMessage) -> BaseMessage:

--- a/hax/hax/motr/planner.py
+++ b/hax/hax/motr/planner.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+from collections import deque
+from dataclasses import dataclass
+from threading import Condition
+from typing import Deque, Type
+
+from hax.log import TRACE
+from hax.message import (AnyEntrypointRequest, BaseMessage, BroadcastHAStates,
+                         Die, HaNvecGetEvent, SnsOperation)
+from hax.motr.util import LinkedSet
+
+LOG = logging.getLogger('hax')
+
+__all__ = ['WorkPlanner']
+
+
+@dataclass
+class State:
+    #
+    # group being executed currently
+    current_group_id: int
+    #
+    # group that is being populated by next add_command() invocation
+    next_group_id: int
+    #
+    # commands that are being processed now
+    active_commands: LinkedSet[BaseMessage]
+    taken_commands: LinkedSet[BaseMessage]
+    next_group_commands: LinkedSet[Type[BaseMessage]]
+
+
+class WorkPlanner:
+    """
+    Thread synchronizing block that is used as a work planner for Motr-aware
+    threads (see ConsumerThread). This synchronizing primitive guarantees that
+
+    1. The messages can be processed by an arbitrary number of ConsumerThread
+       threads.
+
+    2. The parallelism doesn't break semantics (some messages can be processed
+       in parallel to others, while some other not; the ConsumerThread's don't
+       need to worry about that).
+    """
+    def __init__(self):
+        self.state = State(next_group_id=0,
+                           active_commands=LinkedSet(),
+                           taken_commands=LinkedSet(),
+                           current_group_id=0,
+                           next_group_commands=LinkedSet())
+        self.backlog: Deque[BaseMessage] = deque()
+        self.b_lock = Condition()
+
+    def is_empty(self) -> bool:
+        with self.b_lock:
+            return not self.backlog
+
+    def add_command(self, command: BaseMessage) -> None:
+        with self.b_lock:
+            cmd = self._assign_group(command)
+            self.backlog.append(cmd)
+            # Some threads may be waiting because of an empty backlog - let's
+            # notify them
+            self.b_lock.notifyAll()
+
+    def get_next_command(self) -> BaseMessage:
+        # TODO think of is_stopped and shutdown procedure
+        while True:
+            with self.b_lock:
+                if self.backlog:
+                    cmd = self.backlog.popleft()
+                    self.state.taken_commands.add(cmd)
+                    return cmd
+                self.b_lock.wait()
+
+    def ensure_allowed(self, command: BaseMessage) -> None:
+        def is_current(cmd: BaseMessage, st: State) -> bool:
+            return cmd.group == st.current_group_id
+
+        while True:
+            with self.b_lock:
+                state = self.state
+                if is_current(command, state):
+                    state.taken_commands.remove(command)
+                    state.active_commands.add(command)
+                    return
+                self.b_lock.wait()
+
+    def notify_finished(self, command: BaseMessage) -> None:
+        with self.b_lock:
+            state = self.state
+            state.active_commands.remove(command)
+            LOG.log(TRACE, 'Cmd %s removed. Current state: %s', command, state)
+
+            if state.active_commands:
+                return
+            for c in self.backlog:
+                if c.group == state.current_group_id:
+                    return
+            for c in state.taken_commands:
+                if c.group == state.current_group_id:
+                    return
+            # if we're here, command was the only one belonging to group
+            state.current_group_id += 1
+            LOG.log(TRACE, 'Active group changed to %s',
+                    state.current_group_id)
+            # The group changed, let's unblock those who are waiting for
+            # this group
+            self.b_lock.notifyAll()
+
+    def _should_increase_group(self, cmd: BaseMessage) -> bool:
+        def has(cmd_type: Type[BaseMessage]) -> bool:
+            ''' Checks if the group being currently formed (i.e. next_group)
+                contains a message of the given type.
+            '''
+            return cmd_type in self.state.next_group_commands
+
+        if not self.state.next_group_commands:
+            # current group is empty -> join it freely
+            return False
+        if isinstance(cmd, HaNvecGetEvent):
+            # HaNvecGetEvent can be done in parallel to any other commands.
+            # No need to form the new group for it.
+            return False
+        if isinstance(cmd, AnyEntrypointRequest):
+            # if the current group has a BroadcastHAStates request,
+            # then this entrypoint request should be placed to a next group.
+            return has(BroadcastHAStates)
+        if isinstance(cmd, BroadcastHAStates):
+            return True
+
+        if isinstance(cmd, SnsOperation):
+            # Start new group if there is another SNS operation within the
+            # current group.
+            return has(SnsOperation)
+        return False
+
+    def _assign_group(self, cmd: BaseMessage) -> BaseMessage:
+        ''' Sets the correct group_id to the command.
+            Must be invoked with b_lock acquired.
+        '''
+        def join_group(cmd: BaseMessage) -> BaseMessage:
+            cmd.group = self.state.next_group_id
+            self.state.next_group_commands.add(type(cmd))
+            return cmd
+
+        def inc_group() -> None:
+            self.state.next_group_commands = LinkedSet()
+            self.state.next_group_id += 1
+
+        if isinstance(cmd, Die):
+            return join_group(cmd)
+
+        if self._should_increase_group(cmd):
+            inc_group()
+
+        return join_group(cmd)

--- a/hax/hax/motr/util.py
+++ b/hax/hax/motr/util.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+from dataclasses import dataclass
+from typing import Generic, Iterable, Optional, TypeVar
+
+A = TypeVar('A')
+
+
+@dataclass
+class Elem(Generic[A]):
+    data: A
+    next_elem: 'Optional[Elem[A]]' = None
+
+
+class QueueIterator:
+    # TODO choose a proper name
+    def __init__(self, q):
+        self.cur = q.head
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if not self.cur:
+            raise StopIteration()
+        ret = self.cur
+        self.cur = ret.next_elem
+        return ret.data
+
+
+class LinkedSet(Iterable[A]):
+    head: Optional[Elem[A]]
+
+    def __init__(self):
+        self.head = None
+
+    def add(self, value: A) -> None:
+        elem = Elem(data=value)
+        old_head = self.head
+        self.head = elem
+        elem.next_elem = old_head
+
+    def remove(self, value: A) -> bool:
+        prev: Optional[Elem[A]] = None
+        q = self.head
+        while q:
+            if q.data is value:
+                if not prev:
+                    self.head = q.next_elem
+                else:
+                    prev.next_elem = q.next_elem
+                return True
+            prev = q
+            q = q.next_elem
+        return False
+
+    def __contains__(self, value: A) -> bool:
+        # This supports 'in' operator
+        q = self.head
+        while q:
+            if q.data is value:
+                return True
+            q = q.next_elem
+        return False
+
+    def __bool__(self) -> bool:
+        # This adds support of 'not' operator in terms of emptyness.
+        # 'if not linked_set' evaluates to True <=> the set is empty
+        return bool(self.head)
+
+    def __iter__(self):
+        return QueueIterator(self)
+
+    def __repr__(self):
+        if not self.head:
+            return '<empty>'
+        return '(' + ', '.join(str(s) for s in self) + ')'
+
+
+class Queue(Iterable[A]):
+    head: Optional[Elem[A]]
+    tail: Optional[Elem[A]]
+
+    def __init__(self):
+        self.head = None
+        self.tail = None
+
+    def __iter__(self):
+        return QueueIterator(self)
+
+    def push(self, value: A) -> None:
+        elem = Elem(data=value)
+        if not self.tail:
+            self.tail = elem
+            self.head = elem
+            return
+        self.tail.next_elem = elem
+        self.tail = elem
+
+    def pop(self) -> A:
+        if not self.head:
+            raise ValueError('Queue is empty')
+        old_head = self.head
+        self.head = old_head.next_elem
+        return old_head.data
+
+    def is_empty(self) -> bool:
+        return not self.head

--- a/hax/hax/motr/util.py
+++ b/hax/hax/motr/util.py
@@ -27,8 +27,7 @@ class Elem(Generic[A]):
     next_elem: 'Optional[Elem[A]]' = None
 
 
-class QueueIterator:
-    # TODO choose a proper name
+class LinkedListIterator:
     def __init__(self, q):
         self.cur = q.head
 
@@ -43,7 +42,11 @@ class QueueIterator:
         return ret.data
 
 
-class LinkedSet(Iterable[A]):
+class LinkedList(Iterable[A]):
+    ''' The class is used as a replacement for set() in cases when the stored
+    objects are not hashable and it is sufficient to compare them by 'identity'
+    (the equality of memory pointer).
+    '''
     head: Optional[Elem[A]]
 
     def __init__(self):
@@ -84,40 +87,9 @@ class LinkedSet(Iterable[A]):
         return bool(self.head)
 
     def __iter__(self):
-        return QueueIterator(self)
+        return LinkedListIterator(self)
 
     def __repr__(self):
         if not self.head:
             return '<empty>'
         return '(' + ', '.join(str(s) for s in self) + ')'
-
-
-class Queue(Iterable[A]):
-    head: Optional[Elem[A]]
-    tail: Optional[Elem[A]]
-
-    def __init__(self):
-        self.head = None
-        self.tail = None
-
-    def __iter__(self):
-        return QueueIterator(self)
-
-    def push(self, value: A) -> None:
-        elem = Elem(data=value)
-        if not self.tail:
-            self.tail = elem
-            self.head = elem
-            return
-        self.tail.next_elem = elem
-        self.tail = elem
-
-    def pop(self) -> A:
-        if not self.head:
-            raise ValueError('Queue is empty')
-        old_head = self.head
-        self.head = old_head.next_elem
-        return old_head.data
-
-    def is_empty(self) -> bool:
-        return not self.head

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -32,9 +32,10 @@ from hax.message import (BaseMessage, BroadcastHAStates, SnsDiskAttach,
                          SnsRebalanceStop, SnsRepairPause, SnsRepairResume,
                          SnsRepairStart, SnsRepairStatus, SnsRepairStop)
 from hax.motr.delivery import DeliveryHerald
+from hax.motr.planner import WorkPlanner
 from hax.queue import BQProcessor
-from hax.queue.offset import InboxFilter, OffsetStorage
 from hax.queue.confobjutil import ConfObjUtil
+from hax.queue.offset import InboxFilter, OffsetStorage
 from hax.types import Fid, HAState, ServiceHealth, StoppableThread
 from hax.util import ConsulUtil, create_process_fid, dump_json
 
@@ -65,14 +66,14 @@ def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
     ]
 
 
-def process_ha_states(queue: Queue, consul_util: ConsulUtil):
+def process_ha_states(planner: WorkPlanner, consul_util: ConsulUtil):
     async def _process(request):
         data = await request.json()
 
         loop = asyncio.get_event_loop()
-        # Note that queue.put is potentially a blocking call
+        # Note that planner.add_command is potentially a blocking call
         await loop.run_in_executor(
-            None, lambda: queue.put(
+            None, lambda: planner.add_command(
                 BroadcastHAStates(states=to_ha_states(data, consul_util),
                                   reply_to=None)))
         return web.Response()
@@ -80,7 +81,7 @@ def process_ha_states(queue: Queue, consul_util: ConsulUtil):
     return _process
 
 
-def process_sns_operation(queue: Queue):
+def process_sns_operation(planner: WorkPlanner):
     async def _process(request):
         op_name = request.match_info.get('operation')
 
@@ -113,18 +114,18 @@ def process_sns_operation(queue: Queue):
         message = msg_factory[op_name](data)
 
         loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, lambda: queue.put(message))
+        await loop.run_in_executor(None, lambda: planner.add_command(message))
         return web.Response()
 
     return _process
 
 
-def get_sns_status(motr_queue: Queue,
+def get_sns_status(planner: WorkPlanner,
                    status_type: Union[Type[SnsRepairStatus],
                                       Type[SnsRebalanceStatus]]):
     def fn(request):
         queue: Queue = Queue(1)
-        motr_queue.put(
+        planner.add_command(
             status_type(reply_to=queue,
                         fid=Fid.parse(request.query['pool_fid'])))
         return queue.get(timeout=10)
@@ -185,7 +186,7 @@ async def encode_exception(request, handler):
 
 
 def run_server(
-    queue: Queue,
+    planner: WorkPlanner,
     herald: DeliveryHerald,
     consul_util: ConsulUtil,
     threads_to_wait: List[StoppableThread] = [],
@@ -208,16 +209,16 @@ def run_server(
     app = web.Application(middlewares=[encode_exception])
     app.add_routes([
         web.get('/', hello_reply),
-        web.post('/', process_ha_states(queue, consul_util)),
+        web.post('/', process_ha_states(planner, consul_util)),
         web.post(
             '/watcher/bq',
             process_bq_update(inbox_filter,
-                              BQProcessor(queue, herald, conf_obj))),
-        web.post('/api/v1/sns/{operation}', process_sns_operation(queue)),
+                              BQProcessor(planner, herald, conf_obj))),
+        web.post('/api/v1/sns/{operation}', process_sns_operation(planner)),
         web.get('/api/v1/sns/repair-status',
-                get_sns_status(queue, SnsRepairStatus)),
+                get_sns_status(planner, SnsRepairStatus)),
         web.get('/api/v1/sns/rebalance-status',
-                get_sns_status(queue, SnsRebalanceStatus)),
+                get_sns_status(planner, SnsRebalanceStatus)),
     ])
     LOG.info(f'Starting HTTP server at {web_address}:{port} ...')
     try:
@@ -225,6 +226,7 @@ def run_server(
         LOG.debug('Server stopped normally')
     finally:
         LOG.debug('Stopping the threads')
+        # [KN] FIXME Implement shutdown in WorkPlanner
         for thread in threads_to_wait:
             thread.stop()
         for thread in threads_to_wait:

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -226,7 +226,7 @@ def run_server(
         LOG.debug('Server stopped normally')
     finally:
         LOG.debug('Stopping the threads')
-        # [KN] FIXME Implement shutdown in WorkPlanner
+        planner.shutdown()
         for thread in threads_to_wait:
             thread.stop()
         for thread in threads_to_wait:

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -169,13 +169,6 @@ HaNote = NamedTuple('HaNote', [('obj_t', str), ('note', HaNoteStruct)])
 # struct m0_stob_id
 StobId = NamedTuple('StobId', [('domain_fid', Fid), ('fid', Fid)])
 
-# struct m0_stob_ioq_error
-StobIoqError = NamedTuple('StobIoqError', [('fid', Fid), ('conf_sdev', Fid),
-                                           ('stob_id', StobId), ('fd', int),
-                                           ('opcode', int), ('rc', int),
-                                           ('offset', int), ('size', int),
-                                           ('bshift', int)])
-
 # SnsRepairStatusItem = NamedTuple('SnsRepairStatusItem', [('fid', Fid),
 #                                                          ('status', str),
 #                                                          ('progress', int)])

--- a/hax/test/test_work_planner.py
+++ b/hax/test/test_work_planner.py
@@ -116,7 +116,7 @@ class TestMessageOrder(unittest.TestCase):
                      active_commands=LinkedList(),
                      taken_commands=LinkedList(),
                      current_group_id=99999,
-                     next_group_commands=LinkedSet(),
+                     next_group_commands=set(),
                      is_shutdown=False)
 
         planner = WorkPlanner(init_state_factory=my_state)
@@ -358,7 +358,7 @@ class TestWorkPlanner(unittest.TestCase):
                      active_commands=LinkedList(),
                      taken_commands=LinkedList(),
                      current_group_id=99999,
-                     next_group_commands=LinkedSet(),
+                     next_group_commands=set(),
                      is_shutdown=False)
 
         planner = WorkPlanner(init_state_factory=my_state)

--- a/hax/test/test_work_planner.py
+++ b/hax/test/test_work_planner.py
@@ -32,7 +32,7 @@ from hax.message import (BaseMessage, BroadcastHAStates, Die,
                          EntrypointRequest, FirstEntrypointRequest,
                          HaNvecGetEvent)
 from hax.motr.planner import WorkPlanner, State
-from hax.motr.util import LinkedSet
+from hax.motr.util import LinkedList
 from hax.types import Fid, HaLinkMessagePromise, MessageId, Uint128
 
 LOG = logging.getLogger('hax')
@@ -113,8 +113,8 @@ class TestMessageOrder(unittest.TestCase):
     def test_group_id_cycled(self):
         def my_state():
             return State(next_group_id=99999,
-                     active_commands=LinkedSet(),
-                     taken_commands=LinkedSet(),
+                     active_commands=LinkedList(),
+                     taken_commands=LinkedList(),
                      current_group_id=99999,
                      next_group_commands=LinkedSet(),
                      is_shutdown=False)
@@ -355,8 +355,8 @@ class TestWorkPlanner(unittest.TestCase):
 
         def my_state():
             return State(next_group_id=99999,
-                     active_commands=LinkedSet(),
-                     taken_commands=LinkedSet(),
+                     active_commands=LinkedList(),
+                     taken_commands=LinkedList(),
                      current_group_id=99999,
                      next_group_commands=LinkedSet(),
                      is_shutdown=False)

--- a/hax/test/test_work_planner.py
+++ b/hax/test/test_work_planner.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# flake8: noqa
+import logging
+import sys
+import time
+import unittest
+from threading import Condition, Thread
+from time import sleep
+from typing import List
+from unittest.mock import Mock
+
+from hax.exception import NotDelivered
+from hax.log import TRACE
+from hax.message import (BaseMessage, BroadcastHAStates, Die,
+                         EntrypointRequest, FirstEntrypointRequest,
+                         HaNvecGetEvent)
+from hax.motr.planner import WorkPlanner
+from hax.types import Fid, HaLinkMessagePromise, MessageId, Uint128
+
+LOG = logging.getLogger('hax')
+
+
+class GroupTracker:
+    def __init__(self):
+        self.lock = Condition()
+        self.data = []
+
+    def log(self, cmd: BaseMessage):
+        with self.lock:
+            self.data.append(cmd.group)
+
+    def get_tracks(self) -> List[BaseMessage]:
+        with self.lock:
+            return list(self.data)
+
+
+def entrypoint():
+    return EntrypointRequest(reply_context='test',
+                             req_id=Uint128(1, 2),
+                             remote_rpc_endpoint='endpoint',
+                             process_fid=Fid(1, 2),
+                             git_rev='HEAD',
+                             pid=123,
+                             is_first_request=False)
+
+
+def broadcast():
+    return BroadcastHAStates(states=[], reply_to=None)
+
+
+def nvec_get():
+    return HaNvecGetEvent(hax_msg=1, nvec=[])
+
+
+class TestMessageOrder(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # It seems like when unittest is invoked from setup.py,
+        # some default logging configuration is already applied;
+        # invoking setup_logging() will make the log messages to appear twice.
+        logging.addLevelName(TRACE, 'TRACE')
+        logging.getLogger('hax').setLevel(TRACE)
+
+    def test_entrypoint_requests_share_same_group(self):
+        planner = WorkPlanner()
+        ep1 = entrypoint()
+        ep2 = entrypoint()
+
+        ep1 = planner._assign_group(ep1)
+        ep2 = planner._assign_group(ep2)
+        self.assertEqual([0, 0], [ep1.group, ep2.group])
+
+    def test_entrypoint_not_paralleled_with_broadcast(self):
+        planner = WorkPlanner()
+        bcast = broadcast()
+        ep1 = entrypoint()
+
+        bcast = planner._assign_group(bcast)
+        ep1 = planner._assign_group(ep1)
+        self.assertEqual([0, 1], [bcast.group, ep1.group])
+
+    def test_broadcast_starts_new_group(self):
+        planner = WorkPlanner()
+
+        assign = planner._assign_group
+
+        msgs = [
+            assign(broadcast()),
+            assign(broadcast()),
+            assign(broadcast()),
+            assign(entrypoint())
+        ]
+        self.assertEqual([0, 1, 2, 3], [m.group for m in msgs])
+
+    def test_ha_nvec_get_shares_group_always(self):
+        planner = WorkPlanner()
+
+        assign = planner._assign_group
+
+        msgs_after_bc = [
+            assign(broadcast()),
+            assign(nvec_get()),
+            assign(broadcast()),
+            assign(entrypoint())
+        ]
+        msgs_after_ep = [
+            assign(entrypoint()),
+            assign(nvec_get()),
+            assign(broadcast()),
+            assign(entrypoint())
+        ]
+        msgs_after_nvec = [
+            assign(entrypoint()),
+            assign(nvec_get()),
+            assign(nvec_get()),
+            assign(entrypoint())
+        ]
+        self.assertEqual([0, 0, 1, 2], [m.group for m in msgs_after_bc])
+        self.assertEqual([2, 2, 3, 4], [m.group for m in msgs_after_ep])
+        self.assertEqual([4, 4, 4, 4], [m.group for m in msgs_after_nvec])
+
+
+class TestWorkPlanner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # It seems like when unittest is invoked from setup.py,
+        # some default logging configuration is already applied;
+        # invoking setup_logging() will make the log messages to appear twice.
+        logging.addLevelName(TRACE, 'TRACE')
+        logging.getLogger('hax').setLevel(TRACE)
+
+    def test_parallelism_is_possible(self):
+        planner = WorkPlanner()
+        for i in range(40):
+            planner.add_command(entrypoint())
+
+        for j in range(4):
+            planner.add_command(Die())
+
+        exc = None
+
+        def fn(planner: WorkPlanner):
+            try:
+                while True:
+                    LOG.log(TRACE, "Requesting for a work")
+                    cmd = planner.get_next_command()
+                    LOG.log(TRACE, "The command is received")
+                    if isinstance(cmd, Die):
+                        LOG.log(TRACE,
+                                "Poison pill is received - exiting. Bye!")
+                        break
+
+                    planner.ensure_allowed(cmd)
+                    LOG.log(TRACE, "I'm allowed to work on it!")
+                    sleep(0.5)
+                    LOG.log(TRACE, "The job is done, notifying the planner")
+                    planner.notify_finished(cmd)
+                    LOG.log(TRACE, "Notified. ")
+
+            except Exception as e:
+                LOG.exception('*** ERROR ***')
+                exc = e
+
+        workers = [Thread(target=fn, args=(planner, )) for t in range(4)]
+        time_1 = time.time()
+        for t in workers:
+            t.start()
+
+        for t in workers:
+            t.join()
+        time_2 = time.time()
+        logging.info('Processing time %s', time_2 - time_1)
+        if exc:
+            raise exc
+        self.assertTrue(planner.is_empty(), 'Not all commands were read out')
+        # Every thread sleeps for 500ms. 40 commands * 0.5 gives 20 seconds if the
+        # commands executed sequentially
+        self.assertLess(time_2 - time_1, 19, 'Suspiciously slow')
+
+    def test_groups_processed_sequentially_12_threads(self):
+        planner = WorkPlanner()
+        group_idx = 0
+
+        def ret_values(cmd: BaseMessage) -> bool:
+            nonlocal group_idx
+            # We don't care about the group distribution logic
+            # in this test. Instead, we concentrate how different group
+            # numbers are processed by the workers and the order
+            # in which they are allowed to process the messages.
+            #
+            # _assign_group is invoked under a lock acquired, so this
+            # increment is thread-safe.
+            values = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+            ret = bool(values[group_idx])
+            group_idx += 1
+            return ret
+
+        setattr(planner, '_should_increase_group',
+                Mock(side_effect=ret_values))
+        tracker = GroupTracker()
+        thread_count = 12
+        for i in range(10):
+            planner.add_command(entrypoint())
+
+        for j in range(thread_count):
+            planner.add_command(Die())
+
+        exc = None
+
+        def fn(planner: WorkPlanner):
+            try:
+                while True:
+                    LOG.log(TRACE, "Requesting for a work")
+                    cmd = planner.get_next_command()
+                    LOG.log(TRACE, "The command is received %s [group=%s]",
+                            type(cmd), cmd.group)
+
+                    planner.ensure_allowed(cmd)
+                    LOG.log(TRACE, "I'm allowed to work on it!")
+                    if isinstance(cmd, Die):
+                        LOG.log(TRACE,
+                                "Poison pill is received - exiting. Bye!")
+                        planner.notify_finished(cmd)
+                        break
+                    tracker.log(cmd)
+                    LOG.log(TRACE, "The job is done, notifying the planner")
+                    planner.notify_finished(cmd)
+                    LOG.log(TRACE, "Notified. ")
+
+            except Exception as e:
+                LOG.exception('*** ERROR ***')
+                exc = e
+
+        workers = [
+            Thread(target=fn, args=(planner, )) for t in range(thread_count)
+        ]
+        for t in workers:
+            t.start()
+
+        for t in workers:
+            t.join()
+        if exc:
+            raise exc
+        groups_processed = tracker.get_tracks()
+        self.assertEqual([0, 1, 1, 2, 2, 3, 3, 4, 4, 5], groups_processed)
+
+    def test_groups_processed_sequentially_4_threads(self):
+        planner = WorkPlanner()
+        group_idx = 0
+
+        def ret_values(cmd: BaseMessage) -> bool:
+            nonlocal group_idx
+            # We don't care about the group distribution logic
+            # in this test. Instead, we concentrate how different group
+            # numbers are processed by the workers and the order
+            # in which they are allowed to process the messages.
+            #
+            # _assign_group is invoked under a lock acquired, so this
+            # increment is thread-safe.
+            values = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+            ret = bool(values[group_idx])
+            group_idx += 1
+            return ret
+
+        setattr(planner, '_should_increase_group',
+                Mock(side_effect=ret_values))
+        tracker = GroupTracker()
+        thread_count = 4
+        for i in range(10):
+            planner.add_command(entrypoint())
+
+        for j in range(thread_count):
+            planner.add_command(Die())
+
+        exc = None
+
+        def fn(planner: WorkPlanner):
+            try:
+                while True:
+                    LOG.log(TRACE, "Requesting for a work")
+                    cmd = planner.get_next_command()
+                    LOG.log(TRACE, "The command is received %s [group=%s]",
+                            type(cmd), cmd.group)
+
+                    planner.ensure_allowed(cmd)
+                    LOG.log(TRACE, "I'm allowed to work on it!")
+                    if isinstance(cmd, Die):
+                        LOG.log(TRACE,
+                                "Poison pill is received - exiting. Bye!")
+                        planner.notify_finished(cmd)
+                        break
+                    tracker.log(cmd)
+                    LOG.log(TRACE, "The job is done, notifying the planner")
+                    planner.notify_finished(cmd)
+                    LOG.log(TRACE, "Notified. ")
+
+            except Exception as e:
+                LOG.exception('*** ERROR ***')
+                exc = e
+
+        workers = [
+            Thread(target=fn, args=(planner, )) for t in range(thread_count)
+        ]
+        for t in workers:
+            t.start()
+
+        for t in workers:
+            t.join()
+        if exc:
+            raise exc
+        groups_processed = tracker.get_tracks()
+        self.assertEqual([0, 1, 1, 2, 2, 3, 3, 4, 4, 5], groups_processed)


### PR DESCRIPTION
Jira ticket: [EOS-19373](https://jts.seagate.com/browse/EOS-19373) 

Currently we have only one Motr-aware thread (ConsumerThread) that reads out `queue.Queue`, gets BaseMessage from it and interacts with Motr layer accordingly. In bigger installations one thread simply doesn't manage to process the flow of the messages fast (so that entrypoint requests can start delaying which is critical for Motr API).

As a solution. we want to add more consumer threads. There is one problem though: we can't blindly process the ordered messages in parallel to each other, sometimes the order matters. This patch proposes splitting the whole stream of such messages into continous partitions (or groups). Messages within the same partition can be handled in parallel without an issue. If a message belongs to one of the "next" partitions, that processing gets delayed until the previous partitions are processed fully.

More details on the algorithm and terminology can be found here: https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/178421786/22%2BPARHAX%2BParallel%2Bmessage%2Bprocessing%2Bin%2BHaX#Proposed-solution (Seagate internal).
