### PR TITLE
EOS-20332: [Hare] SW Upgrade mini-provisioner: pre/post upgrade

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -627,7 +627,12 @@ def main():
                    handler_fn=noop)
 
     add_subcommand(subparser,
-                   'upgrade',
+                   'pre-upgrade',
+                   help_str='Performs the Hare rpm upgrade tasks',
+                   handler_fn=noop)
+
+    add_subcommand(subparser,
+                   'post-upgrade',
                    help_str='Performs the Hare rpm upgrade tasks',
                    handler_fn=noop)
 

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -20,8 +20,11 @@ hare:
   prepare:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup prepare
     args: --config $URL
-  upgrade:
-    cmd: /opt/seagate/cortx/hare/bin/hare_setup upgrade
+  pre-upgrade:
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup pre-upgrade
+    args: --config $URL
+  post-upgrade:
+    cmd: /opt/seagate/cortx/hare/bin/hare_setup post-upgrade
     args: --config $URL
 support_bundle:
   - /opt/seagate/cortx/hare/bin/hare_setup support_bundle


### PR DESCRIPTION
Solution:
The upgrade is used to support component specific upgrade (excluding 3rd software party upgrade which is handled by Provisioner).
So we can provide this feature for disruptive SW upgrade of components.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>