### PR TITLE
EOS-23093 help strings for pre/post upgrade change

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -640,12 +640,12 @@ def main():
 
     add_subcommand(subparser,
                    'pre-upgrade',
-                   help_str='Performs the Hare rpm upgrade tasks',
+                   help_str='Performs the Hare rpm pre-upgrade tasks',
                    handler_fn=noop)
 
     add_subcommand(subparser,
                    'post-upgrade',
-                   help_str='Performs the Hare rpm upgrade tasks',
+                   help_str='Performs the Hare rpm post-upgrade tasks',
                    handler_fn=noop)
 
     create_logger_directory()


### PR DESCRIPTION
Help strings for pre/post upgrade modified. Currently it shows "upgrade" for both pre and post upgrades.

Signed-off-by: Vaibhav Paratwar <vaibhav.paratwar@seagate.com>