### PR TITLE
Problem: gcc is not in BuildRequires of Specfile

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -37,6 +37,7 @@ Group: System Environment/Daemons
 Source: %{name}-%{h_version}.tar.gz
 
 BuildRequires: binutils-devel
+BuildRequires: gcc >= 4.8.5
 BuildRequires: git
 BuildRequires: cortx-motr
 BuildRequires: cortx-motr-devel


### PR DESCRIPTION
Hare does need gcc to link with Motr C API. By some reason our Specfile
didn't have explicit requirement on gcc compiler to be installed.

Solution: add gcc to BuildRequires list.

