### PR TITLE
Problem: allowed enclosure faillures is not populated for dix/md pools

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1293,7 +1293,8 @@ class ConfPool(ToDhall):
                                  d['disk'])
         else:
             md_allowed_failures = len(cluster_encls(m0conf)) - 1
-            tolerance = Failures(0, 0, 0, min(1, md_allowed_failures),
+            tolerance = Failures(0, 0, min(1, md_allowed_failures),
+                                 min(1, md_allowed_failures),
                                  md_allowed_failures)
 
         pver = ConfPver.build(m0conf, pool_id, pd_attrs, drives, tolerance)


### PR DESCRIPTION
The default allowed enclosure failures for dix/md pools is not populated which
may cause inconsistencies while wrting meta data further causing IO failures
in case of enclosure or node failures.

Solution:
Calculate and populate allowed enclosure failures for dix and md pools using
number of enclosures in the cluster.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>