### PR TITLE
EOS-15803 : Support: support bundle enhancements - Move /var/log/hare to /var/log/seagate/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ install-dirs:
 		  $(HARE_RULES) \
 		  $(ETC_CRON_DIR) \
 		  $(DESTDIR)/run/cortx \
-		  $(DESTDIR)/var/log/hare \
+		  $(DESTDIR)/var/log/seagate/hare \
 		  $(DESTDIR)/etc/logrotate.d \
 		  $(DESTDIR)/var/motr/hax; \
 	 do \
@@ -472,7 +472,7 @@ uninstall:
 	          $(DESTDIR)/$(PREFIX) \
 	          $(DESTDIR)/usr/bin/hctl \
 	          $(DESTDIR)/var/lib/hare \
-	          $(DESTDIR)/var/log/hare \
+	          $(DESTDIR)/var/log/seagate/hare \
 	          $(DESTDIR)/var/motr/hax; \
 	 do \
 	     if [[ -e $$d ]]; then \

--- a/provisioning/hare-logrotate
+++ b/provisioning/hare-logrotate
@@ -1,4 +1,4 @@
-/var/log/hare/*.log
+/var/log/seagate/hare/*.log
 {
     rotate 10
     maxsize 50M

--- a/provisioning/logrotate/hare
+++ b/provisioning/logrotate/hare
@@ -1,4 +1,4 @@
-/var/log/hare/*.log
+/var/log/seagate/hare/*.log
 {
     rotate 10
     maxsize 50M

--- a/provisioning/logrotate/physical
+++ b/provisioning/logrotate/physical
@@ -1,4 +1,4 @@
-/var/log/hare/*.log
+/var/log/seagate/hare/*.log
 {
     rotate 10
     maxsize 50M

--- a/provisioning/logrotate/virtual
+++ b/provisioning/logrotate/virtual
@@ -1,4 +1,4 @@
-/var/log/hare/*.log
+/var/log/seagate/hare/*.log
 {
     rotate 10
     maxsize 50M

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -310,8 +310,8 @@ def cleanup(args):
 
 def logs_cleanup():
     try:
-        logging.info('Cleaning up hare log directory(/var/log/hare)')
-        os.system('rm -rf /var/log/hare')
+        logging.info('Cleaning up hare log directory(/var/log/seagate/hare)')
+        os.system('rm -rf /var/log/seagate/hare')
 
         return 0
     except Exception as error:

--- a/utils/consul-watch-handler
+++ b/utils/consul-watch-handler
@@ -50,7 +50,7 @@ set -eu -o pipefail
 #   $ consul catalog services
 
 # Redirect all printouts to the log file with the timestamp prefix:
-exec &>> /var/log/hare/${0##*/}.log
+exec &>> /var/log/seagate/hare/${0##*/}.log
 exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 
 jq '[.[] | { "Node": .Node.Node,

--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -30,10 +30,10 @@ set -eu -o pipefail
 # $ consul watch -type=key -key leader elect-rc-leader
 #
 
-sudo mkdir -p /var/log/hare
+sudo mkdir -p /var/log/seagate/hare
 
 # Redirect all printouts to the log file with the timestamp prefix:
-exec &>> /var/log/hare/consul-${0##*/}.log
+exec &>> /var/log/seagate/hare/consul-${0##*/}.log
 exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 
 export SRC_DIR="$(dirname $(readlink -f $0))"

--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -112,7 +112,7 @@ done
 
 cp --parents /var/lib/hare/* . 2>/dev/null || true
 cp -r --parents /var/lib/hare/consul-{env,server,client}-* . 2>/dev/null || true
-cp -r --parents /var/log/hare/ . 2>/dev/null || true
+cp -r --parents /var/log/seagate/hare/ . 2>/dev/null || true
 cp -r --parents /var/log/cluster/ . 2>/dev/null || true
 
 cd ..

--- a/utils/proto-rc
+++ b/utils/proto-rc
@@ -37,7 +37,7 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 #
 
 # Redirect all printouts to the log file with the timestamp prefix:
-LOGFILE="/var/log/hare/consul-${0##*/}.log"
+LOGFILE="/var/log/seagate/hare/consul-${0##*/}.log"
 exec &>> ${LOGFILE}
 exec &> >(stdbuf --output=L gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 


### PR DESCRIPTION
Solution :
Redirect logs to Hare support bundle '/var/log/seagate/hare'.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>