### PR TITLE
EOS-21245 Improve hax testability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,12 +494,21 @@ check-cfgen: $(PY_VENV_DIR)
 	@$(call _info,Checking cfgen)
 	@$(PY_VENV); $(MAKE) --quiet -C cfgen flake8 typecheck
 
-.PHONY: check-hax
-check-hax: $(PY_VENV_DIR)
-	@$(call _info,Checking hax)
+.PHONY: test-hax
+test-hax: $(PY_VENV_DIR)
+	@$(call _info,Running hax autotests)
 	@cd hax &&\
 	  $(PY_VENV) &&\
-	  MYPYPATH=../stubs $(PYTHON) setup.py flake8 mypy test
+	  pytest -v test/
+
+.PHONY: lint-hax
+lint-hax: $(PY_VENV_DIR)
+	@cd hax &&\
+	  $(PY_VENV) &&\
+	  MYPYPATH=../stubs $(PYTHON) setup.py flake8 mypy
+
+.PHONY: check-hax
+check-hax: $(PY_VENV_DIR) lint-hax test-hax
 
 .PHONY: check-miniprov
 check-miniprov:

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -29,7 +29,7 @@ from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI
 from hax.motr.planner import WorkPlanner
 from hax.motr.rconfc import RconfcStarter
-from hax.server import run_server
+from hax.server import ServerRunner
 from hax.types import Fid, Profile
 from hax.util import ConsulUtil, repeat_if_fails
 
@@ -123,10 +123,9 @@ def main():
         stats_updater = _run_stats_updater_thread(motr, consul_util=util)
         # [KN] This is a blocking call. It will work until the program is
         # terminated by signal
-        run_server(
-            planner,
-            herald,
-            consul_util=util,
+
+        server = ServerRunner(planner, herald, consul_util=util)
+        server.run(
             threads_to_wait=[*consumer_threads, stats_updater, rconfc_starter])
     except Exception:
         LOG.exception('Exiting due to an exception')

--- a/hax/hax/queue/offset.py
+++ b/hax/hax/queue/offset.py
@@ -3,7 +3,7 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from hax.util import ConsulKVBasic, repeat_if_fails
+from hax.util import KVAdapter, repeat_if_fails
 
 LOG = logging.getLogger('hax')
 
@@ -20,9 +20,9 @@ class OffsetStorage:
     def __init__(self,
                  node_name: str,
                  key_prefix: str = '',
-                 kv: Optional[ConsulKVBasic] = None):
+                 kv: Optional[KVAdapter] = None):
         self.node_name = node_name
-        self.kv = kv or ConsulKVBasic()
+        self.kv = kv or KVAdapter()
         self.key_prefix = key_prefix
 
     @repeat_if_fails()

--- a/hax/hax/queue/publish.py
+++ b/hax/hax/queue/publish.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, NamedTuple, Optional
 
 import simplejson
-from hax.util import ConsulKVBasic, TxPutKV, repeat_if_fails
+from hax.util import KVAdapter, TxPutKV, repeat_if_fails
 
 # XXX do we want to make payload definition more strict?
 # E.g. there could be a type hierarchy for payload objects that depends
@@ -15,10 +15,10 @@ class Publisher:
 
     def __init__(self,
                  queue_prefix: str,
-                 kv: Optional[ConsulKVBasic] = None,
+                 kv: Optional[KVAdapter] = None,
                  epoch_key: str = 'epoch'):
         self.queue_prefix = queue_prefix
-        self.kv = kv or ConsulKVBasic()
+        self.kv = kv or KVAdapter()
         self.epoch_key = epoch_key
 
     @repeat_if_fails(wait_seconds=0.1)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -218,7 +218,9 @@ class ServerRunner:
         # Note that bq-delivered mechanism must use a unique node name rather
         # than broad '0.0.0.0' that doesn't identify the node from outside.
         inbox_filter = InboxFilter(
-            OffsetStorage(node_address, key_prefix='bq-delivered'))
+            OffsetStorage(node_address,
+                          key_prefix='bq-delivered',
+                          kv=self.consul_util.kv))
 
         conf_obj = ConfObjUtil(self.consul_util)
         planner = self.planner

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -71,11 +71,17 @@ def process_ha_states(planner: WorkPlanner, consul_util: ConsulUtil):
         data = await request.json()
 
         loop = asyncio.get_event_loop()
-        # Note that planner.add_command is potentially a blocking call
-        await loop.run_in_executor(
-            None, lambda: planner.add_command(
+
+        def fn():
+            # import pudb.remote
+            # pudb.remote.set_trace(term_size=(80, 40), port=9998)
+            LOG.debug('Service health from Consul: %s', data)
+            planner.add_command(
                 BroadcastHAStates(states=to_ha_states(data, consul_util),
-                                  reply_to=None)))
+                                  reply_to=None))
+
+        # Note that planner.add_command is potentially a blocking call
+        await loop.run_in_executor(None, fn)
         return web.Response()
 
     return _process
@@ -185,51 +191,77 @@ async def encode_exception(request, handler):
                               reason="Unexpected error has happened")
 
 
-def run_server(
-    planner: WorkPlanner,
-    herald: DeliveryHerald,
-    consul_util: ConsulUtil,
-    threads_to_wait: List[StoppableThread] = [],
-    port=8008,
-):
-    node_address = consul_util.get_hax_ip_address()
+class ServerRunner:
+    def __init__(
+        self,
+        planner: WorkPlanner,
+        herald: DeliveryHerald,
+        consul_util: ConsulUtil,
+    ):
+        self.consul_util = consul_util
+        self.herald = herald
+        self.planner = planner
 
-    # We can't use broad 0.0.0.0 IP address to make it possible to run
-    # multiple hax instances at the same machine (i.e. in failover situation).
-    # Instead, every hax will use a private IP only.
-    web_address = node_address
+    def _create_server(self) -> web.Application:
+        return web.Application(middlewares=[encode_exception])
 
-    # Note that bq-delivered mechanism must use a unique node name rather than
-    # broad '0.0.0.0' that doesn't identify the node from outside.
-    inbox_filter = InboxFilter(
-        OffsetStorage(node_address, key_prefix='bq-delivered'))
+    def _get_my_hostname(self) -> str:
+        return self.consul_util.get_hax_ip_address()
 
-    conf_obj = ConfObjUtil(consul_util)
+    def _configure(self) -> None:
+        # We can't use broad 0.0.0.0 IP address to make it possible to run
+        # multiple hax instances at the same machine (i.e. in failover
+        # situation).
+        # Instead, every hax will use a private IP only.
+        node_address = self._get_my_hostname()
 
-    app = web.Application(middlewares=[encode_exception])
-    app.add_routes([
-        web.get('/', hello_reply),
-        web.post('/', process_ha_states(planner, consul_util)),
-        web.post(
-            '/watcher/bq',
-            process_bq_update(inbox_filter,
-                              BQProcessor(planner, herald, conf_obj))),
-        web.post('/api/v1/sns/{operation}', process_sns_operation(planner)),
-        web.get('/api/v1/sns/repair-status',
-                get_sns_status(planner, SnsRepairStatus)),
-        web.get('/api/v1/sns/rebalance-status',
-                get_sns_status(planner, SnsRebalanceStatus)),
-    ])
-    LOG.info(f'Starting HTTP server at {web_address}:{port} ...')
-    try:
-        web.run_app(app, host=web_address, port=port)
-        LOG.debug('Server stopped normally')
-    finally:
-        LOG.debug('Stopping the threads')
-        planner.shutdown()
-        for thread in threads_to_wait:
-            thread.stop()
-        for thread in threads_to_wait:
-            thread.join()
+        # Note that bq-delivered mechanism must use a unique node name rather
+        # than broad '0.0.0.0' that doesn't identify the node from outside.
+        inbox_filter = InboxFilter(
+            OffsetStorage(node_address, key_prefix='bq-delivered'))
 
-        LOG.info('The http server has stopped')
+        conf_obj = ConfObjUtil(self.consul_util)
+        planner = self.planner
+        herald = self.herald
+        consul_util = self.consul_util
+
+        app = self._create_server()
+        app.add_routes([
+            web.get('/', hello_reply),
+            web.post('/', process_ha_states(planner, consul_util)),
+            web.post(
+                '/watcher/bq',
+                process_bq_update(inbox_filter,
+                                  BQProcessor(planner, herald, conf_obj))),
+            web.post('/api/v1/sns/{operation}',
+                     process_sns_operation(planner)),
+            web.get('/api/v1/sns/repair-status',
+                    get_sns_status(planner, SnsRepairStatus)),
+            web.get('/api/v1/sns/rebalance-status',
+                    get_sns_status(planner, SnsRebalanceStatus)),
+        ])
+        self.app = app
+
+    def _start(self, web_address: str, port: int) -> None:
+        web.run_app(self.app, host=web_address, port=port)
+
+    def run(
+        self,
+        threads_to_wait: List[StoppableThread] = [],
+        port=8008,
+    ):
+        self._configure()
+        web_address = self._get_my_hostname()
+        LOG.info(f'Starting HTTP server at {web_address}:{port} ...')
+        try:
+            self._start(web_address, port)
+            LOG.debug('Server stopped normally')
+        finally:
+            LOG.debug('Stopping the threads')
+            self.planner.shutdown()
+            for thread in threads_to_wait:
+                thread.stop()
+            for thread in threads_to_wait:
+                thread.join()
+
+            LOG.info('The http server has stopped')

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -38,6 +38,7 @@ ObjT = Enum(
         ('SERVICE', 0x7300000000000001),
         ('SDEV', 0x6400000000000001),
         ('DRIVE', 0x6b00000000000001),
+        ('PROFILE', 0x7000000000000001),
     ])
 ObjT.__doc__ = 'Motr conf object types and their m0_fid.f_container values'
 

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -90,6 +90,10 @@ def create_drive_fid(key: int) -> Fid:
     return mk_fid(ObjT.DRIVE, key)
 
 
+def create_profile_fid(key: int) -> Fid:
+    return mk_fid(ObjT.PROFILE, key)
+
+
 # See enum m0_conf_ha_process_event in Motr source code.
 ha_process_events = ('M0_CONF_HA_PROCESS_STARTING',
                      'M0_CONF_HA_PROCESS_STARTED',
@@ -258,6 +262,7 @@ class CatalogAdapter:
         Return service(s) registered in Consul by the given name.
         """
         try:
+            # TODO refactor catalog operations into a separate class
             return self.cns.catalog.service(service=svc_name)[1]
         except (ConsulException, HTTPError, RequestException) as e:
             raise HAConsistencyException(

--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -14,6 +14,7 @@ wheel==0.36.2
 pytest==6.2.4
 pytest-aiohttp==0.3.0
 pytest-mock==3.6.1
+pytest-timeout==1.4.2
 
 #:runtime-requirements:
 idna==2.10

--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -11,6 +11,9 @@ mypy==0.910
 pkgconfig==1.5.4
 setuptools==57.1.0
 wheel==0.36.2
+pytest==6.2.4
+pytest-aiohttp==0.3.0
+pytest-mock==3.6.1
 
 #:runtime-requirements:
 idna==2.10

--- a/hax/test/integration/__init__.py
+++ b/hax/test/integration/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#

--- a/hax/test/integration/conftest.py
+++ b/hax/test/integration/conftest.py
@@ -1,0 +1,28 @@
+import logging
+
+import pytest
+from hax.log import setup_logging
+from hax.util import ConsulUtil
+
+
+@pytest.fixture
+def consul_util(mocker):
+    consul = ConsulUtil()
+    exc = RuntimeError('Not allowed')
+    mock = mocker.patch.object
+    mock(consul.kv, 'kv_get', side_effect=exc)
+    mock(consul.kv, 'kv_put', side_effect=exc)
+    mock(consul.kv, 'kv_put_in_transaction', side_effect=exc)
+    mock(consul.kv, 'kv_delete_in_transaction', side_effect=exc)
+    mock(consul.catalog, 'get_services', side_effect=exc)
+    mock(consul.catalog, 'get_service_names', side_effect=exc)
+    mock(consul, 'get_local_nodename', return_value='localhost')
+    mock(consul, 'get_hax_ip_address', return_value='192.168.0.28')
+    return consul
+
+
+@pytest.fixture(autouse=True)
+def logging_support():
+    setup_logging()
+    yield ''
+    logging.shutdown()

--- a/hax/test/integration/pytest.ini
+++ b/hax/test/integration/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --show-capture=log -v
+timeout = 10
+

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import ctypes
+
+import pytest
+from hax.handler import ConsumerThread
+from hax.message import BaseMessage, Die, FirstEntrypointRequest
+from hax.motr import Motr, WorkPlanner
+from hax.motr.delivery import DeliveryHerald
+from hax.motr.ffi import HaxFFI
+from hax.types import Fid, HaNoteStruct, Profile, Uint128
+from hax.util import create_process_fid, create_profile_fid
+
+from .testutils import (AssertionPlan, FakeFFI, Invocation, TraceMatcher,
+                        tr_and, tr_method)
+
+
+@pytest.fixture
+def herald(mocker):
+    herald = DeliveryHerald()
+    mocker.patch.object(herald, 'wait_for_all')
+    return herald
+
+
+@pytest.fixture
+def planner(mocker) -> WorkPlanner:
+    planner = WorkPlanner()
+    mocker.patch.object(planner, 'add_command', side_effect=RuntimeError())
+    return planner
+
+
+def ha_note_failed() -> TraceMatcher:
+    '''
+    Returns true if the second argument is a pointer to HaNoteStruct and that
+    structure brings M0_NC_FAILED state.
+
+    It makes sense to use this matcher together with
+    `tr_method('ha_broadcast')`
+    '''
+    def fn(trace: Invocation) -> bool:
+        if len(trace.args) < 2:
+            return False
+        note = trace.args[1]
+        if not isinstance(note, ctypes.Array):
+            return False
+
+        # It seems like the ctype pointer always looks like an array from
+        # outside. We have to cast it explicitly to (HaNoteStruct *) to
+        # dereference it.
+        ptr = ctypes.cast(note, ctypes.POINTER(HaNoteStruct))
+
+        state: int = ptr.contents.no_state
+        return state == HaNoteStruct.M0_NC_FAILED
+
+    return fn
+
+
+@pytest.fixture
+def ffi() -> HaxFFI:
+    return FakeFFI()
+
+
+@pytest.fixture
+def motr(mocker, ffi, planner, herald, consul_util) -> Motr:
+    motr = Motr(ffi, planner, herald, consul_util)
+    return motr
+
+
+@pytest.fixture
+def consumer(planner, motr, herald, consul_util):
+    return ConsumerThread(planner, motr, herald, consul_util, 0)
+
+
+def run_in_consumer(mocker, msg: BaseMessage, planner: WorkPlanner,
+                    consumer: ConsumerThread, motr: Motr) -> None:
+    mocker.patch.object(planner, 'get_next_command', side_effect=[msg, Die()])
+    profile = Profile(fid=create_profile_fid(22),
+                      name='the_pool',
+                      pool_names=['name1'])
+    motr.start('endpoint', create_process_fid(120), create_process_fid(15),
+               profile)
+    consumer._do_work(planner, motr)
+
+
+def test_first_entrypoint_request_broadcasts_fail_first(
+        mocker, planner, motr, consumer, consul_util):
+    def new_kv(key: str, val: str):
+        return {
+            'Key': key,
+            'CreateIndex': 1793,
+            'ModifyIndex': 1793,
+            'LockIndex': 0,
+            'Flags': 0,
+            'Value': val,
+            'Session': ''
+        }
+
+    def my_get(key: str, recurse: bool = False):
+        if key == 'm0conf/nodes' and recurse:
+            return [
+                new_kv(k, v) for k, v in [(
+                    'm0conf/nodes/cmu/processes/6/services/ha',
+                    '15'), (
+                        'm0conf/nodes/cmu/processes/6/services/rm', '16'
+                    ), ('m0conf/nodes/localhost/processes/7/services/rms',
+                        '17')]
+            ]
+        elif key == 'm0conf/nodes/localhost/processes/7/services/rms':
+            return new_kv('m0conf/nodes/localhost/processes/7/services/rms',
+                          '17')
+        raise RuntimeError(f'Unexpected call: key={key}, recurse={recurse}')
+
+    def my_services(name):
+        if name == 'confd':
+            return [{
+                'Node': 'localhost',
+                'Service': 'confd',
+                'ServiceID': '7',
+                'Address': '192.168.0.28',
+                'ServiceAddress': '192.168.0.28',
+                'ServicePort': '12345'
+            }]
+        if name == 'hax':
+            return [{
+                'Node': 'localhost',
+                'Service': 'hax',
+                'ServiceID': '45',
+                'Address': '192.168.0.28',
+                'ServiceAddress': '192.168.0.28',
+                'ServicePort': '667'
+            }]
+        raise RuntimeError(f'Unexpected call: name={name}')
+
+    mocker.patch.object(consul_util.kv, 'kv_get', side_effect=my_get)
+    mocker.patch.object(consul_util,
+                        'get_leader_session_no_wait',
+                        return_value='localhost')
+    mocker.patch.object(consul_util,
+                        'get_session_node',
+                        return_value='localhost')
+
+    mocker.patch.object(consul_util.catalog,
+                        'get_services',
+                        side_effect=my_services)
+
+    msg = FirstEntrypointRequest(reply_context='stub',
+                                 req_id=Uint128(0, 1),
+                                 remote_rpc_endpoint='ep',
+                                 process_fid=Fid(1, 6),
+                                 git_rev='deadbeef',
+                                 pid=123,
+                                 is_first_request=True)
+    run_in_consumer(mocker, msg, planner, consumer, motr)
+    traces = motr._ffi.traces
+    assert AssertionPlan(
+        tr_and(tr_method('ha_broadcast'),
+               ha_note_failed())).run(traces), 'M0_NC_FAILED not broadcast'
+    assert AssertionPlan(
+        tr_and(tr_method('ha_broadcast'),
+               ha_note_failed())).and_then(
+        tr_method('entrypoint_reply')).run(traces), \
+        'entrypoint_reply should go after M0_NC_FAILED ' \
+        'is broadcast'

--- a/hax/test/integration/test_server.py
+++ b/hax/test/integration/test_server.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+from base64 import b64encode
+from typing import List
+
+import pytest
+import simplejson
+from hax.message import BroadcastHAStates
+from hax.motr import WorkPlanner
+from hax.motr.delivery import DeliveryHerald
+from hax.server import ServerRunner
+from hax.types import Fid, HAState, MessageId, ServiceHealth
+
+
+@pytest.fixture
+def herald(mocker):
+    return DeliveryHerald()
+
+
+@pytest.fixture
+def planner(mocker) -> WorkPlanner:
+    def fake_add(cmd):
+        if hasattr(cmd, 'reply_to') and cmd.reply_to:
+            cmd.reply_to.put([MessageId(1, 42)])
+
+    planner = WorkPlanner()
+    mocker.patch.object(planner, 'add_command', side_effect=fake_add)
+    return planner
+
+
+@pytest.fixture
+async def hax_client(mocker, aiohttp_client, herald, planner, consul_util,
+                     loop):
+    srv = ServerRunner(planner, herald, consul_util)
+    srv._configure()
+    return await aiohttp_client(srv.app)
+
+
+async def test_hello_works(hax_client):
+    resp = await hax_client.get('/')
+    assert resp.status == 200
+    text = await resp.text()
+    assert text == "I'm alive! Sincerely, HaX"
+
+
+@pytest.mark.parametrize('status,health', [('passing', ServiceHealth.OK),
+                                           ('warning', ServiceHealth.FAILED),
+                                           ('critical', ServiceHealth.FAILED)])
+async def test_service_health_broadcast(hax_client, planner, status: str,
+                                        health: ServiceHealth):
+    service_health = [{
+        'Node': {
+            'Node': 'localhost',
+            'Address': '10.1.10.12',
+        },
+        'Service': {
+            'ID': '12',
+            'Service': 'ios',
+            'Tags': [],
+            'Port': 8000,
+        },
+        'Checks': [
+            {
+                'Node': '12',
+                'CheckID': 'service:ios',
+                'Name': "Service 'ios' check",
+                'Status': status,
+                'Notes': '',
+                'Output': '',
+                'ServiceID': '12',
+                'ServiceName': 'ios',
+            },
+        ],
+    }]
+    resp = await hax_client.post('/', json=service_health)
+    assert resp.status == 200
+    assert planner.add_command.called
+    planner.add_command.assert_called_once_with(
+        BroadcastHAStates(
+            states=[HAState(fid=Fid(0x7200000000000001, 12), status=health)],
+            reply_to=None))
+
+
+class ContainsStates:
+    def __init__(self, pattern: List[HAState]):
+        self.pattern = pattern
+
+    def __repr__(self):
+        return str(self.pattern)
+
+    def __eq__(self, value):
+        if not isinstance(value, BroadcastHAStates):
+            return False
+        return self.pattern == value.states
+
+
+async def test_bq_stob_message_type_recognized(hax_client, planner, herald,
+                                               consul_util, mocker):
+    def fake_get(key):
+        ret = {'bq-delivered/192.168.0.28': ''}
+        return ret[key]
+
+    mocker.patch.object(herald, 'wait_for_any')
+    #
+    # InboxFilter will try to read epoch - let's mock KV operations
+    mocker.patch.object(consul_util.kv, 'kv_put')
+    mocker.patch.object(consul_util.kv, 'kv_get', fake_get)
+    event_payload = {
+        'message_type': 'STOB_IOQ_ERROR',
+        'payload': {
+            'fid': '0x1:0x2',
+            'conf_sdev': '0x1:0x4'
+        }
+    }
+    event_str = simplejson.dumps(event_payload)
+    b64: bytes = b64encode(event_str.encode())
+    b64_str = b64.decode()
+
+    payload = [{
+        'Key': 'bq/12',
+        'CreateIndex': 1793,
+        'ModifyIndex': 1793,
+        'LockIndex': 0,
+        'Flags': 0,
+        'Value': b64_str,
+        'Session': ''
+    }]
+    # Test execution
+    resp = await hax_client.post('/watcher/bq', json=payload)
+    # Validate now
+    if resp.status != 200:
+        resp_json = await resp.json()
+        logging.getLogger('hax').debug('Response: %s', resp_json)
+    assert resp.status == 200
+    planner.add_command.assert_called_once_with(
+        ContainsStates(
+            [HAState(fid=Fid(0x1, 0x4), status=ServiceHealth.FAILED)]))

--- a/hax/test/integration/testutils.py
+++ b/hax/test/integration/testutils.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, List, Tuple
+
+from hax.motr.ffi import HaxFFI
+from hax.types import MessageId
+
+
+@dataclass
+class Invocation:
+    method_name: str
+    args: List[Any]
+    called_ts: float
+
+
+def trace_call(fn):
+    '''
+    Decorator that 'logs' the historical sequence of all the methods of the
+    given class.
+
+    The implementation assumes that
+    1. the decorator will decorate methods of a class (not static functions).
+    2. the class has field `traces: List[Invocation]`
+    '''
+    def wrapper(self, *args, **kwargs):
+        ts = time.time()
+        args_copy = [i for i in args]
+        name = fn.__name__
+        self.traces.append(Invocation(name, args_copy, ts))
+        return fn(self, *args, **kwargs)
+
+    return wrapper
+
+
+@dataclass
+class AssertionState:
+    traces: List[Invocation]
+    result: bool
+    found_at: int
+
+
+TraceMatcher = Callable[[Invocation], bool]
+TracePredicate = Callable[[List[Invocation]], int]
+StateTransformer = Callable[[AssertionState], AssertionState]
+
+
+class AssertionPlan:
+    '''
+    Convenient mini-API for checking the traces left by `@trace_call`.
+
+    Example of usage:
+
+    assert AssertionPlan(
+        tr_method('ha_broadcast')).run(traces), 'ha_broadcast must be invoked'
+
+    assert AssertionPlan(
+        tr_method('ha_broadcast')).and_then(
+            tr_method('entrypoint_reply')).run(traces),
+            'ha_broadcast must be invoked before entrypoint_reply'
+    '''
+    def __init__(self, first: TraceMatcher):
+        self.steps: List[Tuple[StateTransformer,
+                               TracePredicate]] = [(self._id(),
+                                                    self._exec(first))]
+
+    def and_then(self, predicate: TraceMatcher) -> 'AssertionPlan':
+        '''
+        Orders the predicates in the historical order (what call happened after
+        which call). In other words, this method helps to build the predicates
+        like this:
+
+            1. Check that method X was invoked (specified by some matcher)
+            2. And check that method Y was invoked afterwards (also specified
+               by some matcher)
+
+        '''
+        self.steps.append((self._after(), self._exec(predicate)))
+        return self
+
+    def run(self, traces: List[Invocation]) -> bool:
+        '''
+        Evaluates the steps in this AssertionPlan and returns the final result
+        of the assertion.
+        '''
+        state = AssertionState(traces, False, -1)
+        for transformer, predicate in self.steps:
+            state = transformer(state)
+            if state.result:
+                return True
+            res = predicate(state.traces)
+            if res >= 0:
+                state = AssertionState(state.traces, True, res)
+        return state.result
+
+    def _id(self):
+        def fn(state: AssertionState) -> AssertionState:
+            return state
+
+        return fn
+
+    def _after(self):
+        def fn(state: AssertionState) -> AssertionState:
+            last_idx = state.found_at
+            return AssertionState(traces=state.traces[:last_idx + 1],
+                                  result=state.result,
+                                  found_at=-1)
+
+        return fn
+
+    def _exec(self, matcher: TraceMatcher) -> TracePredicate:
+        def fn(traces: List[Invocation]) -> int:
+            i = 0
+            for call in traces:
+                if matcher(call):
+                    return i
+                i += 1
+            return -1
+
+        return fn
+
+
+def tr_method(name: str) -> TraceMatcher:
+    '''
+    Matcher for AssertionPlan that matches the invocation by the method name.
+    '''
+    def fn(trace: Invocation) -> bool:
+        return trace.method_name == name
+
+    return fn
+
+
+def tr_and(*matchers: TraceMatcher) -> TraceMatcher:
+    '''
+    Matcher for AssertionPlan that works as logical AND for the matchers
+    passed via arguments.
+    '''
+    def fn(trace: Invocation) -> bool:
+        res = True
+        for m in matchers:
+            res = res and m(trace)
+            if not res:
+                break
+        return res
+
+    return fn
+
+
+class FakeFFI(HaxFFI):
+    def __init__(self):
+        self.traces: List[Invocation] = []
+
+    @trace_call
+    def init_motr_api(self, ptr, some_str):
+        return 1
+
+    @trace_call
+    def start(self, ctx, endpoint, process_fid, ha_fid, rm_fid):
+        ...
+
+    @trace_call
+    def start_rconfc(self):
+        ...
+
+    @trace_call
+    def motr_stop(self, ha_ctx):
+        ...
+
+    @trace_call
+    def stop_rconfc(self, ha_ctx):
+        ...
+
+    @trace_call
+    def adopt_motr_thread(self, ha_ctx):
+        ...
+
+    @trace_call
+    def shun_motr_thread(self):
+        ...
+
+    @trace_call
+    def ha_broadcast(self, _ha_ctx, ha_notes, notes_len):
+        return [MessageId(101, 1), MessageId(101, 2)]
+
+    @trace_call
+    def entrypoint_reply(self, *args):
+        return 1
+
+    @trace_call
+    def hax_stop(self, *args):
+        return [MessageId(111, 1)]

--- a/hax/test/test_offset_storage.py
+++ b/hax/test/test_offset_storage.py
@@ -22,7 +22,7 @@ import unittest
 from time import sleep
 
 from hax.queue.offset import OffsetStorage
-from hax.util import ConsulKVBasic
+from hax.util import KVAdapter
 from unittest.mock import Mock, MagicMock
 
 
@@ -34,7 +34,7 @@ class TestOffsetStorage(unittest.TestCase):
             format='%(asctime)s {%(threadName)s} [%(levelname)s] %(message)s')
 
     def test_key_prefix_correct(self):
-        kv = ConsulKVBasic()
+        kv = KVAdapter()
         kv.kv_put = MagicMock()
 
         storage = OffsetStorage('my-node' , key_prefix='bq-delivered', kv=kv)
@@ -43,7 +43,7 @@ class TestOffsetStorage(unittest.TestCase):
         kv.kv_put.assert_called_with('bq-delivered/my-node', '150')
 
     def test_key_prefix_used_everywhere(self):
-        kv = ConsulKVBasic()
+        kv = KVAdapter()
         kv.kv_put = MagicMock()
         kv.kv_get = MagicMock(side_effect=[{'Value': '120'}])
 

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -35,16 +35,12 @@ from typing import Any, Callable, Dict, List
 import yaml
 from cortx.utils.product_features import unsupported_features
 from hax.types import KeyDelete
-from hax.util import ConsulKVBasic, ConsulUtil, repeat_if_fails
+from hax.util import ConsulUtil, repeat_if_fails, KVAdapter
 
 from hare_mp.cdf import CdfGenerator
 from hare_mp.store import ConfStoreProvider
 from hare_mp.systemd import HaxUnitTransformer
 from hare_mp.validator import Validator
-from hax.util import KVAdapter, ConsulUtil, repeat_if_fails
-from hax.types import KeyDelete
-from time import sleep
-from enum import Enum
 
 # Logger details
 LOG_DIR = "/var/log/seagate/hare/"

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -41,6 +41,10 @@ from hare_mp.cdf import CdfGenerator
 from hare_mp.store import ConfStoreProvider
 from hare_mp.systemd import HaxUnitTransformer
 from hare_mp.validator import Validator
+from hax.util import KVAdapter, ConsulUtil, repeat_if_fails
+from hax.types import KeyDelete
+from time import sleep
+from enum import Enum
 
 # Logger details
 LOG_DIR = "/var/log/seagate/hare/"
@@ -387,7 +391,7 @@ def nr_services() -> int:
 def all_services_started(url: str, nr_svcs: int) -> bool:
     conf = ConfStoreProvider(url)
     hostname = conf.get_hostname()
-    kv = ConsulKVBasic()
+    kv = KVAdapter()
     status_data = kv.kv_get(f'{hostname}/processes', recurse=True)
     statuses = []
     for val in status_data:


### PR DESCRIPTION
Problem: critical parts of hax functionality are not covered by the automatic tests. Things like integration with Consul and communication to Motr land are very hard to test.

Solution:
1. Refactor hax code so that it is possible to implement integration tests that would mock or emulate Consul and Motr
2. Introduce pytest test framework
3. Implement several sample integration tests showing how Consul and Motr-related functionality can be tested.
4. Implement basic infrastructure for running such tests (e.g. integrate them into Makefile).