### PR TITLE
EOS-21119 Hare mini-provisioner reset phase does not shutdown the cluster

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -213,6 +213,10 @@ def reset(args):
         rc = 0
         util: ConsulUtil = ConsulUtil()
 
+        if is_cluster_running():
+            logging.info('Cluster is running, shutting down')
+            shutdown_cluster()
+
         keys: List[KeyDelete] = [KeyDelete(name='epoch', recurse=False),
                                  KeyDelete(name='eq-epoch', recurse=False),
                                  KeyDelete(name='last_fidk', recurse=False),


### PR DESCRIPTION
In 'reset' phase of hare we are cleaning up the data generated. We are deleting consul KV entries generated by Hare.
But before that we need to stop Hare services as they might keep generating more data.

We are calling 'hctl shutdown' to stop services if cluster is running

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>