### PR TITLE
EOS-21274 : setup.log file got created in /root instead of /var/log/seagate/hare

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -42,7 +42,7 @@ from time import sleep
 
 # Logger details
 LOG_DIR = "/var/log/seagate/hare/"
-LOG_FILE = 'setup.log'
+LOG_FILE = "/var/log/seagate/hare/setup.log"
 LOG_FILE_SIZE = 5 * 1024 * 1024
 
 


### PR DESCRIPTION
Solution : Redirect Hare deployment logs to '/var/log/seagate/hare/setup.log'

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>