### PR TITLE
EOS-21437: Corrected the motr RPM installation cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ and health-checking mechanisms.
 * Build Motr RPMs
 
   * From sources
+  
+    **NOTE:** Installing motr RPMs other than "cortx-motr-test*.rpm".
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git
     cd cortx-motr
 
     scripts/m0 make rpms
-    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
+    cd ~/rpmbuild/RPMS/x86_64/
+    sudo rpm -ivh $(ls | grep  "cortx-motr-" | grep -v "cortx-motr-tests")
+    cd -
     ```
 
 * Build `hare` RPMs


### PR DESCRIPTION
Corrected the motr RPM installation cmd to install without "cortx-motr-tests"

-----
[View rendered README.md](https://github.com/pavankrishnat/cortx-hare/blob/main/README.md)