### PR TITLE
Prevent name conflict when installing Motr RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ and health-checking mechanisms.
     cd cortx-motr
 
     scripts/m0 make rpms
-    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
+    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-2*.rpm
     ```
 
 * Build `hare` RPMs


### PR DESCRIPTION
Without this fix, we will get this error:
``` sh
error: Failed dependencies:
	cortx-motr conflicts with cortx-motr-tests-ut-2.0.0-1_gite28e4d3_3.10.0_1127.19.1.el7.x86_64
```

The reason is, when it tries to install `cortx-motr-*.rpm`, it finds two RPMs:
1.  `cortx-motr-2.0.0-1_gite28e4d3_3.10.0_1127.19.1.el7.x86_64.rpm`
2. `cortx-motr-tests-ut-2.0.0-1_gite28e4d3_3.10.0_1127.19.1.el7.x86_64.rpm`

The valid RPM of Motr should be the first one, thus I am adding `2` to prevent the regex catch the `cortx-motr-tests*`. Feel free to close this PR if you find another solution, such as preventing Motr to generate cortx-motr-tests-*.rpm in the first place. 
Thanks!

-----
[View rendered README.md](https://github.com/daniarherikurniawan/cortx-hare/blob/patch-2/README.md)