### PR TITLE
Problem: hax does not report the actual drive status in nvec reply

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -71,17 +71,23 @@ class ConsumerThread(StoppableThread):
         # This thread will become blocked until that
         # intermittent error gets resolved.
         motr_to_svc_status = {
-            (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.value,
-                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED.value): (
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
                     ServiceHealth.OK),
-            (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.value,
-                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED.value): (
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
                     ServiceHealth.STOPPED),
-            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D.value,
-                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED.value): (
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
                     ServiceHealth.OK),
-            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D.value,
-                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED.value): (
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
+                    ServiceHealth.FAILED),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
+                    ServiceHealth.OK),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
                     ServiceHealth.FAILED)}
         self.consul.update_process_status(event)
         if event.chp_event in (m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -348,10 +348,8 @@ class Motr:
                   len(event.nvec))
         notes: List[HaNoteStruct] = []
         for n in event.nvec:
-            n.note.no_state = HaNoteStruct.M0_NC_ONLINE
-            if (n.obj_t in (ObjT.PROCESS.name, ObjT.SERVICE.name)):
-                n.note.no_state = self.consul_util.get_conf_obj_status(
-                    ObjT[n.obj_t], n.note.no_id.f_key)
+            n.note.no_state = self.consul_util.get_conf_obj_status(
+                ObjT[n.obj_t], n.note.no_id.f_key)
             notes.append(n.note)
 
         LOG.debug('Replying ha nvec of length ' + str(len(event.nvec)))

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -39,6 +39,15 @@ ObjT = Enum(
         ('SDEV', 0x6400000000000001),
         ('DRIVE', 0x6b00000000000001),
         ('PROFILE', 0x7000000000000001),
+        ('OBJV', 0x6a00000000000001),
+        ('NODE', 0x6e00000000000001),
+        ('SITE', 0x5300000000000001),
+        ('RACK', 0x6100000000000001),
+        ('ENCLOSURE', 0x6500000000000001),
+        ('CONTROLLER', 0x6300000000000001),
+        ('ROOT', 0x7400000000000001),
+        ('POOL', 0x6f00000000000001),
+        ('PVER', 0x7600000000000001)
     ])
 ObjT.__doc__ = 'Motr conf object types and their m0_fid.f_container values'
 


### PR DESCRIPTION
It is important to send actual device status to any motr process
(server/client) joining the cluster in reply to a nvec request.
Hax is replying drive and sdev status as M0_NC_ONLINE by default
instead of fetching the status from Consul KV.
This may lead to notifying the wrong device status to motr process
and cause further failures during IO.

Solution:
Fetch drive and sdev statuses from Consul KV to reply to the nvec
request.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>