### PR TITLE
EOS-22106: Devices are marked offline on process failure

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -386,7 +386,7 @@ class Motr:
                   proc_fid, len(disk_list), int(new_state), disk_list)
         if disk_list:
             state = (ServiceHealth.OK if new_state ==
-                     HaNoteStruct.M0_NC_ONLINE else ServiceHealth.FAILED)
+                     HaNoteStruct.M0_NC_ONLINE else ServiceHealth.OFFLINE)
             # XXX: Need to check the current state of the device, transition
             # to ONLINE only in case of an explicit request or iff the prior
             # state of the device is UNKNOWN/OFFLINE.


### PR DESCRIPTION
### Problem:
Devices are marked failed, when the corresponding ios service
fails. However, when the service comes back online, device states
remains failed as only explicit device events can mark device online.

### Solution: 
Marking the device states to offline on process failure,
ensures that, on process coming back online, all the devices can be
updated from offline to online except failed ones.

