### PR TITLE
EOS-18795 'hctl status doesn't work after make devinstall'

### DIFF
--- a/hctl
+++ b/hctl
@@ -54,6 +54,10 @@ else
         die 'Hare is not installed, please run `make devinstall`.'
 fi
 
+if [[ -d $SRC_DIR/.py3venv ]]; then
+    source "$SRC_DIR/.py3venv/bin/activate"
+fi
+
 usage() {
     # NB: `local var=$(func)` expression ignores exit status of `func`
     # and always succeeds.


### PR DESCRIPTION
Solution: Sourcing py3venv and activating it.

1. 'Make devinstall' uses python ./setup.py develop. 
2. The "develop" mode doesn't create valid folders with pyc files in the venv. Instead, it creates .egg-link files. 
3. Those .egg-link files don't get considered even if PYTHONPATH is updated. But they are respected when virtual environment is activated.

Closes #1425 
Closes #1603

