### PR TITLE
Added steps to install cortx-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ and health-checking mechanisms.
      export M0_SRC_DIR=$PWD
      cd -
      ```
+* Install py-utils.
+  *  Follow the instructions [here](https://github.com/Seagate/cortx-utils/tree/main/py-utils)
 
 * Build and install `hare`.
   ```sh


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

Steps to install py-utils are essential to be able to `make` and `make install` HARE.

-----
[View rendered README.md](https://github.com/hessio/cortx-hare/blob/patch-5/README.md)