### PR TITLE
EOS-21437: HARE README GitHub Issue: #1664 - cortx-motr-tests rpm installation gives error

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,15 @@ and health-checking mechanisms.
 * Build Motr RPMs
 
   * From sources
+    **NOTE:** Installing motr RPMs other than "cortx-motr-test*.rpm"
     ```sh
     git clone --recursive https://github.com/Seagate/cortx-motr.git
     cd cortx-motr
 
     scripts/m0 make rpms
-    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/cortx-motr-*.rpm
+    cd ~/rpmbuild/RPMS/x86_64/
+    sudo rpm -ivh $(ls | grep  "cortx-motr-" | grep -v "cortx-motr-tests")
+    cd -
     ```
 
 * Build `hare` RPMs

--- a/README.md
+++ b/README.md
@@ -91,20 +91,9 @@ and health-checking mechanisms.
 
 **NOTE: If you have built Motr and HARE from sources you need not generate RPM packages as below, however, it might be more convenient to build and install rpms on a multinode setup sometimes**
 
-* Build Motr RPMs
-
-  * From sources
-    **NOTE:** Installing motr RPMs other than "cortx-motr-test*.rpm"
-    ```sh
-    git clone --recursive https://github.com/Seagate/cortx-motr.git
-    cd cortx-motr
-
-    scripts/m0 make rpms
-    cd ~/rpmbuild/RPMS/x86_64/
-    sudo rpm -ivh $(ls | grep  "cortx-motr-" | grep -v "cortx-motr-tests")
-    cd -
-    ```
-
+* Build & Install Motr RPMs
+  *  Follow [Motr quick start guide](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst) to install Motr.
+  
 * Build `hare` RPMs
 
   * Download `hare` source as mentioned above


### PR DESCRIPTION
Other than cortx-motr-test rpms installing other rpms without removing motr-test rpm
Signed-off-by: Vaibhav Paratwar <vaibhav.paratwar@seagate.com>

-----
[View rendered README.md](https://github.com/Seagate/cortx-hare/blob/vaibhavparatwar-patch-3/README.md)