### PR TITLE
EOS-17954 : Implement "hare_setup upgrade" CLI

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -529,6 +529,11 @@ def main():
                    help_str='Validates configuration pre-requisites',
                    handler_fn=noop)
 
+    add_subcommand(subparser,
+                   'upgrade',
+                   help_str='Performs the Hare rpm upgrade tasks',
+                   handler_fn=noop)
+
     setup_logging()
 
     parsed = p.parse_args(sys.argv[1:])

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -20,5 +20,8 @@ hare:
   prepare:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup prepare
     args: --config $URL
+  upgrade:
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup upgrade
+    args: --config $URL
 support_bundle:
   - /opt/seagate/cortx/hare/bin/hare_setup support_bundle


### PR DESCRIPTION
Implement hare_setup upgrade command.
Currently it is set as no-operation as nothing is expected to be done.
Basic API provision is done.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>