### PR TITLE
Problem: newer mypy fails on Hare sources

### DIFF
--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -1,4 +1,11 @@
 #:build-requirements:
+types-PyYAML
+types-chardet
+types-dataclasses
+types-requests
+types-simplejson
+types-pkg_resources
+types-toml
 flake8
 mypy
 pkgconfig


### PR DESCRIPTION
Problem reason:
1. Hare doesn't specify explicit mypy version in its requirements
2. So once newer mypy version is released, it is applied automatically
if .py3venv/ folder doesn't exist (yet)
3. It turns out that mypy 0.901 stops bringing type stubs for libraries
by default. Corresponding type stubs should be installed explicitly.

Solution: add missing type-* libraries to the build requirements.

Note: these depedendencies are build-time only. Runtime dependencies are
not affected.

