### PR TITLE
EOS-22484: RC can't be re-elected after hctl shutdown

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -390,6 +390,17 @@ class ConsulUtil:
             raise HAConsistencyException(
                 'Could not get the leader from Consul')
 
+    def destroy_session(self, session: str) -> None:
+        """
+        Destroys the given Consul Session by name.
+        The method doesn't raise any exception if the session doesn't exist.
+        """
+        try:
+            self.cns.session.destroy(session)
+        except (ConsulException, HTTPError, RequestException) as e:
+            raise HAConsistencyException('Failed to communicate to'
+                                         ' Consul Agent: ' + str(e))
+
     def get_session_node(self, session_id: str) -> str:
         try:
             session = self.cns.session.info(session_id)[1]

--- a/stubs/consul/__init__.pyi
+++ b/stubs/consul/__init__.pyi
@@ -111,6 +111,10 @@ class Session:
         consistency: str = None,
         dc: str = None,
     ) -> Tuple[int, Any]: ...
+    def destroy(
+        self,
+        session_id: str
+    ) -> bool: ...
 
 class ConsulException(Exception): ...
 


### PR DESCRIPTION
Jira issue: [EOS-22484](https://jts.seagate.com/browse/EOS-22484)

As long as Consul is not stopped anymore during hctl shutdown, Consul
Session may be kept alive even if Hare cluster is down. The Consul
Session mechanism is used for RC leader election. In the described
situation in newly started Hare cluster there is no Hax process which
can consider itself as running at RC leader. In particular, this means
that there is no Hax process that would keep updating FS statistics in Consul KV.

When Consul sessions are destructed?

1. When Consul cluster is restarted. It was the case before --skip-consul-stop flag was added.
2. When any the checks registered as a part of contract of this Session start failing.
In case of RC leader session the contract is the health state of confd and hax processes.
NOTE: only "critical" state is a reason for session destruction

Consul monitors the health state of Hare component processes by means of
check-service script. It is written in a way so that if a systemd service
was stopped gracefully, its status will be "warning" (but not "critical").

## Solution:
When hax starts, it should look for a stale RC leader session and
destroy it.

Signed-off-by: Konstantin Nekrasov <konstantin.nekrasov@seagate.com>