### PR TITLE
EOS-22129:Miniprovisioner cdf generator doesn't take devices from cvg[1]

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -98,9 +98,14 @@ class CdfGenerator:
         conf = self.provider
         pool_type = pool.pool_type
         prop_name = 'data_devices'
+        cvg_num = int(conf.get(f'server_node>{node}>storage>cvg_count'))
+        all_cvg_devices = []
         if pool_type == 'dix':
             prop_name = 'metadata_devices'
-        return conf.get(f'server_node>{node}>storage>cvg[0]>{prop_name}')
+        for i in range(cvg_num):
+            all_cvg_devices += conf.get(
+                f'server_node>{node}>storage>cvg[{i}]>{prop_name}')
+        return all_cvg_devices
 
     def _get_server_nodes(self, pool: PoolHandle) -> List[str]:
         cid = pool.cluster_id

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -39,6 +39,7 @@
       },
       "s3_instances": "1",
       "storage": {
+        "cvg_count": "1",
         "cvg": [
           {
             "data_devices": [
@@ -78,6 +79,7 @@
       },
       "s3_instances": "1",
       "storage": {
+        "cvg_count": "1",
         "cvg": [
           {
             "data_devices": [
@@ -117,6 +119,7 @@
       },
       "s3_instances": "1",
       "storage": {
+        "cvg_count": "1",
         "cvg": [
           {
             "data_devices": [

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -114,12 +114,18 @@ class TestCDF(unittest.TestCase):
                 'tcp',
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
+                'server_node>MACH_ID>storage>cvg[1]>data_devices':
+                ['/dev/sdc'],
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
+                'server_node>MACH_ID>storage>cvg_count':
+                2,
                 'server_node>MACH_ID>storage>cvg':
-                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta']}],
+                [{'data_devices': ['/dev/sdb', '/dev/sdc'], 'metadata_devices': ['/dev/meta', '/dev/meta1']}],
                 'server_node>MACH_ID>storage>cvg[0]>metadata_devices':
                 ['/dev/meta'],
+                'server_node>MACH_ID>storage>cvg[1]>metadata_devices':
+                ['/dev/meta1'],
                 'server_node>MACH_ID>s3_instances':
                 1,
                 'cluster>CLUSTER_ID>site>storage_set_count':
@@ -165,10 +171,13 @@ class TestCDF(unittest.TestCase):
                 'cluster>cluster_id': 'CLUSTER_ID',
                 'server_node': {'MACH_ID': {'cluster_id': 'CLUSTER_ID'}},
                 'server_node>MACH_ID>cluster_id': 'CLUSTER_ID',
+                'server_node>MACH_ID>storage>cvg_count': 2,
                 'server_node>MACH_ID>storage>cvg':
-                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta']}],
+                [{'data_devices': ['/dev/sdb', '/dev/sdc'], 'metadata_devices': ['/dev/meta', '/dev/meta1']}],
                 'server_node>MACH_ID>storage>cvg[0]>data_devices': ['/dev/sdb'],
                 'server_node>MACH_ID>storage>cvg[0]>metadata_devices': ['/dev/meta'],
+                'server_node>MACH_ID>storage>cvg[1]>data_devices': ['/dev/sdc'],
+                'server_node>MACH_ID>storage>cvg[1]>metadata_devices': ['/dev/meta1'],
                 'server_node>MACH_ID>hostname':                'myhost',
                 'server_node>MACH_ID>name': 'mynodename',
                 'server_node>MACH_ID>network>data>interface_type':                'o2ib',
@@ -237,10 +246,14 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'server_node>srvnode_1>s3_instances':
                 1,
+                'server_node>srvnode_1>storage>cvg_count':
+                2,
                 'server_node>srvnode_1>storage>cvg':
-                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta']}],
+                [{'data_devices': ['/dev/sdb', '/dev/sdc'], 'metadata_devices': ['/dev/meta', '/dev/meta1']}],
                 'server_node>srvnode_1>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
+                'server_node>srvnode_1>storage>cvg[1]>data_devices':
+                ['/dev/sdc'],
             }
             return data.get(value)
 
@@ -261,7 +274,7 @@ class TestCDF(unittest.TestCase):
                 'cluster>CLUSTER_ID>storage_set>server_node_count':
                 1,
                 'cluster>CLUSTER_ID>storage_set[0]>durability>sns': {'stub': 1},
-                'cluster>CLUSTER_ID>storage_set[0]>durability>sns>data': 2,
+                'cluster>CLUSTER_ID>storage_set[0]>durability>sns>data': 4,
                 'cluster>CLUSTER_ID>storage_set[0]>durability>sns>parity': 0,
                 'cluster>CLUSTER_ID>storage_set[0]>durability>sns>spare': 0,
                 'cluster>CLUSTER_ID>storage_set[0]>name':
@@ -284,10 +297,16 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
                 1,
+                'server_node>MACH_ID>storage>cvg_count':
+                2,
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
                 'server_node>MACH_ID>storage>cvg[0]>metadata_devices':
                 ['/dev/meta'],
+                'server_node>MACH_ID>storage>cvg[1]>data_devices':
+                ['/dev/sdc'],
+                'server_node>MACH_ID>storage>cvg[1]>metadata_devices':
+                ['/dev/meta1'],
             }
             return data.get(value)
 
@@ -374,10 +393,16 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
                 1,
+                'server_node>MACH_ID>storage>cvg_count':
+                2,
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
                 'server_node>MACH_ID>storage>cvg[0]>metadata_devices':
                 ['/dev/meta'],
+                'server_node>MACH_ID>storage>cvg[1]>data_devices':
+                ['/dev/sdc'],
+                'server_node>MACH_ID>storage>cvg[1]>metadata_devices':
+                ['/dev/meta1'],
             }
             return data.get(value)
 
@@ -385,7 +410,7 @@ class TestCDF(unittest.TestCase):
         ret = CdfGenerator(provider=store)._create_pool_descriptions()
         self.assertEqual(1, len(ret))
         diskrefs = ret[0].disk_refs.get()
-        self.assertEqual(1, len(diskrefs))
+        self.assertEqual(2, len(diskrefs))
         self.assertEqual(Text('/dev/meta'), diskrefs[0].path)
 
     def test_both_dix_and_sns_pools_can_exist(self):
@@ -425,10 +450,16 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
                 1,
+                'server_node>MACH_ID>storage>cvg_count':
+                2,
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sda', '/dev/sdb'],
                 'server_node>MACH_ID>storage>cvg[0]>metadata_devices':
                 ['/dev/meta'],
+                'server_node>MACH_ID>storage>cvg[1]>data_devices':
+                ['/dev/sdc', '/dev/sdd'],
+                'server_node>MACH_ID>storage>cvg[1]>metadata_devices':
+                ['/dev/meta1'],
             }
             return data.get(value)
 
@@ -439,11 +470,11 @@ class TestCDF(unittest.TestCase):
                          [t.name.s for t in ret])
 
         diskrefs_sns = ret[0].disk_refs.get()
-        self.assertEqual([Text('/dev/sda'), Text('/dev/sdb')],
+        self.assertEqual([Text('/dev/sda'), Text('/dev/sdb'), Text('/dev/sdc'), Text('/dev/sdd')],
                          [t.path for t in diskrefs_sns])
 
         diskrefs_dix = ret[1].disk_refs.get()
-        self.assertEqual(1, len(diskrefs_dix))
+        self.assertEqual(2, len(diskrefs_dix))
         self.assertEqual(Text('/dev/meta'), diskrefs_dix[0].path)
 
     def test_metadata_is_hardcoded(self):


### PR DESCRIPTION
Problem :
The miniprovisioner CDF generator utility doesn't take devices
from both (all) the cvgs but just one (cvg[0]).
Solution :
All the devices present in all cvg are read now, using this PR.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>