### PR TITLE
EOS-21354: Consul always has <=1 retry-join address

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -80,6 +80,11 @@ Try reinstalling Hare on the above mentioned node.";
 }
 
 get_server_nodes() {
+    # Produces the output like this:
+    #
+    # localhost 10.230.240.139
+    # localhost2 10.230.240.140
+    #
     jq -r '.servers[] | "\(.node_name) \(.ipaddr)"' \
        $conf_dir/consul-agents.json
 }
@@ -281,7 +286,14 @@ fi
 abort_if_RC_leader_election_is_impossible
 
 read _ join_ip <<< $(get_server_nodes | grep -w $(node-name))
-read _ join_peers <<< $(get_server_nodes | grep -vw $(node-name))
+
+# get_server_nodes will produce multiple lines. We'll join them with space.
+# Note: in case when get_server_nodes is empty list, consequent awk and tr
+# will exit with non-zero code.
+# In order to swallow this error, `|| true` is needed.
+
+join_peers_opt=$(get_server_nodes | grep -vw "$(node-name)" | awk '{print "--join " $2}' | \
+              tr '\n' ' ' || true)
 
 if [[ -z $join_ip ]]; then
     cat <<'EOF' >&2
@@ -314,7 +326,7 @@ if sudo systemctl --quiet is-active hare-consul-agent; then
 fi
 
 say 'Starting Consul server on this node...'
-join_peers_opt="${join_peers:+--join $join_peers}"
+
 # $join_ip is our bind_ip address
 mk-consul-env --mode server --bind $join_ip $join_peers_opt \
               --extra-options '-ui -bootstrap-expect 1'

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -61,7 +61,7 @@ while true; do
         -h|--help)           usage; exit ;;
         -m|--mode)           mode=$2; shift 2 ;;
         -b|--bind)           bind_addr=$2; shift 2 ;;
-        -j|--join)           join_addr=$2; shift 2 ;;
+        -j|--join)           join_addr="$join_addr $2"; shift 2 ;;
         -e|--extra-options)  extra_opts=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   echo 'getopt: internal error...'; exit 1 ;;
@@ -81,8 +81,15 @@ sed -r -e "s/^(NODE=).*/\1$(node-name)/" \
     sudo tee $ENV_FILE >/dev/null
 
 if [[ -n $join_addr ]]; then
-    sudo sed -r -e "s/^(JOIN=).*/\1${join_addr:+-retry-join $join_addr}/" \
-             -i $ENV_FILE
+    # join_addr is not empty and it contains one or more ip addresses separated
+    # by space.
+    # Multiple server addresses must turn into multiple '-retry-join ipN'.
+    # For instance:
+    # '127.0.0.1 192.168.0.1' => '-retry-join 127.0.0.1 -retry-join 192.168.0.1'
+
+    retry_str="$(echo "$join_addr" | \
+                 awk '{for (i=1; i <= NF; ++i) printf " -retry-join "$i }')"
+    sudo sed -r -e "s/^(JOIN=).*/\1$retry_str/" -i $ENV_FILE
 fi
 
 if [[ -n $extra_opts ]]; then


### PR DESCRIPTION
JIRA issue: [EOS-21354](https://jts.seagate.com/browse/EOS-21354)

In case when there are N nodes in Consul cluser, each Consul server
should have (N-1) IP addresses in retry-join list. Current
implementation adds not more than 1 retry-join address.

## Why it is a problem
When a node reboots Consul agent needs to join back to the cluster.
Servers in retry-join list are the ones that will be used to connect
back to the cluster (or form it in case when Raft quorum used to be
lost). If retry-join contains one address only, that address becomes
single point of failure: once that node is down, other Consul agents
will not be able to reconnect to the cluster.

## Solution
Modify bash scripts to allow multiple retry-join arguments.
