### PR TITLE
Update README.md to remove motr-test-*.rpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ and health-checking mechanisms.
     cd cortx-motr
 
     scripts/m0 make rpms
+    rm ~/rpmbuild/RPMS/x86_64/cortx-motr-test*.rpm
     sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
     ```
 


### PR DESCRIPTION
This PR is addressing this issue https://github.com/Seagate/cortx-hare/issues/1664. By removing the `motr-test-*.rpm`, we can safely install motr rpms by running `sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm`

-----
[View rendered README.md](https://github.com/daniarherikurniawan/cortx-hare/blob/patch-4/README.md)