### PR TITLE
changes for Miniprovisioner failing for new key

### DIFF
--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -36,6 +36,7 @@
         }
       },
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT", 
         "cvg": [

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -37,6 +37,7 @@
       },
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage": {
+        "cvg_count": "TMPL_CVG_COUNT", 
         "cvg": [
           {
             "data_devices": [


### PR DESCRIPTION
Problem:

Miniprovisioner jenkins job failing for cvg_count & storage_set_id parameter, so adding cvg_count parameter in the template file.
http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/CentOS-7.9.2009/job/Hare/5/console

Snippet of error :

```
23:29:18  fatal: [srvnode-1]: FAILED! => changed=true 
23:29:18    cmd: /opt/seagate/cortx/hare/bin/hare_setup config --config 'json:///opt/seagate/cortx/hare/conf/hare.config.conf.tmpl.1-node' --file '/var/lib/hare/cluster.yaml'
23:29:18    delta: '0:00:00.791333'
23:29:18    end: '2021-07-27 11:59:18.685174'
23:29:18    msg: non-zero return code
23:29:18    rc: 255
23:29:18    start: '2021-07-27 11:59:17.893841'
23:29:18    stderr: 2021-07-27 11:59:18,578 [ERROR] Error performing configuration (Required key 'server_node>8efd697708a8f7e428d3fd520c180795>storage>cvg_count' not found)
23:29:18    stderr_lines: <omitted>
23:29:18    stdout: ''
23:29:18    stdout_lines: <omitted>
```

```
11:32:44  fatal: [srvnode-1]: FAILED! => changed=true 
11:32:44    cmd: /opt/seagate/cortx/hare/bin/hare_setup config --config 'json:///opt/seagate/cortx/hare/conf/hare.config.conf.tmpl.1-node' --file '/var/lib/hare/cluster.yaml'
11:32:44    delta: '0:00:00.819430'
11:32:44    end: '2021-07-29 00:02:44.410383'
11:32:44    msg: non-zero return code
11:32:44    rc: 255
11:32:44    start: '2021-07-29 00:02:43.590953'
11:32:44    stderr: 2021-07-29 00:02:44,288 [ERROR] Error performing configuration (Required key 'server_node>8efd697708a8f7e428d3fd520c180795>storage_set_id' not found)
11:32:44    stderr_lines: <omitted>
11:32:44    stdout: ''
11:32:44    stdout_lines: <omitted>
```

Solution:
Added cvg_count and storage_set_id keys with TMPL values in the template file

Testing:
In later job this issue got resolved and hare_setup init worked well

```
17:42:34  TASK [hare : [mini_provisioning] : Hare Init] **********************************
17:43:26  changed: [srvnode-1] => changed=true 
17:43:26    cmd: /opt/seagate/cortx/hare/bin/hare_setup init --config 'json:///opt/seagate/cortx/hare/conf/hare.init.conf.tmpl.1-node' --file '/var/lib/hare/cluster.yaml'
17:43:26    delta: '0:00:51.280300'
17:43:26    end: '2021-07-29 06:13:26.442779'
17:43:26    rc: 0
17:43:26    start: '2021-07-29 06:12:35.162479'
17:43:26    stderr: |-
17:43:26      Cluster is not running
17:43:26      2021-07-29 06:13:09,882 [INFO] Waiting for all the processes to start..
17:43:26      2021-07-29 06:13:11,891 [INFO] Waiting for all the processes to start..
17:43:26      Stopping s3server@0x7200000000000001:0x17 at ssc-vm-rhev4-0733.colo.seagate.com...
17:43:26      Stopped s3server@0x7200000000000001:0x17 at ssc-vm-rhev4-0733.colo.seagate.com
17:43:26      Stopping m0d@0x7200000000000001:0x9 (ios) at ssc-vm-rhev4-0733.colo.seagate.com...
17:43:26      Stopped m0d@0x7200000000000001:0x9 (ios) at ssc-vm-rhev4-0733.colo.seagate.com
17:43:26      Stopping m0d@0x7200000000000001:0x14 (confd) at ssc-vm-rhev4-0733.colo.seagate.com...
17:43:26      Stopped m0d@0x7200000000000001:0x14 (confd) at ssc-vm-rhev4-0733.colo.seagate.com
17:43:26      Stopping hare-hax at ssc-vm-rhev4-0733.colo.seagate.com...
17:43:26      Stopped hare-hax at ssc-vm-rhev4-0733.colo.seagate.com
17:43:26      Making sure that RC leader can be re-elected next time
17:43:26      Cluster is not running
17:43:26    stderr_lines: <omitted>
17:43:26    stdout: |-
17:43:26      2021-07-29 06:12:36: Generating cluster configuration... OK
17:43:26      2021-07-29 06:12:37: Starting Consul server on this node......... OK
17:43:26      2021-07-29 06:12:44: Importing configuration into the KV store... OK
17:43:26      2021-07-29 06:12:44: Starting Consul on other nodes...Consul ready on all nodes
17:43:26      2021-07-29 06:12:44: Updating Consul configuraton from the KV store... OK
17:43:26      2021-07-29 06:12:46: Waiting for the RC Leader to get elected........ OK
17:43:26      2021-07-29 06:12:51: Starting Motr (phase1, mkfs)... OK
17:43:26      2021-07-29 06:12:59: Starting Motr (phase1, m0d)... OK
17:43:26      2021-07-29 06:13:00: Starting Motr (phase2, mkfs)... OK
17:43:26      2021-07-29 06:13:06: Starting Motr (phase2, m0d)... OK
17:43:26      2021-07-29 06:13:08: Starting S3 servers (phase3)... OK
17:43:26      2021-07-29 06:13:09: Checking health of services... OK
17:43:26    stdout_lines: <omitted>
```
Signed-off-by: Vaibhav Paratwar <vaibhav.paratwar@seagate.com>