### PR TITLE
EOS-21337: Motr panic: (!pver->pv_is_dirty) at m0_cs_dix_setup() motr /setup_dix.c:347

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -855,7 +855,7 @@ class ConsulUtil:
              'Unknown'): (ServiceHealth.UNKNOWN, ServiceHealth.UNKNOWN),
             ('warning',
              'M0_CONF_HA_PROCESS_STOPPING'): (ServiceHealth.OFFLINE,
-                                              ServiceHealth.FAILED),
+                                              ServiceHealth.STOPPED),
             ('warning',
              'M0_CONF_HA_PROCESS_STARTED'): (ServiceHealth.OFFLINE,
                                              ServiceHealth.FAILED),
@@ -891,12 +891,15 @@ class ConsulUtil:
                     else:
                         status = svc_health[1]
 
-                    # This is situation is not expected but we handle
-                    # that same.
+                    # This situation is not expected but we handle
+                    # the same. Hax may end up here if the process has stopped
+                    # already and its current status is also reported as
+                    # 'unknown' by Consul. Hax will do nothing in this case
+                    # and will report OFFLINE for that process.
                     if (item['Status'] == 'warning' and
                             svc_consul_status == 'Unknown' and
                             status == ServiceHealth.UNKNOWN):
-                        status = ServiceHealth.FAILED
+                        status = ServiceHealth.OFFLINE
 
                     return status
         except (ConsulException, HTTPError, RequestException) as e:


### PR DESCRIPTION
When Consul reports a warning for a motr process to Hax, Hax checks the current
status of the given motr process and reports the status accordingly.
If the current status of the given Motr process evaluates to FAILED, Hax reports
FAILED for its corresponding devices (including CAS device) as well.
If this happens during bootstrap (specifically during mkfs as processes start and
stop), then CAS transaction fails due to lack of availability of a clean pool version
as Hax has reported FAILED for some of the devices in the pool version.

Solution:
- No need to report FAILED if Consul warning is received when process is
  STOPPING, instead report STOPPED for remote process and OFFLINE for local
  Motr process, because local hax establishes connections with only local
  Motr processes, so we don't want to close the connections from Hax side
  to early.
- If consul status and the current process status is reported as UNKNOWN,
  report OFFLINE instead of FAILED and the status is not clear (unknown).
  In case of OFFLINE, device failures are not reported.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>