### PR TITLE
EOS-23291: changes for Miniprovisioner failing for new key

### DIFF
--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -36,7 +36,9 @@
         }
       },
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
+        "cvg_count": "TMPL_CVG_COUNT",
         "cvg": [
           {
             "data_devices": [


### PR DESCRIPTION
Problem:
    Miniprovisioner Jenkins job failing for missing keys cvg_count & storage_set_id parameter.
    Failing job link:
    http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/CentOS-7.9.2009/job/Hare/5/console

 Solution:
    Added cvg_count and storage_set_id keys with TMPL values in the template file.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>