### PR TITLE
EOS-20754: scripts under libexec/ are not runnable when invoked by short name

### DIFF
--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -47,6 +47,14 @@ get_leader_node() {
         jq -r '.[] | .Node'
 }
 
+get_node_name() {
+    # hare/libexec is added to PATH env variable only by hctl 'grounding'
+    # script.
+    # In non-hctl context, the scripts should use absolute path instead
+    # when accessing scripts under hare/libexec/.
+    /opt/seagate/cortx/hare/libexec/node-name
+}
+
 cleanup() {
     # Nicely stop currently running RC handler (if any):
     pkill -9 -f 'consul watch.*prefix eq' || true
@@ -57,7 +65,7 @@ cleanup() {
 # If the session is already set - the leader is elected, so
 # there is nothing to do (except cleanup after ourself).
 get_session_id | grep -q ^- || {
-    if [[ $(get_leader_node) != $(node-name) ]]; then
+    if [[ $(get_leader_node) != $(get_node_name) ]]; then
         cleanup
     fi
     exit 0
@@ -67,7 +75,7 @@ cleanup
 
 # Create session with the service:confd Health Checker:
 create_session() {
-    local checks_a=($(consul kv get -recurse m0conf/nodes/$(node-name) |
+    local checks_a=($(consul kv get -recurse m0conf/nodes/$(get_node_name) |
                       egrep -w 'confd|ha' |
                       sed -r 's/.*processes.([0-9]+).*/"service:\1"/'))
     # Join array items into a comma-separated string.
@@ -96,7 +104,7 @@ while true; do
     sleep $((RANDOM % 10))
     SID=$(create_session || true)
     if [[ $SID ]]; then
-        consul kv put -acquire -session=$SID leader $(node-name) \
+        consul kv put -acquire -session=$SID leader $(get_node_name) \
                       2>/dev/null && break
         destroy_session $SID
     fi

--- a/utils/get-service-health
+++ b/utils/get-service-health
@@ -21,6 +21,10 @@ set -eu -o pipefail
 
 PROG=${0##*/}
 
+get_node_name() {
+    /opt/seagate/cortx/hare/libexec/node-name
+}
+
 usage() {
     cat <<EOF
 Usage: $PROG ID
@@ -47,6 +51,6 @@ case $1 in
 esac
 
 id=$1
-curl -Gs localhost:8500/v1/health/node/$(node-name) \
+curl -Gs localhost:8500/v1/health/node/$(get_node_name) \
     --data-urlencode "filter=CheckID == \"service:$id\"" |
     jq -r '.[].Status'

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -28,7 +28,7 @@ from typing import List, NamedTuple, Optional
 import simplejson
 from hax.types import ObjT
 
-from utils import get_local_nodename
+from utils import get_node_name
 
 Process = NamedTuple('Process', [('name', str), ('fid', str)])
 
@@ -108,7 +108,7 @@ def get_service_for_node(nodes: List[Node], node_name: str,
                          service: str) -> Optional[List[Process]]:
     # if node_name is not specified, then local node is used.
     if not node_name:
-        node_name = get_local_nodename()
+        node_name = get_node_name()
 
     # if service is not specified, return all the services for a node.
     if not service:

--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -55,6 +55,14 @@ def _get_processes_for_node() -> Dict[str, List[utils.Process]]:
     return processes
 
 
+@repeat_if_fails()
+def erase_rc_leader() -> None:
+    cns_util = ConsulUtil()
+    # fake leader value must match r'^elect[0-9]+$'
+    logging.info('Making sure that RC leader can be re-elected next time')
+    cns_util.kv.kv_put('leader', 'elect2805')
+
+
 def stop_all_with_consul(processes: Dict[str, List[utils.Process]],
                          leader_node: str):
     for svc in utils.shutdown_sequence:
@@ -89,6 +97,7 @@ def shutdown_cluster(skip_consul_stop: bool):
     (processes, leader_node) = _get_processes_for_cluster()
     stop_process(processes)
 
+    erase_rc_leader()
     if not skip_consul_stop:
         stop_all_with_consul(processes, leader_node)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -76,6 +76,9 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
     try:
         processes: Dict[str, List[Process]] = {}
         cns_util = ConsulUtil(raw_client=cns)
+
+        # TODO Can we replace cns_util.get_local_nodename()
+        # with get_node_name() function?
         is_local = node_name == cns_util.get_local_nodename()
 
         for node in cns.catalog.nodes()[1]:
@@ -159,13 +162,6 @@ def is_localhost(hostname: str) -> bool:
         return hostname in ('localhost', '127.0.0.1', name, f'{name}.local')
 
     return match_node_file() or match_localhost()
-
-
-def get_local_nodename() -> str:
-    process = subprocess.run("node-name", check=True,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    node_name = process.stdout.strip()
-    return node_name.decode('utf-8')
 
 
 def is_fake_leader_name(leader: str) -> bool:


### PR DESCRIPTION
All the scripts under libexec/ can be invoked by short name only in
the context of hctl script. In non-hctl context, the scripts should use
absolute path instead:

- elect-rc-leader invokes node-name and it doesn't work in context of
hctl.
- get-service-health also invokes node-name; it can be invoked directly
by Consul so node-name should be addressed by absolute path.
- utils/utils.py contains redundant invocation of node-name (by short
name). That function is removed.

