### PR TITLE
EOS-21289: Enclosure does not include all the controllers from the given node

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -781,7 +781,7 @@ class ConfProcess(ToDhall):
               node_desc: Dict[str, Any],
               proc_t: ProcT,
               proc_desc: Dict[str, Any] = None,
-              ctrl: Oid = None) -> Oid:
+              ctrl: Optional[Oid] = None) -> Oid:
         assert parent.type is ObjT.node
         assert ctrl is None or ctrl.type is ObjT.controller
 
@@ -804,10 +804,11 @@ class ConfProcess(ToDhall):
         m0conf[parent].processes.append(proc_id)
 
         for stype in service_types(proc_t, proc_desc):
-            svc_id = ConfService.build(m0conf, proc_id, stype, ep)
+            svc_id = ConfService.build(m0conf, proc_id, stype, ep, ctrl)
             if stype is SvcT.M0_CST_IOS:  # XXX What about M0_CST_CAS?
-                assert proc_desc is not None and ctrl is not None
+                assert proc_desc is not None
                 for disk in proc_desc['_io_disks']:
+                    assert ctrl is not None
                     ConfDrive.build(m0conf, ctrl,
                                     ConfSdev.build(m0conf, svc_id, disk))
         return proc_id
@@ -868,11 +869,13 @@ class ConfService(ToDhall):
     _objt = ObjT.service
     _downlinks = {Downlink('sdevs', ObjT.sdev)}
 
-    def __init__(self, stype: SvcT, endpoint: Endpoint, sdevs: List[Oid]):
+    def __init__(self, stype: SvcT, endpoint: Endpoint, sdevs: List[Oid],
+                 ctrl_id: Oid = None):
         self.type = stype
         self.endpoint = endpoint
         assert all(x.type is ObjT.sdev for x in sdevs)
         self.sdevs = sdevs
+        self.ctrl_id = ctrl_id
 
     def __repr__(self):
         args = ', '.join([f'stype={self.type}',
@@ -890,10 +893,11 @@ class ConfService(ToDhall):
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
-              stype: SvcT, endpoint: Endpoint) -> Oid:
+              stype: SvcT, endpoint: Endpoint,
+              ctrl: Optional[Oid] = None) -> Oid:
         assert parent.type is ObjT.process
         svc_id = new_oid(ObjT.service)
-        m0conf[svc_id] = cls(stype, endpoint, sdevs=[])
+        m0conf[svc_id] = cls(stype, endpoint, sdevs=[], ctrl_id=ctrl)
         m0conf[parent].services.append(svc_id)
         return svc_id
 
@@ -1125,12 +1129,15 @@ def pool_drives(m0conf: Dict[Oid, Any],
     ptype = pool_type(pool_desc)
 
     if ptype is PoolT.dix:
-        cas = [(svc_id, ctrl_id)
-               for encl_id in m0conf if encl_id.type is ObjT.enclosure
-               for ctrl_id in m0conf[encl_id].ctrls
-               for proc_id in m0conf[m0conf[encl_id].node].processes
-               for svc_id in m0conf[proc_id].services
-               if m0conf[svc_id].type is SvcT.M0_CST_CAS]
+        cas = []
+        for item in m0conf:
+            if item.type is ObjT.enclosure:
+                encl_id = item
+                for proc_id in m0conf[m0conf[encl_id].node].processes:
+                    for svc_id in m0conf[proc_id].services:
+                        if m0conf[svc_id].type is SvcT.M0_CST_CAS:
+                            cas.append((svc_id, m0conf[svc_id].ctrl_id))
+
         return [ConfDrive.build(m0conf, ctrl_id,
                                 ConfSdev.build(m0conf, svc_id,
                                                Disk(path='/dev/null',
@@ -1185,6 +1192,14 @@ def pool_drives(m0conf: Dict[Oid, Any],
         raise AssertionError(err)
 
     return [drive_id for drive_id, _ in drives]
+
+
+def cluster_encls(m0conf: Dict[Oid, Any]) -> List[Oid]:
+    encls: List[Oid] = []
+    for item in m0conf:
+        if item.type is ObjT.enclosure:
+            encls.append(item)
+    return encls
 
 
 Failures = NamedTuple('Failures', [('site', int),
@@ -1264,12 +1279,21 @@ class ConfPool(ToDhall):
                 # indivisible pieces of data, the whole CAS record is
                 # always stored on one node.
                 data_units = 1
+                parity_units = len(cluster_encls(m0conf)) - 1
             else:
                 assert t is PoolT.md
-                data_units = len(drives)
+                data_units = 1  # len(drives)
+                parity_units = len(cluster_encls(m0conf)) - 1
             pd_attrs = PDClustAttrs0(
-                data_units=data_units, parity_units=0, spare_units=0)
-        tolerance = None if t is PoolT.sns else Failures(0, 0, 0, 1, 0)
+                data_units=data_units, parity_units=parity_units,
+                spare_units=0)
+        d = pool_desc.get('allowed_failures')
+        if t in (PoolT.sns, PoolT.dix) and d:
+            tolerance = Failures(d['site'], d['rack'], d['encl'], d['ctrl'],
+                                 d['disk'])
+        else:
+            tolerance = Failures(0, 0, 0, 1, 2)
+
         pver = ConfPver.build(m0conf, pool_id, pd_attrs, drives, tolerance)
         if t is PoolT.dix:
             assert m0conf[parent].imeta_pver is None
@@ -1796,18 +1820,22 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
-        ctrl_id = None
+        encl_id = ConfEnclosure.build(conf, rack_id, node_id)
+        ctrl_ids: List[Tuple[Optional[Oid], Any]] = []
         m0ds = node.get('m0_servers', [])
-        if any(m0d['_io_disks'] for m0d in m0ds):
-            ctrl_id = ConfController.build(conf,
-                                           ConfEnclosure.build(conf, rack_id,
-                                                               node_id))
+        for m0d in m0ds:
+            if m0d['_io_disks']:
+                ctrl_ids.append((ConfController.build(conf, encl_id), m0d))
+            else:
+                ctrl_ids.append((None, m0d))
         ConfProcess.build(conf, node_id, node, ProcT.hax)
 
         confd_p = False
-        for m0d in m0ds:
+        for ctrl_id in ctrl_ids:
+            m0d = ctrl_id[1]
+            conf_ctrl_id: Optional[Oid] = ctrl_id[0]
             ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
-                              ctrl_id)
+                              conf_ctrl_id)
             if m0d['runs_confd']:
                 confd_p = True
 

--- a/cfgen/dhall/render/Root.dhall
+++ b/cfgen/dhall/render/Root.dhall
@@ -35,8 +35,7 @@ in
       , named.Oid "mdpool" x.mdpool
       , named.TextUnquoted "imeta_pver"
             (Optional/fold types.Oid x.imeta_pver Text renderOid "(0,0)")
-      , named.Natural "mdredundancy" 1  -- XXX Is this value OK for LDR1?
-                                        --     Check with @madhav.
+      , named.Natural "mdredundancy" (List/length types.Oid x.nodes)
       , "params=[]"
       , named.Oids "nodes" x.nodes
       , named.Oids "sites" x.sites

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -137,7 +137,8 @@ class ConsumerThread(StoppableThread):
                     self.consul.update_process_status(
                         ConfHaProcess(
                             chp_event=event,
-                            chp_type=m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                            chp_type=(
+                                m0HaProcessType.M0_CONF_HA_PROCESS_M0D.value),
                             chp_pid=0,
                             fid=state.fid))
                 new_ha_states.append(

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -88,6 +88,11 @@ ha_process_events = ('M0_CONF_HA_PROCESS_STARTING',
                      'M0_CONF_HA_PROCESS_STOPPING',
                      'M0_CONF_HA_PROCESS_STOPPED')
 
+motr_event_types = ('M0_CONF_HA_PROCESS_OTHER',
+                    'M0_CONF_HA_PROCESS_KERNEL',
+                    'M0_CONF_HA_PROCESS_M0MKFS',
+                    'M0_CONF_HA_PROCESS_M0D')
+
 ha_conf_obj_states = ('M0_NC_UNKNOWN',
                       'M0_NC_ONLINE',
                       'M0_NC_FAILED',
@@ -372,7 +377,7 @@ class ConsulUtil:
 
     def get_svc_status(self, srv_fid: Fid) -> str:
         try:
-            return self.get_process_status(srv_fid)
+            return self.get_process_status(srv_fid)[0]
         except Exception:
             return 'Unknown'
 
@@ -512,10 +517,10 @@ class ConsulUtil:
             pfid = self.get_service_process_fid(svc_fid)
         else:
             pfid = create_process_fid(fidk)
-        if (self.get_process_status(pfid) in ('M0_CONF_HA_PROCESS_STARTING',
-                                              'M0_CONF_HA_PROCESS_STARTED',
-                                              'M0_CONF_HA_PROCESS_STOPPING',
-                                              'Unknown')):
+        if (self.get_process_status(pfid)[0] in ('M0_CONF_HA_PROCESS_STARTING',
+                                                 'M0_CONF_HA_PROCESS_STARTED',
+                                                 'M0_CONF_HA_PROCESS_STOPPING',
+                                                 'Unknown')):
             return HaNoteStruct.M0_NC_ONLINE
         else:
             return HaNoteStruct.M0_NC_FAILED
@@ -693,7 +698,8 @@ class ConsulUtil:
         assert 0 <= event.chp_event < len(ha_process_events), \
             f'Invalid event type: {event.chp_event}'
         local_node = self.get_local_nodename()
-        data = json.dumps({'state': ha_process_events[event.chp_event]})
+        data = json.dumps({'state': ha_process_events[event.chp_event],
+                           'type': motr_event_types[event.chp_type]})
         # Maintain statuses for all the motr processes in the cluster
         # for every node so that in case of 1 or more node failures,
         # as every node will receive the node failure event, the failed
@@ -824,14 +830,15 @@ class ConsulUtil:
         return self.sdev_to_drive_fid(sdev_fid)
 
     # Returns status of process from its local node.
-    def get_process_status(self, fid: Fid) -> str:
+    def get_process_status(self, fid: Fid) -> Tuple[str, str]:
         proc_node = self.get_process_node(fid)
         key = f'{proc_node}/processes/{fid}'
         status = self.kv.kv_get(key)
         if status:
-            return str(json.loads(status['Value'])['state'])
+            return (str(json.loads(status['Value'])['state']),
+                    str(json.loads(status['Value'])['type']))
         else:
-            return 'Unknown'
+            return ('Unknown', 'Unknown')
 
     def get_process_local_status(self, fid: Fid) -> str:
         local_node = self.get_local_nodename()
@@ -939,15 +946,21 @@ class ConsulUtil:
                     if item['Status'] == 'critical':
                         return ServiceHealth.FAILED
                     pfid = create_process_fid(svc_id)
-                    svc_consul_status = self.get_svc_status(pfid)
+                    cns_status = self.get_process_status(pfid)
                     svc_health = svc_to_motr_status_map[(item['Status'],
-                                                         svc_consul_status)]
+                                                         cns_status[0])]
+                    LOG.debug('consul.status %s svc_health: %s',
+                              str(cns_status), str(svc_health))
                     local_node = self.get_local_nodename()
                     proc_node = self.get_process_node(pfid)
                     if proc_node == local_node:
                         status = svc_health[0]
                     else:
                         status = svc_health[1]
+                    if (status == ServiceHealth.FAILED and
+                            cns_status[0] == 'M0_CONF_HA_PROCESS_STARTED' and
+                            cns_status[1] == 'M0_CONF_HA_PROCESS_M0MKFS'):
+                        status = ServiceHealth.STOPPED
 
                     # This situation is not expected but we handle
                     # the same. Hax may end up here if the process has stopped
@@ -955,7 +968,7 @@ class ConsulUtil:
                     # 'unknown' by Consul. Hax will do nothing in this case
                     # and will report OFFLINE for that process.
                     if (item['Status'] == 'warning' and
-                            svc_consul_status == 'Unknown' and
+                            cns_status[0] == 'Unknown' and
                             status == ServiceHealth.UNKNOWN):
                         status = ServiceHealth.OFFLINE
 
@@ -1055,7 +1068,7 @@ class ConsulUtil:
         self.update_process_status(ev)
 
     def is_confd_failed(self, proc_fid: Fid) -> bool:
-        status = self.get_process_status(proc_fid)
+        status = self.get_process_status(proc_fid)[0]
         return status in ('M0_CONF_HA_PROCESS_STOPPING',
                           'M0_CONF_HA_PROCESS_STOPPED',
                           'M0_CONF_HA_PROCESS_STARTING')


### PR DESCRIPTION
In case of multiple controllers per node, confd.xc, generated by cfgen does include
all the controllers per node as the children of the corresponding enclosure.
This leads to failure domain inconsistencies.

Solution:
- Assign all the controllers for a given node as the conrresopnding enclosure's
children.