### PR TITLE
Update README: clarify cortx-py-utils installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ and health-checking mechanisms.
 * Install py-utils.
 
    Please refer to [the instruction](https://github.com/Seagate/cortx-utils/blob/main/py-utils/README.md) to install corxt-py-utils from sources.
-
+   
+   Note: `Hare` needs `pip` and `RPM` packages, so please [build](https://github.com/Seagate/cortx-utils/blob/main/py-utils/README.md#build) both packages. Then [install](https://github.com/Seagate/cortx-utils/blob/main/py-utils/README.md#installation) both of them using `pip3 install` and `yum install` respectively. 
 
 * Build and Install Motr.
 


### PR DESCRIPTION
In the cortx-py-utilis https://github.com/Seagate/cortx-utils/blob/main/py-utils/README.md#build, it noted in the BUILD section that `Note: Use one of following method to create build package`. However, that statement (note) will cause problems as described below:

## 1. If we only install `RPM` package

We will get this error:
```sh
--> Checking hare_mp
--> Checking files with flake8
--> Checking files with mypy
hare_mp/store.py:21: error: Cannot find implementation or library stub for module named "cortx.utils.conf_store"
hare_mp/main.py:34: error: Cannot find implementation or library stub for module named "cortx.utils.product_features"
hare_mp/main.py:34: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
hare_mp/main.py:77: error: Module has no attribute "handlers"; maybe "Handler"?
Found 3 errors in 2 files (checked 8 source files)
make[2]: *** [mypy] Error 1
make[1]: *** [check-miniprov] Error 2
make: *** [build] Error 2
```
when following `Build and install Hare` section, specifically when running the `make`  command.

## 2. If we only install `pip` package

We will get this error:
```sh
‘cortx-hare-2.0.0.tar.gz’ -> ‘/home/daniar/rpmbuild/SOURCES/cortx-hare-2.0.0.tar.gz’
‘hare.spec’ -> ‘/home/daniar/rpmbuild/SPECS/hare.spec’
make[1]: Leaving directory `/mnt/extra/hare'
make[1]: Entering directory `/mnt/extra/hare'
--> Building rpm packages
error: Failed build dependencies:
    cortx-py-utils is needed by cortx-hare-2.0.0-1_git47b95c8.el7.x86_64
make[1]: *** [__rpm] Error 1
make[1]: Leaving directory `/mnt/extra/hare'
make: *** [rpm] Error 2
```
when following `Build hare RPMs` section, specifically when running: 
```sh
make rpm
sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-hare-*.rpm
```

## 3. Another quirky problem (when we install RPM package before installing the pip package)

Turns out, the order of installing the cortx-py-utils does matter. We will get this error 
``` sh
--> Preparing rpmbuild environment
mkdir: created directory ‘/home/daniar/rpmbuild’
mkdir: created directory ‘/home/daniar/rpmbuild/SOURCES’
mkdir: created directory ‘/home/daniar/rpmbuild/SPECS’
‘cortx-hare-2.0.0.tar.gz’ -> ‘/home/daniar/rpmbuild/SOURCES/cortx-hare-2.0.0.tar.gz’
‘hare.spec’ -> ‘/home/daniar/rpmbuild/SPECS/hare.spec’
make[1]: Leaving directory `/mnt/extra/hare'
make[1]: Entering directory `/mnt/extra/hare'
--> Building rpm packages
error: line 52: Unknown tag: package package is not installed
make[1]: *** [__rpm] Error 1
make[1]: Leaving directory `/mnt/extra/hare'
make: *** [rpm] Error 2
```
when following the `Build hare RPMs` section, specifically when running the `make rpm`  command. The reason for this 3rd problem is related to the pip package version. Somehow the wheel will generate version "2.0.0" instead of "1.0.0". I will not dive deeper into this problem. 

## Solution

`Hare` needs both of these packages, as opposed to only install one of them. And to prevent the 3rd problem, the order of installation does matter, the pip package must be installed first, then the RPM package.
This problem has been tested multiple times (>4x) and produce the same result. I am using a baremetal server (from Chameleon cloud) that got erased completely before repeating the test. 
Let me know if you spot any unexpected issues with this PR. Thanks!

Note: I am a Seagate employee, so I don't need to sign CLA.

-----
[View rendered README.md](https://github.com/daniarherikurniawan/cortx-hare/blob/patch-5/README.md)