### PR TITLE
EOS-21028: hare_setup init and test stop cluster too soon

### DIFF
--- a/provisioning/mypy.ini
+++ b/provisioning/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.6
+check_untyped_defs = True
+
+[mypy-urllib3]
+ignore_missing_imports = True
+
+[mypy-urllib3.exceptions]
+ignore_missing_imports = True


### PR DESCRIPTION
After hare bootstrap, it is observed that some services although
reported started by systemd take some time to initialize and thus
start. If the cluster is shutdown before the services are started
during hare_setup init, it may leave the cluster in some
inconsistent state. Which may cause some issues during shutdown or
startup at later point of time by HA.
Presently hare_setup init and test functions only check `hctl status`
and thus systemd output and not the processes state in Consul KV.

Solution:
Check Consul KV status and wait until all the processes are transitioned
to `M0_CONF_HA_PROCESS_STARTED`.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>