### PR TITLE
Problem: hax makes multiple Consul kv recurse calls

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -168,7 +168,6 @@ class ConsumerThread(StoppableThread):
     def _do_work(self, planner: WorkPlanner, motr: Motr):
         LOG.info('Handler thread has started')
         motr.adopt_motr_thread()
-
         try:
             while True:
                 try:


### PR DESCRIPTION
In context of handling various Hare and Motr events, e.g. BroadcastHAStates,
Motr ProcessEvent, Motr nvec requests, Motr entrypoint requests, etc. Hax
makes multiple recurse calls to Consul KV not just one per event but multiple
calls per event as well. This creates multiple such http requests and also
affects the overall performance.
In a large cluster comprising of multiple clients and server this issue can
be seen easily where a motr client takes several miliseconds to start.
(see https://github.com/Seagate/cortx-hare/issues/1682)

Solution:
Cache result of such ConsulKV requests in thread local storage and refer to
the same instead of making multiple Consul KV calls over http.
Invalidate the cache in case of the relevant KV update.

Addresses: https://github.com/Seagate/cortx-hare/issues/1682
Addresses: https://jts.seagate.com/browse/EOS-22148

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>