### PR TITLE
EOS-21138: Support '--pre-factory' option in Hare factory reset

### DIFF
--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -16,7 +16,7 @@ hare:
     args: --config $URL
   cleanup:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup cleanup
-    args: --config $URL
+    args: --config $URL --pre-factory
   prepare:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup prepare
     args: --config $URL


### PR DESCRIPTION
Solution:
By default, cleanup will take you to post-factory(i.e. after post-install) and Pre-factory will take you to before-factory (i.e. undo everything that was done in post-install).
So we need to support this option in cleanup state.
In hare code post-install is no-op. So `--pre-factory` option is also no-op for us. 
We can use this command to cleanup with --pre-factory `/opt/seagate/cortx/hare/bin/hare_setup cleanup --config 'json:///root/hare.cleanup.conf.tmpl.1-node' --pre-factory`