### PR TITLE
EOS-19656: Notify M0_NC_FAILED for motr configuration objects on server node failure

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -98,8 +98,6 @@ class ConsumerThread(StoppableThread):
                         # notifications, it may cause delay in cleanup
                         # activities.
                         continue
-                    else:
-                        current_status = ServiceHealth.STOPPED
                 if current_status == ServiceHealth.UNKNOWN:
                     # We got service status as UNKNOWN, that means hax was
                     # notified about process failure but hax couldn't

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -282,7 +282,6 @@ class Motr:
                 notify_devices = False
             notes += self._generate_sub_services(note, self.consul_util,
                                                  notify_devices)
-
         if not notes:
             return []
         message_ids: List[MessageId] = self._ffi.ha_broadcast(
@@ -344,7 +343,7 @@ class Motr:
             n.note.no_state = HaNoteStruct.M0_NC_ONLINE
             if (n.obj_t in (ObjT.PROCESS.name, ObjT.SERVICE.name)):
                 n.note.no_state = self.consul_util.get_conf_obj_status(
-                                      ObjT[n.obj_t], n.note.no_id.f_key)
+                    ObjT[n.obj_t], n.note.no_id.f_key)
             notes.append(n.note)
 
         LOG.debug('Replying ha nvec of length ' + str(len(event.nvec)))
@@ -362,7 +361,10 @@ class Motr:
         service_notes = [HaNoteStruct(no_id=x.fid.to_c(), no_state=new_state)
                          for x in service_list]
         if notify_devices:
+            # For process failure, we report failure for the corresponding
+            # node (enclosure) and CVGs.
             service_notes += self._generate_sub_disks(note, service_list, cns)
+            service_notes += self.notify_node_failure(note)
 
         return service_notes
 
@@ -380,6 +382,28 @@ class Motr:
             HaNoteStruct(no_id=x.to_c(), no_state=new_state)
             for x in disk_list
         ]
+
+    def notify_node_failure(self,
+                            proc_note: HaNoteStruct) -> List[HaNoteStruct]:
+        new_state = proc_note.no_state
+        proc_fid = Fid.from_struct(proc_note.no_id)
+        LOG.debug('Notifying node failure for process_fid=%s state=%s',
+                  proc_fid, new_state)
+
+        node = self.consul_util.get_process_node(proc_fid)
+
+        node_fid = self.consul_util.get_node_fid(node)
+        encl_fid = self.consul_util.get_node_encl_fid(node)
+        ctrl_fid = self.consul_util.get_node_ctrl_fid(node)
+        LOG.debug('node_fid: %s encl_fid: %s ctrl_fid: %s',
+                  node_fid, encl_fid, ctrl_fid)
+
+        notes = []
+        if node_fid and encl_fid and ctrl_fid:
+            notes = [HaNoteStruct(no_id=x.to_c(), no_state=new_state)
+                     for x in [node_fid, encl_fid, ctrl_fid]]
+
+        return notes
 
     def notify_hax_stop(self):
         LOG.debug('Notifying hax stop')


### PR DESCRIPTION
## Description
Jira - [EOS-19656](https://jts.seagate.com/browse/EOS-19656)
On server node failure notification, Hare needs to report M0_NC_FAILED for the corresponding motr configuration objects, viz: node, enclosure (post EOS-17599), controller, and drives to all the Motr processes including s3servers.

## Solution

 In `broadcast_ha_states()`, added a check for process failures.
- fetch node from the failed process fid
- fetch fids of all configuration objects
            fetch node fid
            fetch enclosure fid
            fetch controller fid
 - append all states (fid: status) to HaNoteStruct notes

which is further notified to motr processes.

**Note**:  **how to be sure that process failure is due to node failure?**
We don't need to. Logically node failure and process failure will have the same effect. 
If the node fails devices are not accessible, or even if the process fails we lose access to devices. Without ioservice, we cannot access the devices on that node so they are effectively failed.


### OUTPUT

journalctl logs
``` 04:39:07,389 [DEBUG] {qconsumer} Got BroadcastHAStates(states=[HAState(fid=0x7200000000000001:0x35, status=FAILED), HAState(fid=0x7200000000000001:0x9, status=OK)], reply_to=None) message from queue
 04:39:07,389 [INFO] {qconsumer} HA states: [HAState(fid=0x7200000000000001:0x35, status=FAILED), HAState(fid=0x7200000000000001:0x9, status=OK)]
 04:39:07,398 [DEBUG] {qconsumer} item.status warning
 04:39:07,413 [INFO] {qconsumer} node: ssc-vm-4899.colo.seagate.com proc: 0x7200000000000001:0x35 current status: ServiceHealth.FAILED
 04:39:07,421 [DEBUG] {qconsumer} Setting process status in KV: ssc-vm-c-1899.colo.seagate.com/processes/0x7200000000000001:0x35:{"state": "M0_CONF_HA_PROCESS_STOPPED"}
 04:39:07,435 [DEBUG] {qconsumer} item.status passing
 04:39:07,449 [INFO] {qconsumer} node: ssc-vm-c-1899.colo.seagate.com proc: 0x7200000000000001:0x9 current status: ServiceHealth.OK
 04:39:07,453 [DEBUG] {qconsumer} Broadcasting HA states [HAState(fid=0x7200000000000001:0x35, status=FAILED)] over ha_link
 04:39:07,458 [DEBUG] {qconsumer} Process fid=0x7200000000000001:0x35 encloses 2 services as follows: [FidWithType(fid=0x7300000000000001:0x37, service_type='confd'), FidWithType(fid=0x7300000000000001:0x36, service_type='rms')]
 04:39:07,458 [DEBUG] {qconsumer} Notifying node failure for process_fid=0x7200000000000001:0x35 state=2
 04:39:07,479 [DEBUG] {qconsumer} node_fid: 0x6e00000000000001:0x2f encl_fid: 0x6500000000000001:0x30 ctrl_fid: 0x6300000000000001:0x31
 04:39:07,485 [DEBUG] {qconsumer} proc fid=0x7200000000000001:0x35 encloses 0 disks with state 2 as follows: []
]:  d910   WARN  [ha/halon/interface.c:1111:m0_halon_interface_send]  hl=0x7f3d64008f10 ep=10.230.247.68@tcp:12345:1:1 epoch=0 tag=681 type=2
]:  d910   WARN  [ha/halon/interface.c:1111:m0_halon_interface_send]  hl=0x7f3d64043960 ep=10.230.247.68@tcp:12345:2:1 epoch=0 tag=31 type=2
]:  d910   WARN  [ha/halon/interface.c:1111:m0_halon_interface_send]  hl=0x7f3d6408e1d0 ep=10.230.247.68@tcp:12345:2:2 epoch=0 tag=19 type=2
]:  d910   WARN  [ha/halon/interface.c:1111:m0_halon_interface_send]  hl=0x7f3df018b8e0 ep=10.230.247.68@tcp:12345:4:1 epoch=0 tag=15 type=2
 04:39:07,485 [DEBUG] {qconsumer} Broadcast HA state complete with the following message_ids = [MessageId(0x7f3d64008f10, 681), MessageId(0x7f3d64043960, 31), MessageId(0x7f3d6408e1d0, 19), MessageId(0x7f3df018b8e0, 15)]
```