### PR TITLE
EOS-22227: Hare reports device failures for motr m0mkfs process

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -138,7 +138,8 @@ class ConsumerThread(StoppableThread):
                     self.consul.update_process_status(
                         ConfHaProcess(
                             chp_event=event,
-                            chp_type=m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                            chp_type=int(
+                                m0HaProcessType.M0_CONF_HA_PROCESS_M0D),
                             chp_pid=0,
                             fid=state.fid))
                 new_ha_states.append(

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -250,7 +250,7 @@ class m0HaProcessEvent(IntEnum):
         return m0ProcessEvToSvcHealth[self]
 
 
-class m0HaProcessType(Enum):
+class m0HaProcessType(IntEnum):
     M0_CONF_HA_PROCESS_OTHER = 0
     M0_CONF_HA_PROCESS_KERNEL = 1
     M0_CONF_HA_PROCESS_M0MKFS = 2

--- a/rfc/4/README.md
+++ b/rfc/4/README.md
@@ -33,7 +33,7 @@ Key | Value | Description
 `m0conf/sites/<site_fid>/racks/<rack_fid>/encls/<encl_fid>` | `{ "node": "<node_fid>", "state": "<HA state>" }` | Fid of the corresponding node and [HA state](#ha-state) of this enclosure.
 `m0conf/sites/<site_fid>/racks/<rack_fid>/encls/<encl_fid>/ctrls/<ctrl_fid>` | `{ "state": "<HA state>" }` | [HA state](#ha-state) of this controller.
 `m0conf/sites/<site_fid>/racks/<rack_fid>/encls/<encl_fid>/ctrls/<ctrl_fid>/drives/<drive_fid>` | `{ "dev": "<sdev_fid>", "state": "<HA state>" }` | Fid of the corresponding storage device and [HA state](#ha-state) of this drive.
-`processes/<fid>` | `{ "state": "<HA state>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`.
+`processes/<fid>` | `{ "state": "<HA state>", "type": "<Motr process type>" }` | The items are created and updated by `hax` processes.  Supported values of \<HA state\>: `M0_CONF_HA_PROCESS_STARTING`, `M0_CONF_HA_PROCESS_STARTED`, `M0_CONF_HA_PROCESS_STOPPING`, `M0_CONF_HA_PROCESS_STOPPED`. Supported values of Motr process types: `M0_CONF_HA_PROCESS_OTHER`, `M0_CONF_HA_PROCESS_KERNEL`, `M0_CONF_HA_PROCESS_M0MKFS`, `M0_CONF_HA_PROCESS_M0D`.
 `sspl.SYSTEM_INFORMATION.log_level` | | This key is used by SSPL.
 `stats/filesystem` | JSON object | See ['stats/filesystem' value](#statsfilesystem-value) below.
 `timeout` | YYYYmmddHHMM.SS | This value is used by the RC timeout mechanism.


### PR DESCRIPTION
Motr panic: (!pver->pv_is_dirty) is seen in motr-mkfs completion window,
where the Consul KV for motr process status is updated to STARTED for motr-mkfs
process and Consul reports warning for the same, this happens when motr-mkfs
start shuting down but has not reported STOPPING yet or due to delayed Consul
warning notification. Hare thinks that process crashed because Consul reported
a warning and process status remained started but not stopping or stopped.

Solution:
This needs to be handled by storing additional information and checking for
the process type (M0MKFS or M0D) along with process status.
Thus if the process status evaluates to FAILED based on Consul service status
and present process status in Consul KV but the process type is M0MKFS then
report STOPPED instead of FAILED so that no device failures are reported for
the process. This needs to be handled for motr process type M0D in-order to
handle a cluster node shutdown, where the devices must be marked FAILED to
facilitate degraded IO. For motr process type M0D this situation is not expected
because Motr process is expected to be running if its corresponding Consul KV
status is STARTED or the current Consul service status for the same is warning
if the process is genuinely stopped or the corresponding node itself has stopped.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>