### PR TITLE
EOS-21355: newer mypy version fails at Hare sources (cortx-1.0)

### DIFF
--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -1,6 +1,6 @@
 #:build-requirements:
-flake8
-mypy
+flake8==3.9.2
+mypy==0.812
 pkgconfig
 setuptools
 wheel

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -124,7 +124,7 @@ setup(
     name='hax',
     version=get_hax_version(),
     packages=find_packages(),
-    setup_requires=['flake8', 'mypy', 'pkgconfig'],
+    setup_requires=['flake8==3.9.2', 'mypy==0.812', 'pkgconfig'],
     install_requires=[
         'python-consul>=1.1.0', 'simplejson', 'aiohttp', 'click', 'dataclasses'
     ],


### PR DESCRIPTION
JIRA ticket: [EOS-21355](https://jts.seagate.com/browse/EOS-21355)

In Hare sources there is no specific requirement on mypy version. It
seems like the newer version 0.901 stops bringing type information (so
called type stubs) for standard libraries; those type stubs should be
installed separately.

Solution: stick mypy to version 0.812 in cortx-1.0 to avoid more
surprises in a release branch.

