### PR TITLE
EOS-21424: Cortx-HA conflicts with hax systemd unit

### DIFF
--- a/provisioning/miniprov/hare_mp/systemd.py
+++ b/provisioning/miniprov/hare_mp/systemd.py
@@ -15,3 +15,24 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
+
+import re
+from typing import List
+
+
+class HaxUnitTransformer:
+    def transform(self, contents: List[str]) -> List[str]:
+        result = []
+        # Note that more matchers may be required in the future.
+        # E.g. when HA starts controlling motr-kernel, we may want to disable
+        # 'After' dependency.
+        matchers = [
+            r'^[\s]*Restart=',
+        ]
+        for line in contents:
+            out = line
+            if any(re.match(i, line) for i in matchers):
+                out = f'# {line} # - Added by Hare Mini Provisioner'
+            result.append(out)
+
+        return result

--- a/provisioning/miniprov/hare_mp/validator.py
+++ b/provisioning/miniprov/hare_mp/validator.py
@@ -14,9 +14,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
-# report unsupported features, etc.
-
 import socket
 from hare_mp.store import ValueProvider
 

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -16,9 +16,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
-# report unsupported features, etc.
-
 # flake8: noqa
 #
 import os

--- a/provisioning/miniprov/test/test_systemd.py
+++ b/provisioning/miniprov/test/test_systemd.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# flake8: noqa
+#
+import unittest
+from typing import List
+
+from hare_mp.systemd import HaxUnitTransformer
+
+
+class TestHaxUnitTrasform(unittest.TestCase):
+    def test_empty_source_results_empty(self):
+        source: List[str] = []
+        output = HaxUnitTransformer().transform(source)
+        self.assertEqual([], output)
+
+    def test_restart_commented(self):
+        source: List[str] = ['Restart=on-failure']
+        output = HaxUnitTransformer().transform(source)
+        self.assertRegex(output[0], r'^#.*')
+
+    def test_not_everything_commented(self):
+        source = '''[Unit]
+Description=HAX daemon for Hare
+Requires=hare-consul-agent.service motr-kernel.service
+After=hare-consul-agent.service motr-kernel.service
+
+[Service]
+# TODO: '/opt/seagate/cortx/hare' prefix can be different, e.g. '/usr'
+SyslogIdentifier=hare-hax
+Environment=PYTHONPATH=/opt/seagate/cortx/hare/lib64/python3.6/site-packages:/opt/seagate/cortx/hare/lib/python3.6/site-packages
+ExecStart=/bin/sh -c 'cd /var/motr/hax && exec /opt/seagate/cortx/hare/bin/hax'
+KillMode=process'''
+        output = HaxUnitTransformer().transform(source.splitlines())
+        self.assertEqual(source, '\n'.join(output))

--- a/provisioning/miniprov/test/test_validator.py
+++ b/provisioning/miniprov/test/test_validator.py
@@ -16,9 +16,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
-# report unsupported features, etc.
-
 # flake8: noqa
 import unittest
 import json


### PR DESCRIPTION
JIRA ticket: [EOS-21424](https://jts.seagate.com/browse/EOS-21424)

Solution: when deploying via mini provisioner, Hare must update hax'
systemd unit so that the following statements get commented out:
1. Requires=
2. After=
3. Restart=