### PR TITLE
EOS-20861: Hare consul services are disabled on freshly deployed VM

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -197,11 +197,22 @@ def post_install(args):
         exit(-1)
 
 
+def enable_hare_consul_agent() -> None:
+    cmd = ['systemctl', 'enable', 'hare-consul-agent']
+    execute(cmd)
+
+
+def disable_hare_consul_agent() -> None:
+    cmd = ['systemctl', 'disable', 'hare-consul-agent']
+    execute(cmd)
+
+
 def init(args):
     try:
         rc = 0
         url = args.config[0]
         validator = Validator(ConfStoreProvider(url))
+        disable_hare_consul_agent()
         if validator.is_first_node_in_cluster():
             path_to_cdf = args.file[0]
             if not is_cluster_running() and bootstrap_cluster(
@@ -211,6 +222,7 @@ def init(args):
             if rc == 0:
                 wait_for_cluster_start(url)
             shutdown_cluster()
+        enable_hare_consul_agent()
         exit(rc)
     except Exception as error:
         logging.error('Error while initializing the cluster (%s)', error)


### PR DESCRIPTION
Cortx-ha does not manage hare-consul-agent.service being a 3rd party software.
Presently, by default, hare-consul-agent.service is disabled as part of cortx
deployment. In-order to support automatic restart in case of node restart and
because hare-consul-agent.service is not managed by cortx-ha, the systemd unit
needs to be enabled post hare deployment.
But a non cortx-ha deployments does not require hare-consul-agent.service to be
enabled and this will change post Hare starts using the default consul service
instead of hare-consul-agent.service as part of Hare-Consul separation.

Solution:
Enable hare-consul-agent.service post init phase of Hare deployment.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>