### PR TITLE
EOS-21420: motr rconfc_stop fails during hax shutdown

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -57,6 +57,7 @@ class ConsumerThread(StoppableThread):
         self.consul = consul
         self.eq_publisher = EQPublisher()
         self.herald = herald
+        self.idx = idx
 
     def stop(self) -> None:
         self.is_stopped = True
@@ -258,7 +259,8 @@ class ConsumerThread(StoppableThread):
                     planner.notify_finished(item)
         except StopIteration:
             LOG.info('Consumer Stopped')
-            motr.stop()
+            if self.idx == 0:
+                motr.stop()
             motr.shun_motr_thread()
         finally:
             LOG.info('Handler thread has exited')


### PR DESCRIPTION
With the addition of multiple Hax consumer threads, motr::stop()
was invoked from multiple threads which lead to multiple invocations
of rconfc_stop() during Hax shutdown. Motr rconfc might get finalised
in one of these calls. Thus a subsequent call to rconfc_stop would
fail due to already destroyed or invalid structure.

Solution:
- Allow only consumer thread 0 to invoke motr::stop() and finalise
rconfc.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>