### PR TITLE
EOS-15353: Specfile allows invalid facter version

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -46,7 +46,7 @@ BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
 Requires: consul >= 1.7.0, consul < 1.10.0
-Requires: facter
+Requires: facter >= 3.14.8
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}
 Requires: python36


### PR DESCRIPTION
JIRA issue: [EOS-15353](https://jts.seagate.com/browse/EOS-15353)

Currently the hare.spec file doesn't specify explicit version for facter
tool. It turns out that older facter versions didn't handle labeled
network interfaces well.

Solution: set explicit requirement >= 3.14.8 in the specfile.