### PR TITLE
EOS-19727: Map confd locations to consul servers

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -275,11 +275,13 @@ class CdfGenerator:
         # Adding a Motr confd entry per server node in CDF.
         # The `runs_confd` value (true/false) determines if Motr confd process
         # will be started on the node or not.
-        servers.value.append(M0ServerDesc(
-            io_disks=DisksDesc(
-                data=DList([], 'List Text'),
-                meta_data=Maybe(None, 'Text')),
-            runs_confd=Maybe(True, 'Bool')))
+        roles = store.get(f'server_node>{machine_id}>roles')
+        if 'consul_server' in roles:
+            servers.value.append(M0ServerDesc(
+                io_disks=DisksDesc(
+                    data=DList([], 'List Text'),
+                    meta_data=Maybe(None, 'Text')),
+                runs_confd=Maybe(True, 'Bool')))
 
         return NodeDesc(
             hostname=Text(hostname),


### PR DESCRIPTION
If Consul cluster is deployed separately, Hare needs to know the locations
of consul server nodes in order to decide if motr confd must be started on that
node or not.

Solution:
- Add `consul_server` as one of the roles to `server_node>{machine-id}>roles`
  in conf-store corresponding to the node that runs a consul agent in server mode.
  e.g.
  ```
  "server_node": {
    "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
      "cluster_id": "my-cluster",
      "hostname": "ssc-vm-1623.colo.seagate.com",
      "roles": [
        "primary",
        "openldap_server",
        "consul_server"
      ],
      "name": "srvnode-1",
      "network": {
        "data": {
          "interface_type": "tcp",
          "private_interfaces": [
            "eth0"
          ]
        }
      },
      "s3_instances": "2",
  ```
- Fetch roles from `server_node>{machine-id}>roles` and check for `consul_server`
  as one of the roles before configuring that node to run motr confd process.
