### PR TITLE
EOS-21433 cfgen: add support for FDMI filters

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2302,8 +2302,9 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         ConfProfile.build(conf, root_id, prof)
 
     if 'fdmi_filters' in cluster_desc:
-        for fdmi_filter in cluster_desc['fdmi_filters']:
-            ConfFdmiFltGrp.build(conf, root_id, fdmi_filter, other_clients)
+        if cluster_desc['fdmi_filters'] is not None:
+            for fdmi_filter in cluster_desc['fdmi_filters']:
+                ConfFdmiFltGrp.build(conf, root_id, fdmi_filter, other_clients)
 
     validate_m0conf(conf)
     assert cluster.consul_servers

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -196,6 +196,24 @@ profiles:  # This section is optional.  If it is missing, a single "default"
            # profile referring to all pools will be created.
   - name: <str>
     pools: [ <str> ]
+
+# FDMI filter defines if an FDMI record would be sent from FDMI source to FDMI
+# plugin. Only M0_FDMI_FILTER_TYPE_KV_SUBSTRING filters are supported.
+#
+fdmi_filters:  # This section is optional.  If it is missing, no fdmi filters
+               # would be defined
+  - name: <str>  # Human-readable name of the filter
+    node: <str>  # Hostname of the node that hosts FDMI plugin
+                 # that would receive every FDMI record this filter matches
+    client_index: <int>  # 0-based index of the client that would be
+                         # the FDMI plugin. Only "other" clients could be FDMI
+                         # plugins. "s3" clients are not used to for this
+                         # index.
+                         # The client has to be defined in m0_clients section
+                         # already.
+    substrings: [ <str> ]  # List of strings for FDMI plugin to match
+                           # See m0_conf_fdmi_filter::ff_substrings
+                           # for the reference. May be empty or absent.
 ...  # end of the document (optional)""")
         sys.exit()
 
@@ -332,6 +350,8 @@ def validate_cluster_desc(desc: Dict[str, Any]) -> None:
     validate_pools_desc(desc['pools'])
     if 'profiles' in desc:
         validate_profiles_desc(desc['profiles'], desc['pools'])
+    if 'fdmi_filters' in desc and desc['fdmi_filters'] is not None:
+        validate_fdmi_filters_desc(desc['fdmi_filters'], desc['nodes'])
 
 
 def validate_nodes_desc(nodes_desc: List[Dict[str, Any]]) -> None:
@@ -492,6 +512,33 @@ def validate_profiles_desc(profiles_desc: List[Dict[str, Any]],
                     ', '.join(bad))
         assert all_unique(pools), \
             f'Profile {name!r} has non-unique pool references'
+
+
+def validate_fdmi_filters_desc(fdmi_filters_desc: List[Dict[str, Any]],
+                               nodes_desc: List[Dict[str, Any]]) \
+        -> None:
+    assert all_unique(x['name'] for x in fdmi_filters_desc), \
+        'FDMI filter names are not unique:\n' + \
+        '\n'.join('  ' + x['name'] for x in fdmi_filters_desc)
+    assert all(x['name'] for x in fdmi_filters_desc), \
+        'FDMI filter name must not be empty'
+
+    Node = NamedTuple('Node', [('name', str), ('clients_nr', int)])
+    nodes = [Node(name=x['hostname'], clients_nr=x['m0_clients']['other'])
+             for x in nodes_desc]
+
+    for fdmi_filter_desc in fdmi_filters_desc:
+        node = fdmi_filter_desc['node']
+        client_index = fdmi_filter_desc['client_index']
+        assert node, f"FDMI filter {fdmi_filter_desc} " \
+            "doesn't refer to any node"
+        matching_nodes = [n for n in nodes if n.name == node]
+        assert len(matching_nodes) == 1, \
+            (f"FDMI filter have exactly one node: {fdmi_filter_desc}",
+             matching_nodes)
+        assert client_index < matching_nodes[0].clients_nr, \
+            "FDMI filter m0_clients index is out of bound: " \
+            f"client_index={client_index}, node={matching_nodes[0]}"
 
 
 @lru_cache(maxsize=1)
@@ -717,15 +764,18 @@ class ConfRoot(ToDhall):
     _downlinks = {Downlink('nodes', ObjT.node),
                   Downlink('sites', ObjT.site),
                   Downlink('pools', ObjT.pool),
-                  Downlink('profiles', ObjT.profile)}  # XXX + fdmi_flt_grps
+                  Downlink('profiles', ObjT.profile),
+                  Downlink('fdmi_flt_grps', ObjT.fdmi_flt_grp)}
 
     def __init__(self, nodes: List[Oid], sites: List[Oid], pools: List[Oid],
-                 profiles: List[Oid], mdpool: Oid = None,
+                 profiles: List[Oid],
+                 fdmi_flt_grps: List[Oid], mdpool: Oid = None,
                  mdredundancy: int = 0, imeta_pver: Oid = None):
         assert all(x.type is ObjT.node for x in nodes)
         assert all(x.type is ObjT.site for x in sites)
         assert all(x.type is ObjT.pool for x in pools)
         assert all(x.type is ObjT.profile for x in profiles)
+        assert all(x.type is ObjT.fdmi_flt_grp for x in fdmi_flt_grps)
         assert mdpool is None or mdpool.type is ObjT.pool
         assert imeta_pver is None or imeta_pver.type is ObjT.pver
 
@@ -733,6 +783,7 @@ class ConfRoot(ToDhall):
         self.sites = sites
         self.pools = pools
         self.profiles = profiles
+        self.fdmi_flt_grps = fdmi_flt_grps
         self.mdpool = mdpool
         self.mdredundancy = mdredundancy
         self.imeta_pver = imeta_pver
@@ -742,6 +793,7 @@ class ConfRoot(ToDhall):
                           f'sites={self.sites}',
                           f'pools={self.pools}',
                           f'profiles={self.profiles}',
+                          f'fdmi_flt_grps={self.fdmi_flt_grps}',
                           f'mdpool={self.mdpool}',
                           f'mdredundancy={self.mdredundancy}',
                           f'imeta_pver={self.imeta_pver}'])
@@ -759,14 +811,15 @@ class ConfRoot(ToDhall):
             f'nodes = {oids_to_dhall(self.nodes)}',
             f'sites = {oids_to_dhall(self.sites)}',
             f'pools = {oids_to_dhall(self.pools)}',
-            f'profiles = {oids_to_dhall(self.profiles)}'
-        ])
+            f'profiles = {oids_to_dhall(self.profiles)}',
+            f'fdmi_flt_grps = {oids_to_dhall(self.fdmi_flt_grps)}'])
         return '{ %s }' % args
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any]) -> Oid:
         root_id = new_oid(ObjT.root)
-        m0conf[root_id] = cls(nodes=[], sites=[], pools=[], profiles=[])
+        m0conf[root_id] = cls(nodes=[], sites=[], pools=[], profiles=[],
+                              fdmi_flt_grps=[])
         return root_id
 
 
@@ -1744,6 +1797,93 @@ class ConfProfile(ToDhall):
         return prof_id
 
 
+class ConfFdmiFltGrp(ToDhall):
+    _objt = ObjT.fdmi_flt_grp
+    _downlinks: Set[Downlink] = set()
+
+    def __init__(self, rec_type: int, fdmi_filters: List[Oid]):
+        assert all(x.type is ObjT.fdmi_filter for x in fdmi_filters)
+        self.rec_type = rec_type
+        self.fdmi_filters = fdmi_filters
+
+    def __repr__(self):
+        args = ', '.join([f'rec_type={self.rec_type}',
+                          f'fdmi_filters={self.fdmi_filters!r}'])
+        return f'{self.__class__.__name__}({args})'
+
+    def to_dhall(self, oid: Oid) -> str:
+        assert oid.type is ObjT.fdmi_flt_grp
+        args = ', '.join([f'id = {oid_to_dhall(oid)}',
+                          f'rec_type = {self.rec_type}',
+                          f'filters = {oids_to_dhall(self.fdmi_filters)}'])
+        return f'{{ {args} }}'
+
+    @classmethod
+    def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
+              fdmi_filter_desc: Dict[str, Any],
+              other_clients: Dict[str, List[Tuple[Oid, Oid]]]) -> Oid:
+        assert parent.type is ObjT.root
+
+        fdmi_flt_grp_id = new_oid(ObjT.fdmi_flt_grp)
+        fdmi_filter_oid = ConfFdmiFilter.build(
+            m0conf, parent, fdmi_flt_grp_id, fdmi_filter_desc, other_clients)
+        # rec_type=0x1000 is M0_FDMI_REC_TYPE_FOL
+        m0conf[fdmi_flt_grp_id] = cls(rec_type=0x1000,
+                                      fdmi_filters=[fdmi_filter_oid])
+        m0conf[parent].fdmi_flt_grps.append(fdmi_flt_grp_id)
+        return fdmi_flt_grp_id
+
+
+class ConfFdmiFilter(ToDhall):
+    _objt = ObjT.fdmi_filter
+    _downlinks: Set[Downlink] = set()
+
+    def __init__(self, dix_pver: Oid, node: Oid,
+                 substrings: List[str], endpoint: str):
+        self.dix_pver = dix_pver
+        self.node = node
+        self.substrings = substrings
+        self.endpoint = endpoint
+
+    def __repr__(self):
+        args = ', '.join([f'dix_pver={self.dix_pver}',
+                          f'substrings={self.substrings}]',
+                          f'endpoint={self.endpoint}'])
+        return f'{self.__class__.__name__}({args})'
+
+    def to_dhall(self, oid: Oid) -> str:
+        assert oid.type is ObjT.fdmi_filter
+
+        substrings = '[' + ', '.join([f'"{s}"' for s in self.substrings]) + ']'
+        args = ', '.join([f'id = {oid_to_dhall(oid)}',
+                          # 2 is M0_FDMI_FILTER_TYPE_KV_SUBSTRING
+                          'filter_type = 2',
+                          f'filter_id = {oid_to_dhall(oid)}',
+                          'filter_root = ""',
+                          f'node = {oid_to_dhall(self.node)}',
+                          f'dix_pver = {oid_to_dhall(self.dix_pver)}',
+                          f'substrings = {substrings} : List Text',
+                          f'endpoints = ["{self.endpoint}"]'])
+        return f'{{ {args} }}'
+
+    @classmethod
+    def build(cls, m0conf: Dict[Oid, Any], root: Oid, parent: Oid,
+              fdmi_filter_desc: Dict[str, Any],
+              other_clients: Dict[str, List[Tuple[Oid, Oid]]]) -> Oid:
+        assert parent.type is ObjT.fdmi_flt_grp
+
+        fdmi_filter_oid = new_oid(ObjT.fdmi_filter)
+        node_oid, process_oid = other_clients[
+            fdmi_filter_desc['node']][int(fdmi_filter_desc['client_index'])]
+        process = m0conf[process_oid]
+        m0conf[fdmi_filter_oid] = cls(
+            dix_pver=m0conf[root].imeta_pver,
+            node=node_oid,
+            substrings=fdmi_filter_desc['substrings'],
+            endpoint=str(process.endpoint))
+        return fdmi_filter_oid
+
+
 ConsulAgent = NamedTuple('ConsulAgent', [('node_name', str), ('ipaddr', str)])
 
 Cluster = NamedTuple('Cluster', [('m0conf', Dict[Oid, Any]),
@@ -2080,6 +2220,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     rack_id = ConfRack.build(conf, ConfSite.build(conf, root_id))
 
+    other_clients: Dict[str, List[Tuple[Oid, Oid]]] = {}
+
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
         encl_id = ConfEnclosure.build(conf, rack_id, node_id)
@@ -2112,6 +2254,10 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
             for _ in range(node['m0_clients'][client_t]):
                 proc_id = ConfProcess.build(conf, node_id, node, proc_t)
                 cluster.m0_clients[proc_id] = new_oid(ObjT.service)
+                if client_t == 'other':
+                    if node['hostname'] not in other_clients:
+                        other_clients[node['hostname']] = []
+                    other_clients[node['hostname']].append((node_id, proc_id))
 
     for pool in cluster_desc['pools']:
         pool_t = pool_type(pool)
@@ -2154,6 +2300,10 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                           for pool_name in prof['pools']
                           for aux_pool in aux_pools.get(pool_name, [])]
         ConfProfile.build(conf, root_id, prof)
+
+    if 'fdmi_filters' in cluster_desc:
+        for fdmi_filter in cluster_desc['fdmi_filters']:
+            ConfFdmiFltGrp.build(conf, root_id, fdmi_filter, other_clients)
 
     validate_m0conf(conf)
     assert cluster.consul_servers

--- a/cfgen/dhall/render/FdmiFilter.dhall
+++ b/cfgen/dhall/render/FdmiFilter.dhall
@@ -30,8 +30,11 @@ in
  ++ Prelude.Text.concatSep " "
       [ ./Oid.dhall x.id
       , named.Oid "id" x.filter_id
+      , named.Natural "type" x.filter_type
       , named.Text "root" x.filter_root
       , named.Oid "node" x.node
+      , named.Oid "dix_pver" x.dix_pver
+      , named.Texts "substrings" x.substrings
       , named.Texts "endpoints" x.endpoints
       ]
  ++ ")"

--- a/cfgen/dhall/render/Root.dhall
+++ b/cfgen/dhall/render/Root.dhall
@@ -41,6 +41,6 @@ in
       , named.Oids "sites" x.sites
       , named.Oids "pools" x.pools
       , named.Oids "profiles" x.profiles
-      , "fdmi_flt_grps=[]"
+      , named.Oids "fdmi_flt_grps" x.fdmi_flt_grps
       ]
  ++ ")"

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -46,6 +46,7 @@
 , FailVec      = ./types/FailVec.dhall
 , PoolType     = ./types/PoolType.dhall
 , PoolsRef     = ./types/PoolsRef.dhall
+, FdmiFilterDesc = ./types/FdmiFilterDesc.dhall
 
 , Obj         = ./types/Obj.dhall
 , ObjT        = ./types/ObjT.dhall

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -28,4 +28,5 @@ in
 { nodes : List Node
 , pools : List Pool
 , profiles : Optional (List ./PoolsRef.dhall)
+, fdmi_filters: Optional (List ./FdmiFilterDesc.dhall)
 }

--- a/cfgen/dhall/types/FdmiFilter.dhall
+++ b/cfgen/dhall/types/FdmiFilter.dhall
@@ -23,8 +23,11 @@ let Oid = ./Oid.dhall
 in
 -- m0_confx_fdmi_filter
 { id : Oid
+, filter_type : Natural
 , filter_id : Oid  -- XXX s/Oid/Fid/
 , filter_root : Text
 , node : Oid  -- XXX s/Oid/Fid/
+, dix_pver : Oid  -- XXX s/Oid/Fid/
+, substrings : List Text
 , endpoints : List Text
 }

--- a/cfgen/dhall/types/FdmiFilterDesc.dhall
+++ b/cfgen/dhall/types/FdmiFilterDesc.dhall
@@ -18,17 +18,8 @@
 
 -}
 
-let Oid = ./Oid.dhall
-
-in
--- m0_confx_root
-{ id : Oid
-, mdpool : Oid
-, imeta_pver : Optional Oid
-, mdredundancy : Natural
-, nodes : List Oid
-, sites : List Oid
-, pools : List Oid
-, profiles : List Oid
-, fdmi_flt_grps : List Oid
+{ name : Text
+, node : Text
+, client_index : Natural
+, substrings : List Text
 }

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -47,3 +47,8 @@ pools:
 #profiles:
 #  - name: default
 #    pools: [ the pool ]
+#fdmi_filters:
+#  - name: test
+#    node: localhost
+#    client_index: 1
+#    substrings: ["Bucket-Name", "Object-Name", "Object-URI"]

--- a/cfgen/tests/sample-confd.dhall
+++ b/cfgen/tests/sample-confd.dhall
@@ -120,6 +120,7 @@ let root = types.Obj.Root
   , sites = [ids.site]
   , pools = [ids.pool_69, ids.pool_48, ids.pool_1]
   , profiles = [ids.profile]
+  , fdmi_flt_grps = [] : List types.Oid
   }
 
 let node = types.Obj.Node

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -71,4 +71,5 @@ in
       }
     ]
 , profiles = None (List types.PoolsRef)
+, fdmi_filters = None (List types.FdmiFilterDesc)
 } : types.ClusterDesc

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -47,7 +47,9 @@ ObjT = Enum(
         ('CONTROLLER', 0x6300000000000001),
         ('ROOT', 0x7400000000000001),
         ('POOL', 0x6f00000000000001),
-        ('PVER', 0x7600000000000001)
+        ('PVER', 0x7600000000000001),
+        ('FDMI_FILTER', 0x6c00000000000001),
+        ('FDMI_FLT_GRP', 0x6700000000000001),
     ])
 ObjT.__doc__ = 'Motr conf object types and their m0_fid.f_container values'
 

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -9,7 +9,8 @@ import pkg_resources
 from hare_mp.store import ValueProvider
 from hare_mp.types import (ClusterDesc, DiskRef, DList, Maybe, NodeDesc,
                            PoolDesc, PoolType, ProfileDesc, Protocol, Text,
-                           M0ServerDesc, DisksDesc, AllowedFailures, Layout)
+                           M0ServerDesc, DisksDesc, AllowedFailures, Layout,
+                           FdmiFilterDesc)
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
 DHALL_EXE = '/opt/seagate/cortx/hare/bin/dhall'
@@ -219,16 +220,22 @@ class CdfGenerator:
 
         return profiles
 
+    def _create_fdmi_filter_descriptions(
+            self, nodes: List[NodeDesc]) -> Maybe[List[FdmiFilterDesc]]:
+        return Maybe(None, 'List T.FdmiFilterDesc')
+
     def _get_cdf_dhall(self) -> str:
         dhall_path = self._get_dhall_path()
         nodes = self._create_node_descriptions()
         pools = self._create_pool_descriptions()
         profiles = self._create_profile_descriptions(pools)
+        fdmi_filters = self._create_fdmi_filter_descriptions(nodes)
 
         params_text = str(
             ClusterDesc(node_info=nodes,
                         pool_info=pools,
-                        profile_info=profiles))
+                        profile_info=profiles,
+                        fdmi_filter_info=fdmi_filters))
         gencdf = Template(self._gencdf()).substitute(path=dhall_path,
                                                      params=params_text)
         return gencdf

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -45,6 +45,7 @@ let ClusterInfo =
       { node_info: List NodeInfo
       , pool_info: List PoolInfo
       , profile_info: List ProfileInfo
+      , fdmi_filter_info: Optional (List T.FdmiFilterDesc)
       }
 
 let toNodeDesc
@@ -75,6 +76,7 @@ let genCdf
       ->  { nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
           , pools = Prelude.List.map PoolInfo T.PoolDesc toPoolDesc cluster_info.pool_info
           , profiles = Some cluster_info.profile_info
+          , fdmi_filters = cluster_info.fdmi_filter_info
           }
 
 in  genCdf

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -12,7 +12,7 @@ class Maybe(Generic[A]):
 
     def __str__(self):
         if self.value is None:
-            return f'None {self.comment}'
+            return f'None ({self.comment})'
 
         return f'Some ({self.value})'
 
@@ -145,10 +145,19 @@ class ProfileDesc(DhallTuple):
 
 
 @dataclass(repr=False)
+class FdmiFilterDesc(DhallTuple):
+    client_index: int
+    name: Text
+    node: Text
+    substrings: DList[Text]
+
+
+@dataclass(repr=False)
 class ClusterDesc(DhallTuple):
     node_info: List[NodeDesc]
     pool_info: List[PoolDesc]
     profile_info: List[ProfileDesc]
+    fdmi_filter_info: Maybe[List[FdmiFilterDesc]]
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -44,7 +44,7 @@ class TestTypes(unittest.TestCase):
 
     def test_maybe_none(self):
         val = Maybe(None, 'P')
-        self.assertEqual('None P', str(val))
+        self.assertEqual('None (P)', str(val))
         self.assertEqual('Some (P.tcp)', str(Maybe(Protocol.tcp, 'P')))
 
     def test_disks_empty(self):
@@ -52,7 +52,7 @@ class TestTypes(unittest.TestCase):
                            io_disks=DisksDesc(meta_data=Maybe(None, 'Text'),
                                               data=DList([], 'List Text')))
         self.assertEqual(
-            '{ runs_confd = Some (True), io_disks = { meta_data = None Text, data = [] : List Text } }',
+            '{ runs_confd = Some (True), io_disks = { meta_data = None (Text), data = [] : List Text } }',
             str(val))
 
     def test_pooldesc_empty(self):
@@ -76,7 +76,7 @@ class TestTypes(unittest.TestCase):
                 meta_data=Maybe(None, 'Text'),
                 data=DList([Text('/disk1'), Text('/disk2')], 'test')))
         self.assertEqual(
-            '{ runs_confd = Some (True), io_disks = { meta_data = None Text, data = ["/disk1", "/disk2"] } }',
+            '{ runs_confd = Some (True), io_disks = { meta_data = None (Text), data = ["/disk1", "/disk2"] } }',
             str(val))
 
 
@@ -836,4 +836,4 @@ class TestCDF(unittest.TestCase):
         cdf = CdfGenerator(provider=store, motr_provider=Mock())
         cdf._get_m0d_per_cvg = Mock(return_value=1)
         ret = cdf._create_node_descriptions()
-        self.assertEqual('None P', str(ret[0].data_iface_type))
+        self.assertEqual('None (P)', str(ret[0].data_iface_type))


### PR DESCRIPTION
Solution: add the code to configure the filters in CDF.

To use FDMI the following needs to be configured in CDF:

- FDMI plugin endpoint which will consume FDMI records sent by FDMI
  sources. Currently FDMI filter is one of Motr client processes;
- FDMI filters. `fdmi_filters` section defines filters and their FDMI
  plugin endpoints.

`cfgen/cfgen --help-schema` explains format of the `fdmi_filters`
section in CDF:

```
 # FDMI filter defines if an FDMI record would be sent from FDMI source to FDMI
 # plugin. Only M0_FDMI_FILTER_TYPE_KV_SUBSTRING filters are supported.
 #
fdmi_filters:  # This section is optional.  If it is missing, no fdmi filters
               # would be defined
  - name: <str>  # Human-readable name of the filter
    node: <str>  # Hostname of the node that hosts FDMI plugin
                 # that would receive every FDMI record this filter matches
    client_index: <int>  # 0-based index of the client that would be
                         # the FDMI plugin. Only "other" clients could be FDMI
                         # plugins. "s3" clients are not used to for this
                         # index.
                         # The client has to be defined in m0_clients section
                         # already.
    substrings: [ <str> ]  # List of strings for FDMI plugin to match
                           # See m0_conf_fdmi_filter::ff_substrings
                           # for the reference. May be empty or absent.
```

cfgen/examples/singlenode.yaml has an example of `fdmi_filters` section
commented. Uncomment it and run an FDMI plugin to start using an FDMI
filter.

If there is no fdmi_filters section then no fdmi filters would be added
to Motr configuration.

Signed-off-by: Maksym Medvied <maksym.medvied@seagate.com>