### PR TITLE
EOS-22149: Hare system tests - Add Bootstrap-shutdown test case to IVT framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Symptoms:
     19:58:21  make[4]: *** [mypy] Error 1
     ```
 
-Solution: install cortx-py-utils RPM and retry.
+Solution: install cortx-py-utils RPM and retry
 
 <!------------------------------------------------------------------->
 ## See also

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Symptoms:
     19:58:21  make[4]: *** [mypy] Error 1
     ```
 
-Solution: install cortx-py-utils RPM and retry
+Solution: install cortx-py-utils RPM and retry.
 
 <!------------------------------------------------------------------->
 ## See also

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -259,132 +259,6 @@ def test(args):
         exit(-1)
 
 
-def test_hare_prereq():
-    """Test suite for setting the test environment before start of test."""
-    pcs_status = ['pcs', 'status']
-    cluster_stop = ['cortx', 'cluster', 'stop']
-
-    logging.info('Test started on Host: {}'.format(execute(['hostname'])))
-    logging.info('Check that all services are up in PCS.')
-
-    resp = execute(pcs_status)
-    logging.info('PCS status: %s', resp)
-
-    if 'cluster is not currently' in resp:
-        return
-
-    logging.info('Make Node ready for testing, by stopping the cluster.')
-    resp = execute(cluster_stop)
-    logging.info('Cluster Stopped: %s', resp)
-    if 'Cluster stop is in progress' not in resp:
-        logging.error('Cluster is in progress.')
-
-
-def test_hare_postreq(cdf_file: str, timeinfo: str, logfile: str):
-    """Test suite is for restoring the setting after test."""
-    pcs_status = ['pcs', 'status']
-    cluster_start = ['cortx', 'cluster', 'start']
-
-    logging.info('Start the Cluster')
-    resp = execute(cluster_start)
-    logging.info('cluster status: %s', resp)
-    if 'Cluster start operation performed' not in resp:
-        logging.error('Cluster not yet started.')
-
-    logging.info('PCS: Check all services are up.')
-    resp = execute(pcs_status)
-    logging.info('PCS status: %s', resp)
-    if 'stopped' not in resp:
-        logging.error('Some services are not up.')
-
-    logging.info('hctl: Check that all the services are started.')
-    cluster_sts = check_cluster_status(cdf_file)
-    if cluster_sts:
-        resp = execute(['journalctl', '--since', timeinfo, '>', logfile])
-        logging.info('created journal log: %s', logfile)
-        raise Exception('hctl status reports failure.')
-
-    logging.info('Successfully performed cleanup after testing')
-
-
-def _hctlstatus():
-    """know the hctl status."""
-    hctl_status = ['hctl', 'status', '-d']
-    hctl_shutdown = ['hctl', 'shutdown', '--skip-consul-stop']
-
-    process = subprocess.Popen(hctl_status,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE,
-                               encoding='utf8')
-    logging.debug('Issuing CLI command: %s', hctl_status)
-    out, err = process.communicate()
-    exit_code = process.returncode
-    logging.debug('Finished. Exit code: %d', exit_code)
-    if exit_code:
-        if 'Cluster is not running' not in out:
-            resp = execute(hctl_shutdown)
-            logging.info('hctl shutdown: %s', resp)
-            if is_cluster_running():
-                raise Exception('After shutdown, hctl is running.')
-        else:
-            raise Exception(
-                f'Command hctl status exited with error code {exit_code}'
-                f'Command output: {err}')
-    else:
-        raise Exception('Fail to control cluster, exit the test.')
-
-
-def test_hare_bootstrap_shutdown(args):
-    """Test suite for single node hare init in loop."""
-    loop_count = int(args.dev[0])
-    hctl_shutdown = ['hctl', 'shutdown', '--skip-consul-stop']
-
-    test_hare_prereq()
-
-    if is_cluster_running():
-        _hctlstatus()
-
-    logging.info('-------Starting BOOTSTRAP-SHUTDOWN in LOOP-------')
-    for count in range(loop_count):
-        logging.info('Loop count# {}'.format(count + 1))
-        now = datetime.now()     # current date and time
-        date_time = now.strftime("%Y-%m-%d %H:%M:%S")
-        jlog = '~/journal_ctrl_' + now.strftime('%Y_%m_%d_%H%M%S') + '.log'
-
-        logging.info('Start hctl Bootstrap')
-        resp = bootstrap_cluster(str(args.file[0]), True)
-        if resp:
-            logging.error('Failed to bootstrap')
-            resp = execute(['journalctl', '--since', date_time, '>', jlog])
-            logging.info('created journal log: %s', jlog)
-            exit(-1)
-
-        logging.info('Check that all the services are up in hctl.')
-        if is_cluster_running():
-            logging.info('hctl is running.')
-            cluster_sts = check_cluster_status(str(args.file[0]))
-            if cluster_sts:
-                resp = execute(
-                    ['journalctl', '--since', date_time, '>', jlog])
-                logging.info('created journal log: %s', jlog)
-                raise Exception('hctl status reports failure.')
-        else:
-            resp = execute(['journalctl', '--since', date_time, '>', jlog])
-            logging.info('created journal log: %s', jlog)
-            raise Exception('After Bootstrap, hctl is not running.')
-
-        logging.info('Shutdown the cluster.')
-        resp = execute(hctl_shutdown)
-        logging.info('hctl shutdown: %s', resp)
-        if is_cluster_running():
-            resp = execute(['journalctl', '--since', date_time, '>', jlog])
-            logging.info('created journal log: %s', jlog)
-            raise Exception('After shutdown, hctl is running.')
-
-    test_hare_postreq(str(args.file[0]), date_time, jlog)
-
-
 def test_IVT(args):
     try:
         rc = 0
@@ -399,7 +273,8 @@ def test_IVT(args):
                               'running for executing tests')
                 exit(-1)
         else:
-            test_hare_bootstrap_shutdown(args)
+            subprocess.Popen(['pytest', '/root/devTest/eos22149/st/test/test_h'
+                                        'are_bootstrap_shutdown.py', 'args'])
 
         cluster_status = check_cluster_status(path_to_cdf)
         if cluster_status:

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -31,6 +31,7 @@ from enum import Enum
 from sys import exit
 from time import sleep
 from typing import Any, Callable, Dict, List
+from datetime import datetime
 
 import yaml
 from cortx.utils.product_features import unsupported_features
@@ -254,21 +255,202 @@ def test(args):
         exit(-1)
 
 
+def executecmds(cmd: List[str]) -> list:
+    process = subprocess.Popen(cmd,
+                               stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               encoding='utf8')
+    resp = list(process.communicate())
+    resp.append(str(process.returncode))
+
+    return resp
+
+
+def test_hare_prereq():
+    """Test suite for setting the test environment before start of test."""
+    pcs_status = ['pcs', 'status']
+    cluster_stop = ['cortx', 'cluster', 'stop']
+
+    logging.info('Test started on Host: {}'.format(executecmds(['hostname'])))
+    logging.info('Check that all services are up in PCS.')
+
+    resp = executecmds(pcs_status)
+    logging.info('PCS status: %s', resp[0])
+
+    if 'cluster is not currently' in resp[0]:
+        return
+
+    logging.info('Make Node ready for testing, by stopping the cluster')
+    resp = executecmds(cluster_stop)
+    if int(resp[2]):
+        logging.info('Cluster status : %s', resp[0])
+        logging.error('Cluster failed to stop %s', resp[1])
+        raise Exception(
+            f'Command {cluster_stop} exited with error code '
+            f'{int(resp[2])}. Command output: {resp[1]}')
+    else:
+        logging.info('Cluster Stopped : %s', resp[0])
+        for line in resp[0]:
+            assert 'Cluster stop is in progress' not in line, \
+                'Cluster is in progress.' if 'Cluster is in progress.' \
+                else line
+
+
+def test_hare_postreq(cdf_file: str, timeinfo: str, logfile: str):
+    """Test suite is for restoring the setting after test."""
+    pcs_status = ['pcs', 'status']
+    cluster_start = ['cortx', 'cluster', 'start']
+    hctl_status = ['hctl', 'status', '-d']
+
+    logging.info('Start the Cluster')
+    resp = executecmds(cluster_start)
+    logging.info('cluster status: %s', resp[0])
+    if int(resp[2]):
+        logging.error('Cluster failed to start %s', resp[1])
+        resp = executecmds(['journalctl', '--since', timeinfo, '>', logfile])
+        logging.info('created journal log %s', logfile)
+        raise Exception(
+            f'Command {cluster_start} exited with error code {int(resp[2])}'
+            f'Command output: {resp[1]}')
+    else:
+        for line in resp[0]:
+            assert 'Cluster start operation performed' not in line, \
+                'Cluster not yet started.' if 'Cluster not yet started.' \
+                else line
+
+    cluster_sts = check_cluster_status(cdf_file)
+    if cluster_sts:
+        logging.error('Cluster status reports failure')
+        resp = executecmds(['journalctl', '--since', timeinfo, '>', logfile])
+        logging.info('created journal log.%s', logfile)
+        exit(-1)
+
+    logging.info('PCS: Check all services are up.')
+    sleep(20)
+    resp = executecmds(pcs_status)
+    logging.info('PCS status: %s', resp[0])
+    if int(resp[2]):
+        logging.error('PCS failed to updated the status %s', resp[1])
+    else:
+        for line in resp[0]:
+            assert 'stopped' not in line, 'Some services are not up.' \
+                if 'Some services are not up.' else line
+
+    logging.info('hctl: Check that all the services are up.')
+    sleep(10)
+    resp = executecmds(hctl_status)
+    logging.info('hctl status: %s', resp[0])
+    if int(resp[2]):
+        logging.error('hctl failed to updated the status %s', resp[1])
+        resp = executecmds(['journalctl', '--since', timeinfo, '>', logfile])
+        logging.info('created journal log.%s', logfile)
+        raise Exception(
+            f'Command {hctl_status} exited with error code {int(resp[2])}.'
+            f'Command output: {resp[1]}')
+    else:
+        for line in resp[0]:
+            assert 'stopped' not in line, 'Some services are not up.' \
+                if 'Some services are not up.' else line
+    logging.info('Successfully performed cleanup after testing')
+
+
+# @pytest.mark.sanity
+def test_hare_bootstrap_shutdown(args):
+    """Test suite for single node hare init in loop."""
+    loop_count = int(args.dev[0])
+    hctl_status = ['hctl', 'status', '-d']
+    hctl_shutdown = ['hctl', 'shutdown']
+
+    test_hare_prereq()
+
+    resp = executecmds(hctl_status)
+    logging.info('hctl status: %s', resp[0])
+    if int(resp[2]):
+        logging.error('hctl failed to updated the status %s', resp[1])
+        raise Exception(
+            f'Command {hctl_status} exited with error code {int(resp[2])}.'
+            f'Command output: {resp[1]}')
+    else:
+        if 'Cluster is not running' not in resp[0]:
+            resp = executecmds(hctl_shutdown)
+            logging.info('hctl shutdown: %s', resp[0])
+
+        logging.info('-------Starting BOOTSTRAP-SHUTDOWN in LOOP-------')
+        for count in range(loop_count):
+            logging.info('Loop count# {}'.format(count + 1))
+            now = datetime.now()     # current date and time
+            date_time = now.strftime("%Y-%m-%d %H:%M:%S")
+            jlog = '~/journal_ctrl_' + now.strftime('%Y_%m_%d_%H%M%S') + '.log'
+
+            logging.info('Start hctl Bootstrap')
+            resp = bootstrap_cluster(str(args.file[0]), True)
+            if resp:
+                logging.error('Failed to bootstrap')
+                resp = executecmds(['journalctl', '--since', date_time, '>',
+                                    jlog])
+                logging.info('created journal log %s', jlog)
+                exit(-1)
+
+            logging.info('Check that all the services are up in hctl.')
+            if is_cluster_running():
+                logging.info('hctl is running.')
+            else:
+                logging.error('Still hctl is not running.')
+                resp = executecmds(['journalctl', '--since', date_time, '>',
+                                    jlog])
+                logging.info('created journal log %s', jlog)
+                exit(-1)
+
+            sleep(10)
+            logging.info('Shutdown the cluster.')
+            resp = executecmds(hctl_shutdown)
+            logging.info('hctl shutdown: %s', resp[0])
+            if int(resp[2]):
+                logging.error('Shutdown Failed %s', resp[1])
+                resp = executecmds(
+                    ['journalctl', '--since', date_time, '>', jlog])
+                logging.info('created journal log.%s', jlog)
+                raise Exception(
+                    f'Command {hctl_shutdown} exited with error code '
+                    f'{int(resp[2])}. Command output: {resp[1]}')
+
+            sleep(10)
+            if is_cluster_running():
+                logging.error('Still Cluster is running.')
+                resp = executecmds(['journalctl', '--since', date_time, '>',
+                                    jlog])
+                logging.info('created journal log %s', jlog)
+                exit(-1)
+
+    test_hare_postreq(str(args.file[0]), date_time, jlog)
+
+
 def test_IVT(args):
     try:
         rc = 0
         path_to_cdf = args.file[0]
+        is_dev_opt_enbl = int(args.dev[0])
 
-        logging.info('Running test plan: ' + str(args.plan[0].value))
+        if not is_dev_opt_enbl:
+            logging.info('Running test plan: ' + str(args.plan[0].value))
         # TODO We need to handle plan type and execute test cases accordingly
-        if not is_cluster_running():
-            logging.error('Cluster is not running. Cluster must be running '
-                          'for executing tests')
-            exit(-1)
-        cluster_status = check_cluster_status(path_to_cdf)
-        if cluster_status:
-            logging.error('Cluster status reports failure')
-            rc = -1
+            if not is_cluster_running():
+                logging.error('Cluster is not running. Cluster must be '
+                              'running for executing tests')
+                exit(-1)
+            cluster_status = check_cluster_status(path_to_cdf)
+            if cluster_status:
+                logging.error('Cluster status reports failure')
+                rc = -1
+        else:
+            logging.info('Running test plan: ' + str(args.plan[0].value))
+            test_hare_bootstrap_shutdown(args)
+
+            cluster_status = check_cluster_status(path_to_cdf)
+            if cluster_status:
+                logging.error('Cluster status reports failure')
+                rc = -1
 
         logging.info('Tests executed successfully')
         exit(rc)
@@ -565,6 +747,16 @@ def add_param_argument(parser):
     return parser
 
 
+def add_dev_argument(parser):
+    parser.add_argument('--dev',
+                        help='Test Development purpose. Supported '
+                        'values: any non zero value',
+                        default='0',
+                        type=str,
+                        action='store')
+    return parser
+
+
 def main():
     p = argparse.ArgumentParser(description='Configure hare settings')
     subparser = p.add_subparsers()
@@ -593,13 +785,14 @@ def main():
                        help_str='Initializes Hare',
                        handler_fn=init))
 
-    add_param_argument(
-        add_plan_argument(
-            add_file_argument(
-                add_subcommand(subparser,
-                               'test',
-                               help_str='Tests Hare component',
-                               handler_fn=test_IVT))))
+    add_dev_argument(
+        add_param_argument(
+            add_plan_argument(
+                add_file_argument(
+                    add_subcommand(subparser,
+                                   'test',
+                                   help_str='Tests Hare component',
+                                   handler_fn=test_IVT)))))
 
     sb_sub_parser = add_subcommand(subparser,
                                    'support_bundle',

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ from enum import Enum
 from sys import exit
 from time import sleep
 from typing import Any, Callable, Dict, List
-from datetime import datetime
 
 import yaml
 from cortx.utils.product_features import unsupported_features

--- a/st/commons/commands.py
+++ b/st/commons/commands.py
@@ -1,0 +1,6 @@
+#Hare cmds
+pcs_status = ['pcs', 'status']
+cluster_start = ['cortx', 'cluster', 'start']
+cluster_stop = ['cortx', 'cluster', 'stop']
+hctl_shutdown = ['hctl', 'shutdown', '--skip-consul-stop']
+hctl_status = ['hctl', 'status', '-d']

--- a/st/test/test_hare_bootstrap_shutdown.py
+++ b/st/test/test_hare_bootstrap_shutdown.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+"""
+Hare test suite for bootstrap shutdown on single node.
+"""
+
+import logging
+import pytest
+
+from datetime import datetime
+
+from commons import commands as cmds
+from provisioning.miniprov.hare_mp.main import execute, check_cluster_status,\
+    is_cluster_running, bootstrap_cluster
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestHareBootstrapShutdown:
+    """
+    Test suite for hare bootstrap shutdown on single node.
+    """
+
+    @classmethod
+    def setup_class(self, args):
+        """
+        Setup operations for the test file.
+        """
+        LOGGER.info("STARTED: Setup Module operations")
+        self.loop_count = int(args.dev[0])
+        self.now = datetime.now()
+        self.cdf_file = str(args.file[0])
+
+        LOGGER.info("Done: Setup module operations")
+
+    def setup_method(self):
+        """
+        This function will be invoked prior to each test case.
+        """
+        LOGGER.info("STARTED: Setup Operations")
+
+        logging.info('Test started on Host: {}'
+                     .format(execute(['hostname'])))
+        logging.info('Check that all services are up in PCS.')
+
+        resp = execute(cmds.pcs_status)
+        logging.info('PCS status: %s', resp)
+
+        if 'cluster is not currently' in resp:
+            return
+
+        logging.info('Make Node ready for testing, by stopping the cluster.')
+        resp = execute(cmds.cluster_stop)
+        logging.info('Cluster Stopped: %s', resp)
+        if 'Cluster stop is in progress' not in resp:
+            logging.error('Cluster is in progress.')
+
+    def teardown_method(self):
+        """
+        This function will be invoked after each test function in the module.
+        """
+        LOGGER.info("STARTED: Teardown Operations.")
+        logging.info('Start the Cluster')
+        resp = execute(cmds.cluster_start)
+        logging.info('cluster status: %s', resp)
+        if 'Cluster start operation performed' not in resp:
+            logging.error('Cluster not yet started.')
+
+        logging.info('PCS: Check all services are up.')
+        resp = execute(cmds.pcs_status)
+        logging.info('PCS status: %s', resp)
+        if 'stopped' not in resp:
+            logging.error('Some services are not up.')
+
+        logging.info('hctl: Check that all the services are started.')
+        cluster_sts = check_cluster_status(self.cdf_file)
+        if cluster_sts:
+            resp = execute(['journalctl', '--since', self.date_time, '>',
+                            self.jlog])
+            logging.info('created journal log: %s', self.jlog)
+            raise Exception('hctl status reports failure.')
+
+        logging.info('Successfully performed cleanup after testing')
+        LOGGER.info("All nodes are online and PCS looks clean.")
+        LOGGER.info("ENDED: Teardown Operations.")
+
+    @pytest.mark.hare
+    @pytest.mark.tags("EOS-22149")
+    def test_single_nodes_bootstrap_shutdown(self):
+        """
+        Test hare init in loop on single node .
+        """
+
+        if is_cluster_running():
+            execute(cmds.hctl_status)
+            # if exit_code:
+            #     if 'Cluster is not running' not in out:
+            #         resp = execute(hctl_shutdown)
+            #         logging.info('hctl shutdown: %s', resp)
+            #         if is_cluster_running():
+            #             raise Exception('After shutdown, hctl is running.')
+            #     else:
+            #         raise Exception(
+            #         f'Command hctl status exited with error code {exit_code}'
+            #             f'Command output: {err}')
+            # else:
+            #     raise Exception('Fail to control cluster, exit the test.')
+
+        logging.info('-------Starting BOOTSTRAP-SHUTDOWN in LOOP-------')
+        for count in range(self.loop_count):
+            logging.info('Loop count# {}'.format(count + 1))
+            self.now = datetime.now()  # current date and time
+            self.date_time = self.now.strftime("%Y-%m-%d %H:%M:%S")
+            self.jlog = '~/journal_ctrl_' + \
+                        self.now.strftime('%Y_%m_%d_%H%M%S') + '.log'
+
+            logging.info('Start hctl Bootstrap')
+            resp = bootstrap_cluster(self.cdf_file, True)
+            if resp:
+                resp = execute(['journalctl', '--since', self.date_time, '>',
+                                self.jlog])
+                logging.info('created journal log: %s', self.jlog)
+                raise Exception('Failed to bootstrap.')
+
+            logging.info('Check that all the services are up in hctl.')
+            if is_cluster_running():
+                logging.info('hctl is running.')
+                cluster_sts = check_cluster_status(self.cdf_file)
+                if cluster_sts:
+                    resp = execute(
+                        ['journalctl', '--since', self.date_time, '>',
+                         self.jlog])
+                    logging.info('created journal log: %s', self.jlog)
+                    raise Exception('hctl status reports failure.')
+            else:
+                resp = execute(['journalctl', '--since', self.date_time, '>',
+                                self.jlog])
+                logging.info('created journal log: %s', self.jlog)
+                raise Exception('After Bootstrap, hctl is not running.')
+
+            logging.info('Shutdown the cluster.')
+            resp = execute(cmds.hctl_shutdown)
+            logging.info('hctl shutdown: %s', resp)
+            if is_cluster_running():
+                resp = execute(['journalctl', '--since', self.date_time, '>',
+                                self.jlog])
+                logging.info('created journal log: %s', self.jlog)
+                raise Exception('After shutdown, hctl is running.')
+
+        # test_hare_postreq(str(args.file[0]), date_time, jlog)

--- a/st/test/test_hare_bootstrap_shutdown.py
+++ b/st/test/test_hare_bootstrap_shutdown.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added Bootstrap-Shutdown test case to IVT framework.

CMD to run Bootstrap-Shutdown test in loop for 10 times.
`/opt/seagate/cortx/hare/bin/hare_setup test --config 'json:///opt/seagate/cortx_configs/provisioner_cluster.json' --file /var/lib/hare/cluster.yaml --plan sanity --dev 10`

Test will run only if `--dev` argument is used.