### PR TITLE
EOS-18907: Implement "reset" and "cleanup" phase for Hare mini-provisioner

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -278,3 +278,6 @@ class Profile(NamedTuple):
     fid: Fid
     name: str
     pool_names: List[str]
+
+
+KeyDelete = NamedTuple('KeyDelete', [('name', str), ('recurse', bool)])

--- a/provisioning/miniprov/Makefile
+++ b/provisioning/miniprov/Makefile
@@ -101,10 +101,11 @@ flake8:
 	@$(PY_VENV); flake8 hare_mp
 
 .PHONY: mypy
+override MYPY_OPTS += --config-file mypy.ini
 mypy:
 	@$(call _info,Checking files with mypy)
 	@$(PY_VENV); \
-	 set -eu -o pipefail; MYPYPATH=../../stubs mypy $(MYPY_OPTS) hare_mp
+ 	 set -eu -o pipefail; MYPYPATH=../../stubs:../../hax mypy $(MYPY_OPTS) hare_mp
 
 # Functions ------------------------------------------- {{{1
 #

--- a/provisioning/miniprov/mypy.ini
+++ b/provisioning/miniprov/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.6
+check_untyped_defs = True
+
+[mypy-urllib3]
+ignore_missing_imports = True
+
+[mypy-urllib3.exceptions]
+ignore_missing_imports = True


### PR DESCRIPTION
'Reset' will delete entries from consul KV which are added by Hare
'Cleanup' will delete config(/var/lib/hare) and logs(/var/log/hare)