### PR TITLE
EOS-21102: Singlenode deployment will never succeed

### DIFF
--- a/utils/get-process-state
+++ b/utils/get-process-state
@@ -50,4 +50,8 @@ case $1 in
 esac
 
 fid=$1
-consul kv get $HOSTNAME/processes/$fid 2> /dev/null | jq -r '.state'
+get_node_name() {
+    /opt/seagate/cortx/hare/libexec/node-name
+}
+
+consul kv get $(get_node_name)/processes/$fid 2> /dev/null | jq -r '.state'


### PR DESCRIPTION
Problem: when hare-bootstrap script awaits for m0d processes to start,
it looks into Consul KV. The corresponding key looks as follows: $HOSTNAME/processes/$fid

In singlenode deployments $HOSTNAME is resolved to FQDN while in Consul
KV the corresponding node is known as 'localhost'.

As long as utils/get-process-state queries non-existent key, the output
is empty string (instead of desired 'M0_CONF_HA_PROCESS_STARTED').

Solution: use node-name script instead of $HOSTNAME variable.
