### PR TITLE
EOS-20675 Populate allowed_failures vector in CDF

### DIFF
--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -17,6 +17,14 @@ let NodeInfo =
       , s3_instances : Natural
       }
 
+let AllowedFailures =
+      { site : Natural
+      , rack : Natural
+      , encl : Natural
+      , ctrl : Natural
+      , disk : Natural
+      }
+
 let PoolInfo =
       { name : Text
       , disk_refs : Optional (List T.DiskRef)
@@ -24,6 +32,7 @@ let PoolInfo =
       , parity_units : Natural
       , spare_units : Optional Natural
       , type : T.PoolType
+      , allowed_failures: Optional AllowedFailures
       }
 
 let ProfileInfo =
@@ -56,14 +65,7 @@ let toPoolDesc
           , data_units = p.data_units
           , parity_units = p.parity_units
           , spare_units = p.spare_units
-          , allowed_failures =
-                    None
-                      { ctrl : Natural
-                      , disk : Natural
-                      , encl : Natural
-                      , rack : Natural
-                      , site : Natural
-                      }
+          , allowed_failures = p.allowed_failures
           }
 
 let genCdf

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -38,7 +38,9 @@
         }
       },
       "s3_instances": "1",
+      "storage_set_id": "storage1",
       "storage": {
+        "cvg_count": "2",
         "cvg": [
           {
             "data_devices": [
@@ -77,7 +79,9 @@
         }
       },
       "s3_instances": "1",
+      "storage_set_id": "storage1",
       "storage": {
+        "cvg_count": "2",
         "cvg": [
           {
             "data_devices": [
@@ -116,7 +120,9 @@
         }
       },
       "s3_instances": "1",
+      "storage_set_id": "storage1",
       "storage": {
+        "cvg_count": "2",
         "cvg": [
           {
             "data_devices": [

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -118,6 +118,15 @@ class DiskRef(DhallTuple):
 
 
 @dataclass(repr=False)
+class AllowedFailures(DhallTuple):
+    site: int
+    rack: int
+    encl: int
+    ctrl: int
+    disk: int
+
+
+@dataclass(repr=False)
 class PoolDesc(DhallTuple):
     name: Text
     disk_refs: Maybe[DList[DiskRef]]
@@ -125,6 +134,7 @@ class PoolDesc(DhallTuple):
     parity_units: int
     spare_units: Maybe[int]
     type: PoolType
+    allowed_failures: Maybe[AllowedFailures]
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/hare_mp/validator.py
+++ b/provisioning/miniprov/hare_mp/validator.py
@@ -35,7 +35,7 @@ class Validator:
     def is_first_node_in_storage_set(self) -> bool:
         machine_id = self._get_machine_id()
         cluster_id = self.provider.get_cluster_id()
-        storage_set_id = self.provider.get_storage_set_id()
+        storage_set_id = self.provider.get_storage_set_index()
         server_nodes_key: str = (f'cluster>{cluster_id}>'
                                  f'storage_set[{storage_set_id}]>server_nodes')
         server_nodes = self.provider.get(server_nodes_key)


### PR DESCRIPTION
In CORTX, data is distributed over targets (devices) using layout. Layout is computed from input erasure coding configuration of N, K and S.
In CORTX, any component can fail and it can be mapped to following failure domains

- Node, Cylindrical Volume Group (CVG) and Disk (few more like Site and Rack).

As data is distributed  according to erasure coding configuration we can allow some number of failure for above domains(e.g. CVG)

Now we need to calculate this allowed failure vector based on erasure coding configuration, number of nodes and number of CVG per node and  populate this info in CDF so that it can be used by motr.

For exact formula used to calculate allowed failure vector refer to https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/127893680/CORTX+Durability+Configuration#Deployment-Config