### PR TITLE
EOS-22340 correction in hare's test interface usage

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -501,7 +501,16 @@ def add_subcommand(subparser,
     parser = subparser.add_parser(command, help=help_str)
     parser.set_defaults(func=handler_fn)
 
-    parser.add_argument('--config',
+    if config_required:
+        requiredArg = parser.add_argument_group('required argument')
+        requiredArg.add_argument('--config',
+                        help='Conf Store URL with cluster info',
+                        required=config_required,
+                        nargs=1,
+                        type=str,
+                        action='store')
+    else:
+        parser.add_argument('--config',
                         help='Conf Store URL with cluster info',
                         required=config_required,
                         nargs=1,
@@ -521,7 +530,9 @@ def add_file_argument(parser):
 
 
 def add_plan_argument(parser):
-    parser.add_argument('--plan',
+    requiredArg = parser.add_argument_group('required argument')
+
+    requiredArg.add_argument('--plan',
                         help='Testing plan to be executed. Supported '
                         'values:' + str([e.value for e in Plan]),
                         required=True,


### PR DESCRIPTION
**Problem:** Currently all the arguments are listed under optional args even if they are 'required'
```
[root@ssc-vm-5774 ~]# /opt/seagate/cortx/hare/bin/hare_setup test -h
usage: hare_setup test [-h] --config CONFIG [--file FILE]

optional arguments:
  -h, --help       show this help message and exit
  --config CONFIG  Conf Store URL with cluster info
  --file FILE      Full path to the CDF file.
```

**Note:** This is known behavior(issue) according to following thread
https://stackoverflow.com/questions/24180527/argparse-required-arguments-listed-under-optional-arguments/24181138

Solution is to use `add_argument_group`

```
[root@ssc-vm-5245 hare]# /opt/seagate/cortx/hare/bin/hare_setup init -h
usage: hare_setup init [-h] --config CONFIG [--file FILE]

optional arguments:
  -h, --help       show this help message and exit
  --file FILE      Full path to the CDF file.

required argument:
  --config CONFIG  Conf Store URL with cluster info
```

Also there is one more thing, as can be seen below,
```
[root@ssc-vm-5245 hare]# /opt/seagate/cortx/hare/bin/hare_setup test -h
usage: hare_setup test [-h] --config CONFIG [--file FILE] --plan PLAN
                       [--param PARAM]

optional arguments:
  -h, --help       show this help message and exit
  --file FILE      Full path to the CDF file.
  --param PARAM    Test input URL.

required argument:
  --config CONFIG  Conf Store URL with cluster info

required argument:
  --plan PLAN      Testing plan to be executed. Supported values:['sanity',
                   'regression', 'full', 'performance', 'scalability']
```

As we can see, if there are multiple required args then they will be listed in above format