### PR TITLE
EOS-22349: Replace hostname with Private FQDN in CDF

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -9,6 +9,7 @@ import itertools
 import json
 import os
 from pprint import pprint
+import psutil
 import random
 import re
 import socket
@@ -462,10 +463,23 @@ def minion_id() -> Optional[str]:
         return f.readline().strip()
 
 
+def get_all_local_addrs() -> List[str]:
+    interface_details = psutil.net_if_addrs()
+    ips = []
+    for iface in interface_details.values():
+        ips.append(iface[0].address)
+    return ips
+
+
 def is_localhost(hostname: str) -> bool:
     assert hostname
-    return hostname in ('localhost', '127.0.0.1', minion_id(),
-                        socket.gethostname(), socket.getfqdn())
+    m_id = minion_id()
+    ids = [m_id] if m_id is not None else []
+    ids.extend(get_all_local_addrs())
+    for item in socket.gethostbyname_ex(hostname):
+        if any(x in item for x in ids):
+            return True
+    return False
 
 
 @repeat_on_cmd_timeout(max_retries=-1)

--- a/cfgen/requirements.txt
+++ b/cfgen/requirements.txt
@@ -1,3 +1,5 @@
+types-psutil==5.8.0
 idna==2.10
 PyYAML==5.4.1
 ply==3.11
+psutil==5.8.0

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -176,7 +176,8 @@ class CdfGenerator:
                         DiskRef(
                             path=Text(device),
                             node=Maybe(
-                                Text(conf.get(f'server_node>{node}>hostname')),
+                                Text(conf.get(f'server_node>{node}>'
+                                              'network>data>private_fqdn')),
                                 'Text'))
                         for node in self._get_server_nodes(pool)
                         for device in self._get_devices(pool, node)
@@ -283,7 +284,8 @@ class CdfGenerator:
 
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
-        hostname = store.get(f'server_node>{machine_id}>hostname')
+        hostname = store.get(
+            f'server_node>{machine_id}>network>data>private_fqdn')
         name = store.get(f'server_node>{machine_id}>name')
         iface = self._get_iface(machine_id)
         try:

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -96,7 +96,8 @@ class ConfStoreProvider(ValueProvider):
 
     def get_hostname(self) -> str:
         machine_id = self.get_machine_id()
-        hostname = self._raw_get(f'server_node>{machine_id}>hostname')
+        hostname = self._raw_get(
+            f'server_node>{machine_id}>network>data>private_fqdn')
         return hostname
 
     def get_storage_set_nodes(self) -> List[str]:

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -29,6 +29,7 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -40,6 +40,7 @@
       "network": {
         "data": {
           "interface_type": "tcp",
+          "private_fqdn": "srvnode-1.data.private",
           "private_interfaces": [
             "eth0",
             "eno2"
@@ -81,6 +82,7 @@
       "network": {
         "data": {
           "interface_type": "tcp",
+          "private_fqdn": "srvnode-2.data.private",
           "private_interfaces": [
             "eth0",
             "eno2"
@@ -122,6 +124,7 @@
       "network": {
         "data": {
           "interface_type": "tcp",
+          "private_fqdn": "srvnode-3.data.private",
           "private_interfaces": [
             "eth0",
             "eno2"

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -31,6 +31,7 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_1",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
@@ -70,6 +71,7 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_2",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
@@ -109,6 +111,7 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_3",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -114,6 +114,8 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'server_node>MACH_ID>network>data>interface_type':
                 'tcp',
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
                 'server_node>MACH_ID>storage>cvg[1]>data_devices':
@@ -188,6 +190,8 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID>hostname':                'myhost',
                 'server_node>MACH_ID>name': 'mynodename',
                 'server_node>MACH_ID>network>data>interface_type':                'o2ib',
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':                1,
                 'cortx>software>motr>service>client_instances':                2,
@@ -201,7 +205,7 @@ class TestCDF(unittest.TestCase):
         ret = CdfGenerator(provider=store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
-        self.assertEqual(Text('myhost'), ret[0].hostname)
+        self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
         self.assertEqual(1, ret[0].s3_instances)
         self.assertEqual(2, ret[0].client_instances)
@@ -215,7 +219,8 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(0, ret[0].parity_units)
         self.assertEqual(0, ret[0].spare_units.get())
         disk_refs = ret[0].disk_refs.value
-        self.assertEqual(Text('myhost'), disk_refs.value[0].node.value)
+        self.assertEqual(Text('srvnode-1.data.private'),
+                         disk_refs.value[0].node.value)
         self.assertEqual(Text('/dev/sdb'), disk_refs.value[0].path)
         self.assertEqual(0, ret[0].allowed_failures.value.site)
         self.assertEqual(0, ret[0].allowed_failures.value.rack)
@@ -295,6 +300,8 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID1>hostname':                'myhost',
                 'server_node>MACH_ID1>name': 'mynodename',
                 'server_node>MACH_ID1>network>data>interface_type':                'o2ib',
+                'server_node>MACH_ID1>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID1>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'server_node>MACH_ID1>s3_instances':                1,
                 'server_node>MACH_ID2>storage>cvg_count': '2',
@@ -305,6 +312,8 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID2>hostname':                'myhost',
                 'server_node>MACH_ID2>name': 'mynodename',
                 'server_node>MACH_ID2>network>data>interface_type':                'o2ib',
+                'server_node>MACH_ID2>network>data>private_fqdn':
+                    'srvnode-2.data.private',
                 'server_node>MACH_ID2>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'server_node>MACH_ID2>s3_instances':                1,
                 'server_node>MACH_ID3>storage>cvg_count': '2',
@@ -315,6 +324,8 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID3>hostname':                'myhost',
                 'server_node>MACH_ID3>name': 'mynodename',
                 'server_node>MACH_ID3>network>data>interface_type':                'o2ib',
+                'server_node>MACH_ID3>network>data>private_fqdn':
+                    'srvnode-3.data.private',
                 'server_node>MACH_ID3>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'server_node>MACH_ID3>s3_instances':                1,
             }
@@ -357,6 +368,8 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'server_node>srvnode_1>network>data>interface_type':
                 'o2ib',
+                'server_node>srvnode_1>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>srvnode_1>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'server_node>srvnode_1>s3_instances':
@@ -513,6 +526,8 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'server_node>MACH_ID>network>data>interface_type':
                 'o2ib',
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
@@ -575,6 +590,8 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'server_node>MACH_ID>network>data>interface_type':
                 'o2ib',
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
@@ -632,7 +649,9 @@ class TestCDF(unittest.TestCase):
                 'cortx>software>motr>service>client_instances':
                 2,
                 'server_node>MACH_ID>network>data>interface_type':
-                'o2ib'
+                'o2ib',
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
             }
             return data[value]
 
@@ -667,6 +686,8 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID>name': 'mynodename',
                 'server_node>MACH_ID>network>data>interface_type':
                 'o2ib',
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1'],
                 'server_node>MACH_ID>s3_instances':
@@ -682,6 +703,8 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_2_ID>name':                'host-2',
                 'server_node>MACH_2_ID>hostname':            'host-2',
                 'server_node>MACH_2_ID>network>data>interface_type':                'tcp',
+                'server_node>MACH_2_ID>network>data>private_fqdn':
+                    'srvnode-2.data.private',
                 'server_node>MACH_2_ID>network>data>private_interfaces':
                 ['eno1'],
                 'server_node>MACH_2_ID>s3_instances':                5,
@@ -700,11 +723,11 @@ class TestCDF(unittest.TestCase):
         ret = CdfGenerator(provider=store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(2, len(ret))
-        self.assertEqual(Text('myhost'), ret[0].hostname)
+        self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
         self.assertEqual(1, ret[0].s3_instances)
         self.assertEqual(2, ret[0].client_instances)
-        self.assertEqual(Text('host-2'), ret[1].hostname)
+        self.assertEqual(Text('srvnode-2.data.private'), ret[1].hostname)
         self.assertEqual(Text('eno1'), ret[1].data_iface)
         self.assertEqual(5, ret[1].s3_instances)
         self.assertEqual(2, ret[1].client_instances)
@@ -728,6 +751,8 @@ class TestCDF(unittest.TestCase):
                 ['/dev/sdb'],
                 'server_node>MACH_ID>network>data>interface_type':
                 None,
+                'server_node>MACH_ID>network>data>private_fqdn':
+                    'srvnode-1.data.private',
                 'server_node>MACH_ID>s3_instances':
                 1,
                 'cortx>software>motr>service>client_instances':

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -194,12 +194,18 @@ EOF
     exit 1
 }
 
+getip() {
+    ping -c 1 -t 1 $1 | head -1 | cut -d ' ' -f 3 | tr -d '()'
+}
+
 is_localhost() {
     (($# == 1)) && [[ -n $1 ]] || die "${FUNCNAME[0]}: Invalid usage"
     local node=$1
     case $node in
         localhost|127.0.0.1|$(hostname)|$(hostname --fqdn)) return 0;;
     esac
+    local all_ips=$(hostname -I)
+    [[ " ${all_ips[@]} " =~ " $(getip $node) " ]] && return 0
     local path=/etc/salt/minion_id
     [[ -e $path && $(cat $path) == $node ]] && return 0 || return 1
 }


### PR DESCRIPTION
### Description:
HA uses private FQDN to report node events, whereas hare is using
hostnames presently to generate configurations (CDF), which is subject
to change.

### Solution:
Update the configurations generated by Hare to use private FQDNs from
confstore.
Update functionality in scripts to use private FQDN.
Update unit tests and templates.

### Output
CDF file
```
$ cat /var/lib/hare/cluster2.yaml
pools:
- allowed_failures:
    disk: 0
    ctrl: 0
    encl: 0
    rack: 0
    site: 0
  spare_units: 0
  name: storage-set-1__sns
  data_units: 1
  parity_units: 0
  disk_refs:
  - path: /dev/sdc
    node: srvnode-1.data.private
  type: sns
profiles:
- pools:
  - storage-set-1__sns
  name: Profile_the_pool
nodes:
- m0_servers:
  - io_disks:
      data:
      - /dev/sdc
      meta_data: /dev/vg_srvnode-1_md1/lv_raw_md1
    runs_confd: false
  - io_disks:
      data: []
      meta_data: null
    runs_confd: true
  data_iface: eth1
  hostname: srvnode-1.data.private
  m0_clients:
    other: 2
    s3: 0
  data_iface_type: tcp
```

Consul KV keys
```
m0conf/nodes/srvnode-1.data.private/processes/9/endpoint:192.168.57.236@tcp:12345:2:1
m0conf/nodes/srvnode-1.data.private/processes/9/meta_data:/dev/vg_srvnode-1_md1/lv_raw_md1
m0conf/nodes/srvnode-1.data.private/processes/9/services/addb2:16
m0conf/nodes/srvnode-1.data.private/processes/9/services/cas:17
m0conf/nodes/srvnode-1.data.private/processes/9/services/fdmi:19
m0conf/nodes/srvnode-1.data.private/processes/9/services/ios:11
m0conf/nodes/srvnode-1.data.private/processes/9/services/iscs:18
m0conf/nodes/srvnode-1.data.private/processes/9/services/rms:10
m0conf/nodes/srvnode-1.data.private/processes/9/services/sns_reb:15
m0conf/nodes/srvnode-1.data.private/processes/9/services/sns_rep:14
```

### Tests
UTs of mini-provisioning (test_cdf.py)
```
$ python ./setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing hare_mp.egg-info/PKG-INFO
writing dependency_links to hare_mp.egg-info/dependency_links.txt
writing entry points to hare_mp.egg-info/entry_points.txt
writing requirements to hare_mp.egg-info/requires.txt
writing top-level names to hare_mp.egg-info/top_level.txt
reading manifest file 'hare_mp.egg-info/SOURCES.txt'
writing manifest file 'hare_mp.egg-info/SOURCES.txt'
running build_ext
test_allowed_failure_generation (test.test_cdf.TestCDF) ... ok
test_both_dix_and_sns_pools_can_exist (test.test_cdf.TestCDF) ... ok
test_disk_refs_can_be_empty (test.test_cdf.TestCDF) ... ok
test_dix_pool_uses_metadata_devices (test.test_cdf.TestCDF) ... ok
test_iface_type_can_be_null (test.test_cdf.TestCDF) ... ok
test_invalid_storage_set_configuration_rejected (test.test_cdf.TestCDF)
This test case checks whether exception will be raise if total ... ok
test_it_works (test.test_cdf.TestCDF) ... ok
test_md_pool_ignored (test.test_cdf.TestCDF) ... ok
test_metadata_is_hardcoded (test.test_cdf.TestCDF) ... ok
test_multiple_nodes_supported (test.test_cdf.TestCDF) ... ok
test_provided_values_respected (test.test_cdf.TestCDF) ... ok
test_template_sane (test.test_cdf.TestCDF) ... ok
test_disks_empty (test.test_cdf.TestTypes) ... ok
test_m0clients (test.test_cdf.TestTypes) ... ok
test_m0server_with_disks (test.test_cdf.TestTypes) ... ok
test_maybe_none (test.test_cdf.TestTypes) ... ok
test_pooldesc_empty (test.test_cdf.TestTypes) ... ok
test_protocol (test.test_cdf.TestTypes) ... ok
test_invalid_machine_id (test.test_validator.TestValidator) ... ok
test_is_cluster_first_node (test.test_validator.TestValidator) ... ok
test_empty_source_results_empty (test.test_systemd.TestHaxUnitTrasform) ... ok
test_not_everything_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_restart_commented (test.test_systemd.TestHaxUnitTrasform) ... ok

----------------------------------------------------------------------
Ran 23 tests in 0.248s

OK
```

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>