### PR TITLE
EOS-18481: Update device status in consul KV

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -47,6 +47,7 @@ class ConsumerThread(StoppableThread):
     The thread exits gracefully when it receives message of type Die (i.e.
     it is a 'poison pill').
     """
+
     def __init__(self, planner: WorkPlanner, motr: Motr,
                  herald: DeliveryHerald, consul: ConsulUtil, idx: int):
         super().__init__(target=self._do_work,
@@ -74,7 +75,8 @@ class ConsumerThread(StoppableThread):
                                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED):
             motr.broadcast_ha_states(
                 [HAState(fid=event.fid, status=svc_status)],
-                notify_devices=False)
+                notify_devices=True if event.chp_event ==
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED else False)
 
     @repeat_if_fails(wait_seconds=1)
     def update_process_failure(self, planner: WorkPlanner,
@@ -119,7 +121,7 @@ class ConsumerThread(StoppableThread):
                         BroadcastHAStates(states=[
                             HAState(fid=state.fid, status=ServiceHealth.FAILED)
                         ],
-                                          reply_to=None))
+                            reply_to=None))
                 if current_status not in (ServiceHealth.UNKNOWN,
                                           ServiceHealth.OFFLINE):
                     # We also need to account and report the failure of remote


### PR DESCRIPTION
### Description:
jira link- https://jts.seagate.com/browse/EOS-18481

### Solution:  
1. Initialization during bootstrap, after ios service, is online.
2. Device failure/online events

### Output:
1. After bootstrap
```
$ hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    ssc-vm-c-1813.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   10.230.248.67@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   10.230.248.67@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   10.230.248.67@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  10.230.248.67@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  10.230.248.67@tcp:12345:4:2
Devices:
    ssc-vm-c-1813.colo.seagate.com
    [online]  /dev/null
    [online]  /dev/loop1
    [online]  /dev/loop2
    [online]  /dev/loop3
    [online]  /dev/loop4
    [online]  /dev/loop5
    [online]  /dev/loop6
    [online]  /dev/loop7
    [online]  /dev/loop8
    [online]  /dev/loop9
    [online]  /dev/loop0
```
2.  raising device failure event
```
$ hctl drive-state --json '{"node":"ssc-vm-c-1813.colo.seagate.com","source_type":"drive","device":"/dev/loop8","state":"failed"}'
0
2021-06-25 05:31:08,735 [DEBUG] Starting new HTTP connection (1): 127.0.0.1:8500
2021-06-25 05:31:08,737 [DEBUG] http://127.0.0.1:8500 "GET /v1/kv/eq-epoch HTTP/1.1" 200 93
2021-06-25 05:31:09,506 [DEBUG] http://127.0.0.1:8500 "PUT /v1/txn HTTP/1.1" 200 220
2021-06-25 05:31:09,507 [INFO] Written to epoch: 2
```
```
$ hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    ssc-vm-c-1813.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   10.230.248.67@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   10.230.248.67@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   10.230.248.67@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  10.230.248.67@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  10.230.248.67@tcp:12345:4:2
Devices:
    ssc-vm-c-1813.colo.seagate.com
    [online]  /dev/null
    [online]  /dev/loop1
    [online]  /dev/loop2
    [online]  /dev/loop3
    [online]  /dev/loop4
    [online]  /dev/loop5
    [online]  /dev/loop6
    [online]  /dev/loop7
    [failed]  /dev/loop8
    [online]  /dev/loop9
    [online]  /dev/loop0
```
3. process failure (by killing process)
```
$ hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    ssc-vm-c-1813.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   10.230.248.67@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   10.230.248.67@tcp:12345:2:1
    [offline]  ioservice  0x7200000000000001:0xc   10.230.248.67@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  10.230.248.67@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  10.230.248.67@tcp:12345:4:2
Devices:
    ssc-vm-c-1813.colo.seagate.com
    [failed]  /dev/null
    [failed]  /dev/loop1
    [failed]  /dev/loop2
    [failed]  /dev/loop3
    [failed]  /dev/loop4
    [failed]  /dev/loop5
    [failed]  /dev/loop6
    [failed]  /dev/loop7
    [failed]  /dev/loop8
    [failed]  /dev/loop9
    [failed]  /dev/loop0
```
4. device marked as failed, and hax notifies process online (tested by systemctl start process). 
result - the failed devices remain in failed state, after process coming online.
```
$ sudo systemctl stop m0d@0x7200000000000001:0xc

root@ssc-vm-c-1813.colo.seagate.com:/root/test1
$ hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    ssc-vm-c-1813.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   10.230.248.67@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   10.230.248.67@tcp:12345:2:1
    [offline]  ioservice  0x7200000000000001:0xc   10.230.248.67@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  10.230.248.67@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  10.230.248.67@tcp:12345:4:2
Devices:
    ssc-vm-c-1813.colo.seagate.com
    [online]  /dev/null
    [failed]  /dev/loop1
    [online]  /dev/loop2
    [online]  /dev/loop3
    [online]  /dev/loop4
    [online]  /dev/loop5
    [online]  /dev/loop6
    [online]  /dev/loop7
    [failed]  /dev/loop8
    [online]  /dev/loop9
    [online]  /dev/loop0

root@ssc-vm-c-1813.colo.seagate.com:/root/test1
$ sudo systemctl start m0d@0x7200000000000001:0xc

root@ssc-vm-c-1813.colo.seagate.com:/root/test1
$ hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    ssc-vm-c-1813.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x6   10.230.248.67@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0x9   10.230.248.67@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xc   10.230.248.67@tcp:12345:2:2
    [unknown]  m0_client  0x7200000000000001:0x29  10.230.248.67@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x2c  10.230.248.67@tcp:12345:4:2
Devices:
    ssc-vm-c-1813.colo.seagate.com
    [online]  /dev/null
    [failed]  /dev/loop1
    [online]  /dev/loop2
    [online]  /dev/loop3
    [online]  /dev/loop4
    [online]  /dev/loop5
    [online]  /dev/loop6
    [online]  /dev/loop7
    [failed]  /dev/loop8
    [online]  /dev/loop9
    [online]  /dev/loop0
```
### Note:
 Node failure notifications were raised due to device failure events. Device failure should not be the case for node failure.
Added an explicit check for only process failure events, node failure should be notified.