### PR TITLE
EOS-21976: ConfStore must not be used

### DIFF
--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -18,7 +18,7 @@
 
 from typing import Any
 
-from cortx.utils.conf_store import ConfStore
+from cortx.utils.conf_store import Conf
 
 from hare_mp.types import MissingKeyError
 
@@ -46,8 +46,22 @@ class ValueProvider:
 class ConfStoreProvider(ValueProvider):
     def __init__(self, url: str):
         self.url = url
-        conf = ConfStore()
-        conf.load('hare', url)
+        # Note that we don't instantiate Conf class on purpose.
+        #
+        # Conf is a 'singleton' (as it is understood by its authors).
+        # In fact it is a class with static methods only.
+        #
+        # fail_reload flag is required to be False otherwise the error as
+        # follows will be thrown when ConfStoreProvider is instantiated not for
+        # the first time in the current address space:
+        #
+        # ConfError: error(22): conf index hare already exists
+        #
+        # Reason: although Conf has static methods only, it does have a state.
+        # That state is also static...
+
+        conf = Conf
+        conf.load('hare', url, fail_reload=False)
         self.conf = conf
 
     def _raw_get(self, key: str) -> str:


### PR DESCRIPTION
JIRA ticket: EOS-21976

It seems like ConfStore class should be used internally in
cortx-py-utils only; external code should use Conf 'wrapper' class
instead. Reason behind this change is that ConfStore signatures will
change soon and that change will be reflected automatically in Conf.

Solution: use 'wrapper' Conf class instead.