### PR TITLE
Add chown after sudo make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ and health-checking mechanisms.
   ```sh
   make
   sudo make install
+  sudo chown -R $USER .
   ```
 
 * Add current user to `hare` group.


### PR DESCRIPTION
Adding chown to change the ownership of any files (i.e vendor/) create by the root user during `sudo make install`.  This PR is the replacement of https://github.com/Seagate/cortx-hare/pull/1670.

-----
[View rendered README.md](https://github.com/daniarherikurniawan/cortx-hare/blob/chown-branch/README.md)