### PR TITLE
EOS-21389: motr rconfc_stop fails due to spiel not ready

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -103,7 +103,8 @@ class Motr:
         LOG.info('Stopping motr')
         self.is_stopping = True
         self.notify_hax_stop()
-        self.stop_rconfc()
+        if self.is_spiel_ready():
+            self.stop_rconfc()
         self._ffi.motr_stop(self._ha_ctx)
 
     def fini(self):


### PR DESCRIPTION
### Problem:
  rconfc_stop was invoked before completion of rconfc_start.
  This is indicated by spiel_ready.

### Solution: 
Invoke rconfc_stop if rconfc_start is complete.

### Testing:
Looped through 100+ iterations of hare_setup init stage. Panic didn't appear.
> ======================================================================================
start_count=130,
Thu Jul  8 03:56:46 MDT 2021
======================================================================================
panic_cnt_n1_after = 0
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@


Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>