### PR TITLE
EOS-19065: Use shared Motr-Hare confstore to populate BE segment1 in CDF

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -30,9 +30,12 @@ class PoolHandle:
 
 
 class CdfGenerator:
-    def __init__(self, provider: ValueProvider):
+    def __init__(self,
+                 provider: ValueProvider,
+                 motr_provider: ValueProvider):
         super().__init__()
         self.provider = provider
+        self.motr_provider = motr_provider
 
     def _get_dhall_path(self) -> str:
         if P.exists(DHALL_PATH):
@@ -277,10 +280,15 @@ class CdfGenerator:
                 f'storage>cvg[{cvg}]>data_devices')], 'List Text')
         return data_devices
 
-    def _get_metadata_device(self, name: str, cvg: int) -> Text:
-        metadata_device = Text(f'/dev/vg_{name}_md{cvg+1}'
-                               f'/lv_raw_md{cvg+1}')
+    def _get_metadata_device(self, name: str, cvg: int, m0d: int) -> Text:
+        motr_store = self.motr_provider
+        metadata_device = Text(motr_store.get(
+            f'server>{name}>cvg[{cvg}]>m0d[{m0d}]>md_seg1'))
         return metadata_device
+
+    def _get_m0d_per_cvg(self, name: str, cvg: int) -> int:
+        motr_store = self.motr_provider
+        return len(motr_store.get(f'server>{name}>cvg[{cvg}]>m0d'))
 
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
@@ -294,18 +302,20 @@ class CdfGenerator:
                 allow_null=True))
         except TypeError:
             no_m0clients = 2
+        # Currently, there is 1 m0d per cvg.
         # We will create 1 IO service entry in CDF per cvg.
         # An IO service entry will use data devices from corresponding cvg.
-        # meta data device is currently hardcoded.
+        # meta data device is taken from motr-hare shared store.
         servers = DList([
             M0ServerDesc(
                 io_disks=DisksDesc(
-                    data=self._get_data_devices(machine_id, i),
+                    data=self._get_data_devices(machine_id, cvg),
                     meta_data=Maybe(
-                        self._get_metadata_device(name, i), 'Text')),
+                        self._get_metadata_device(name, cvg, m0d), 'Text')),
                 runs_confd=Maybe(False, 'Bool'))
-            for i in range(len(store.get(
+            for cvg in range(len(store.get(
                 f'server_node>{machine_id}>storage>cvg')))
+            for m0d in range(self._get_m0d_per_cvg(name, cvg))
         ], 'List M0ServerDesc')
 
         # Adding a Motr confd entry per server node in CDF.

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -31,6 +31,7 @@ from enum import Enum
 from sys import exit
 from time import sleep
 from typing import Any, Callable, Dict, List
+from urllib.parse import urlparse
 
 import yaml
 from cortx.utils.product_features import unsupported_features
@@ -479,8 +480,13 @@ def check_cluster_status(path_to_cdf: str):
     return 0
 
 
-def generate_cdf(url: str) -> str:
-    generator = CdfGenerator(ConfStoreProvider(url))
+def generate_cdf(url: str, motr_md_url: str) -> str:
+    # ConfStoreProvider creates an empty file, if file does not exist.
+    # So, we are validating the file is present or not.
+    if not os.path.isfile(urlparse(motr_md_url).path):
+        raise FileNotFoundError(f'config file: {motr_md_url} does not exist')
+    motr_provider = ConfStoreProvider(motr_md_url, index='motr_md')
+    generator = CdfGenerator(ConfStoreProvider(url), motr_provider)
     return generator.generate()
 
 
@@ -517,7 +523,9 @@ def config(args):
     try:
         url = args.config[0]
         filename = args.file[0] or '/var/lib/hare/cluster.yaml'
-        save(filename, generate_cdf(url))
+        motr_md_path = '/opt/seagate/cortx/motr/conf/motr_hare_keys.json'
+        motr_md_url = 'json://' + motr_md_path
+        save(filename, generate_cdf(url, motr_md_url))
         update_hax_unit('/usr/lib/systemd/system/hare-hax.service')
         generate_config(url, filename)
     except Exception as error:

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -27,7 +27,7 @@ class ValueProvider:
     def get(self, key: str, allow_null: bool = False) -> Any:
         ret = self._raw_get(key)
         if ret is None and not allow_null:
-            raise MissingKeyError(key)
+            raise MissingKeyError(key, self.url)
         return ret
 
     def _raw_get(self, key: str) -> str:
@@ -47,7 +47,7 @@ class ValueProvider:
 
 
 class ConfStoreProvider(ValueProvider):
-    def __init__(self, url: str):
+    def __init__(self, url: str, index='hare'):
         self.url = url
         # Note that we don't instantiate Conf class on purpose.
         #
@@ -64,11 +64,12 @@ class ConfStoreProvider(ValueProvider):
         # That state is also static...
 
         conf = Conf
-        conf.load('hare', url, fail_reload=False)
+        conf.load(index, url, fail_reload=False)
         self.conf = conf
+        self.index = index
 
     def _raw_get(self, key: str) -> str:
-        return self.conf.get('hare', key)
+        return self.conf.get(self.index, key)
 
     def get_machine_id(self) -> str:
         with open('/etc/machine-id', 'r') as f:

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -154,9 +154,10 @@ class ClusterDesc(DhallTuple):
 @dataclass(repr=False)
 class MissingKeyError(Exception):
     key: str
+    url: str
 
     def __str__(self):
-        return f"Required key '{self.key}' not found"
+        return f"Required key '{self.key}' not found in '{self.url}'"
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -98,12 +98,15 @@ class TestCDF(unittest.TestCase):
             #
             # the method will raise an exception if either
             # Dhall is unhappy or some values are not found in ConfStore
-            CdfGenerator(provider=store).generate()
+            cdf = CdfGenerator(provider=store, motr_provider=Mock())
+            cdf._get_m0d_per_cvg = Mock(return_value=1)
+            cdf.generate()
         finally:
             os.unlink(path)
 
     def test_it_works(self):
         store = ValueProvider()
+        motr_store = ValueProvider()
 
         def ret_values(value: str) -> Any:
             data = {
@@ -160,10 +163,26 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
 
-        CdfGenerator(provider=store).generate()
+        def ret_motr_mdvalues(value: str) -> Any:
+            data = {
+                'server>myhost>cvg[0]>m0d':
+                ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
+                'server>myhost>cvg[0]>m0d[0]>md_seg1':
+                '/dev/vg_srvnode-1_md1/lv_raw_md1',
+                'server>myhost>cvg[1]>m0d':
+                ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
+                'server>myhost>cvg[1]>m0d[0]>md_seg1':
+                '/dev/vg_srvnode-1_md2/lv_raw_md2'
+            }
+            return data.get(value)
+
+        motr_store._raw_get = Mock(side_effect=ret_motr_mdvalues)
+
+        CdfGenerator(provider=store, motr_provider=motr_store).generate()
 
     def test_provided_values_respected(self):
         store = ValueProvider()
+        motr_store = ValueProvider()
 
         def ret_values(value: str) -> Any:
             data = {
@@ -202,7 +221,23 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
 
-        ret = CdfGenerator(provider=store)._create_node_descriptions()
+        def ret_motr_mdvalues(value: str) -> Any:
+            data = {
+                'server>mynodename>cvg[0]>m0d':
+                ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
+                'server>mynodename>cvg[0]>m0d[0]>md_seg1':
+                '/dev/vg_srvnode-1_md1/lv_raw_md1',
+                'server>mynodename>cvg[1]>m0d':
+                ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
+                'server>mynodename>cvg[1]>m0d[0]>md_seg1':
+                '/dev/vg_srvnode-1_md2/lv_raw_md2'
+            }
+            return data.get(value)
+
+        motr_store._raw_get = Mock(side_effect=ret_motr_mdvalues)
+
+        ret = CdfGenerator(provider=store,
+                           motr_provider=motr_store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
@@ -210,7 +245,9 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(1, ret[0].s3_instances)
         self.assertEqual(2, ret[0].client_instances)
 
-        ret = CdfGenerator(provider=store)._create_pool_descriptions()
+
+        ret = CdfGenerator(provider=store,
+                           motr_provider=Mock())._create_pool_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('StorageSet-1__sns'), ret[0].name)
@@ -228,7 +265,8 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(0, ret[0].allowed_failures.value.ctrl)
         self.assertEqual(0, ret[0].allowed_failures.value.disk)
 
-        ret = CdfGenerator(provider=store)._create_profile_descriptions(ret)
+        ret = CdfGenerator(provider=store,
+                           motr_provider=Mock())._create_profile_descriptions(ret)
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('Profile_the_pool'), ret[0].name)
@@ -335,7 +373,8 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID1')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID1', 'MACH_ID2', 'MACH_ID3'])
 
-        ret = CdfGenerator(provider=store)._create_pool_descriptions()
+        ret = CdfGenerator(provider=store,
+                           motr_provider=Mock())._create_pool_descriptions()
         self.assertIsInstance(ret, list)
         return ret
 
@@ -390,7 +429,9 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
-        ret = CdfGenerator(provider=store).generate()
+        cdf = CdfGenerator(provider=store, motr_provider=Mock())
+        cdf._get_m0d_per_cvg = Mock(return_value=1)
+        cdf.generate()
 
     def test_invalid_storage_set_configuration_rejected(self):
         ''' This test case checks whether exception will be raise if total
@@ -448,7 +489,8 @@ class TestCDF(unittest.TestCase):
 
         with self.assertRaisesRegex(RuntimeError,
                                     r'Invalid storage set configuration'):
-            CdfGenerator(provider=store)._create_pool_descriptions()
+            CdfGenerator(provider=store,
+                         motr_provider=Mock())._create_pool_descriptions()
 
     def test_md_pool_ignored(self):
         store = ValueProvider()
@@ -493,7 +535,8 @@ class TestCDF(unittest.TestCase):
             return data.get(value)
 
         store._raw_get = Mock(side_effect=ret_values)
-        ret = CdfGenerator(provider=store)._create_pool_descriptions()
+        ret = CdfGenerator(provider=store,
+                           motr_provider=Mock())._create_pool_descriptions()
         self.assertEqual(0, len(ret))
 
     def test_dix_pool_uses_metadata_devices(self):
@@ -550,7 +593,8 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
-        ret = CdfGenerator(provider=store)._create_pool_descriptions()
+        ret = CdfGenerator(provider=store,
+                           motr_provider=Mock())._create_pool_descriptions()
         self.assertEqual(1, len(ret))
         diskrefs = ret[0].disk_refs.get()
         self.assertEqual(2, len(diskrefs))
@@ -614,7 +658,8 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
-        ret = CdfGenerator(provider=store)._create_pool_descriptions()
+        ret = CdfGenerator(provider=store,
+                           motr_provider=Mock())._create_pool_descriptions()
         self.assertEqual(['sns', 'dix'], [t.type.name for t in ret])
         self.assertEqual(['StorageSet-1__sns', 'StorageSet-1__dix'],
                          [t.name.s for t in ret])
@@ -629,6 +674,7 @@ class TestCDF(unittest.TestCase):
 
     def test_metadata_is_hardcoded(self):
         store = ValueProvider()
+        motr_store = ValueProvider()
 
         def ret_values(value: str) -> Any:
             data = {
@@ -639,9 +685,12 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'server_node>MACH_ID>name': 'mynodename',
                 'server_node>MACH_ID>storage>cvg':
-                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta']}],
+                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta1']},
+                 {'data_devices': ['/dev/sdc'], 'metadata_devices': ['/dev/meta2']}],
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
+                'server_node>MACH_ID>storage>cvg[1]>data_devices':
+                ['/dev/sdc'],
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
@@ -657,11 +706,30 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
 
-        ret = CdfGenerator(provider=store)._create_node_descriptions()
+        def ret_motr_mdvalues(value: str) -> Any:
+            data = {
+                'server>mynodename>cvg[0]>m0d':
+                ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
+                'server>mynodename>cvg[0]>m0d[0]>md_seg1':
+                '/dev/vg_srvnode-1_md1/lv_raw_md1',
+                'server>mynodename>cvg[1]>m0d':
+                ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
+                'server>mynodename>cvg[1]>m0d[0]>md_seg1':
+                '/dev/vg_srvnode-1_md2/lv_raw_md2'
+            }
+            return data.get(value)
+
+        motr_store._raw_get = Mock(side_effect=ret_motr_mdvalues)
+
+
+        ret = CdfGenerator(provider=store,
+                           motr_provider=motr_store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
-        self.assertEqual(Text('/dev/vg_mynodename_md1/lv_raw_md1'),
+        self.assertEqual(Text('/dev/vg_srvnode-1_md1/lv_raw_md1'),
                          (ret[0].m0_servers.value.value)[0].io_disks.meta_data.value)
+        self.assertEqual(Text('/dev/vg_srvnode-1_md2/lv_raw_md2'),
+                         (ret[0].m0_servers.value.value)[1].io_disks.meta_data.value)
 
 
     def test_multiple_nodes_supported(self):
@@ -720,7 +788,9 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
 
-        ret = CdfGenerator(provider=store)._create_node_descriptions()
+        cdf = CdfGenerator(provider=store, motr_provider=Mock())
+        cdf._get_m0d_per_cvg = Mock(return_value=1)
+        ret = cdf._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(2, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
@@ -763,6 +833,7 @@ class TestCDF(unittest.TestCase):
             return data[value]
 
         store._raw_get = Mock(side_effect=ret_values)
-
-        ret = CdfGenerator(provider=store)._create_node_descriptions()
+        cdf = CdfGenerator(provider=store, motr_provider=Mock())
+        cdf._get_m0d_per_cvg = Mock(return_value=1)
+        ret = cdf._create_node_descriptions()
         self.assertEqual('None P', str(ret[0].data_iface_type))


### PR DESCRIPTION
### Description:
<html>
<body>
<!--StartFragment-->

prepare | Motr | server>name>cvg[0]>m0d[0]>md_seg1 | /dev/vg_srvnode-1_md1/lv_raw_md1 | string |  
prepare | Motr | server>name>cvg[0]>m0d[0]>md_journal | /dev/vg_srvnode-1_md1/lv_be_log | string |  
prepare | Motr | server>name>cvg[1]>m0d[0]>md_seg0 | /dev/vg_srvnode-1_md2/lv_md2_seg0 | string |  
<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>
The above keys are generated by Motr. Since, we cannot update the global confstore and the keys are specific to Motr-hare.
A shared confstore between hare-motr is required.

This confstore will be available after motr's prepare stage.

Note: Currently, the value for BE segment1 (path to metadata devices) is hard-coded.

### Solution: 

Read BE segment1 using Motr-Hare confStore in config stage.
Update the cluster definition file.

### Tests
Sample **motr_hare_keys.json** file used for testing.

```
{
    "server": {
      "srvnode-1": {
        "cvg": [
          {
            "m0d": [
              {
                "md_seg1": "/dev/vg_srvnode-1_md1/lv_raw_md1"
              }
            ]
          },
          {
            "m0d": [
              {
                "md_seg1": "/dev/vg_srvnode-1_md2/lv_raw_md2"
              }
            ]
          }
        ]
      }
    }
  }
  ```
**CDF** file generated
```
...
nodes:
- m0_servers:
  - io_disks:
      data:
      - /dev/loop0
      - /dev/loop1
      - /dev/loop3
      meta_data: /dev/vg_srvnode-1_md1/lv_raw_md1
    runs_confd: false
  - io_disks:
      data:
      - /dev/loop4
      - /dev/loop5
      - /dev/loop6
      meta_data: /dev/vg_srvnode-1_md2/lv_raw_md2
    runs_confd: false
  - io_disks:
      data: []
      meta_data: null
    runs_confd: true
  data_iface: eth0
  hostname: ssc-vm-4899.colo.seagate.com
...
```

Note: Currently, we need this file at the desired location to be present. Else hare config stage will fail.