### PR TITLE
EOS-21210: Modify s3 key path according to changes in confstore

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -337,5 +337,5 @@ class CdfGenerator:
             # TODO in the future the value must be taken from a correct
             # ConfStore key (it doesn't exist now).
             s3_instances=int(
-                store.get(f'server_node>{machine_id}>s3_instances')),
+                store.get('cortx>software>s3>service>instances')),
             client_instances=no_m0clients)

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -21,6 +21,20 @@
       ]
     }
   },
+   "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
   "server_node": {
     "TMPL_MACHINE_ID": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -36,7 +50,6 @@
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
@@ -23,6 +23,20 @@
       ]
     }
   },
+  "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
   "server_node": {
     "TMPL_MACHINE_ID_1": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -31,13 +45,13 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_1",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",
@@ -70,6 +84,7 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_2",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
@@ -109,6 +124,7 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_3",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -29,9 +29,14 @@
         "service": {
           "client_instances": "2"
         }
+      },
+      "s3": {
+        "service": {
+          "instances": "1"
+        }
       }
     }
-  },      
+  },   
   "server_node": {
     "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
       "cluster_id": "my-cluster",
@@ -47,7 +52,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage_set_id": "storage1",
       "storage": {
         "cvg_count": "2",
@@ -89,7 +93,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage_set_id": "storage1",
       "storage": {
         "cvg_count": "2",
@@ -131,7 +134,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage_set_id": "storage1",
       "storage": {
         "cvg_count": "2",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
@@ -21,6 +21,20 @@
       ]
     }
   },
+    "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
   "server_node": {
     "TMPL_MACHINE_ID": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -29,13 +43,13 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -23,6 +23,20 @@
       ]
     }
   },
+  "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
   "server_node": {
     "TMPL_MACHINE_ID_1": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -38,7 +52,6 @@
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",
@@ -78,7 +91,6 @@
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",
@@ -118,7 +130,6 @@
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node.sample
@@ -23,6 +23,20 @@
       ]
     }
   },
+  "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "1"
+        }
+      }
+    }
+  },
   "server_node": {
     "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
       "cluster_id": "my-cluster",
@@ -37,7 +51,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage": {
         "cvg": [
           {
@@ -76,7 +89,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage": {
         "cvg": [
           {
@@ -115,7 +127,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage": {
         "cvg": [
           {

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
@@ -21,6 +21,20 @@
       ]
     }
   },
+  "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
   "server_node": {
     "TMPL_MACHINE_ID": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -29,13 +43,13 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -23,6 +23,20 @@
       ]
     }
   },
+    "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
   "server_node": {
     "TMPL_MACHINE_ID_1": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -31,13 +45,13 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_1",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",
@@ -70,13 +84,13 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_2",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",
@@ -109,13 +123,13 @@
       "network": {
         "data": {
           "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_3",
           "private_interfaces": [
             "TMPL_PRIVATE_DATA_INTERFACE_1",
             "TMPL_PRIVATE_DATA_INTERFACE_2"
           ]
         }
       },
-      "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
         "cvg_count": "TMPL_CVG_COUNT",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
@@ -23,6 +23,20 @@
       ]
     }
   },
+  "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "1"
+        }
+      }
+    }
+  }, 
   "server_node": {
     "1114a50a6bf6f9c93ebd3c49d07d3fd4": {
       "cluster_id": "my-cluster",
@@ -37,7 +51,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage": {
         "cvg": [
           {
@@ -76,7 +89,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage": {
         "cvg": [
           {
@@ -115,7 +127,6 @@
           ]
         }
       },
-      "s3_instances": "1",
       "storage": {
         "cvg": [
           {

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -133,7 +133,7 @@ class TestCDF(unittest.TestCase):
                 ['/dev/meta'],
                 'server_node>MACH_ID>storage>cvg[1]>metadata_devices':
                 ['/dev/meta1'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'cortx>software>motr>service>client_instances':
                 2,
@@ -212,7 +212,7 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':                ['eth1', 'eno2'],
-                'server_node>MACH_ID>s3_instances':                1,
+                'cortx>software>s3>service>instances':                1,
                 'cortx>software>motr>service>client_instances':                2,
             }
             return data.get(value)
@@ -341,7 +341,7 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID1>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'server_node>MACH_ID1>network>data>private_interfaces':                ['eth1', 'eno2'],
-                'server_node>MACH_ID1>s3_instances':                1,
+                'cortx>software>s3>service>instances':                1,
                 'server_node>MACH_ID2>storage>cvg_count': '2',
                 'server_node>MACH_ID2>storage>cvg[0]>data_devices': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
                 'server_node>MACH_ID2>storage>cvg[1]>data_devices': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
@@ -353,7 +353,7 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID2>network>data>private_fqdn':
                     'srvnode-2.data.private',
                 'server_node>MACH_ID2>network>data>private_interfaces':                ['eth1', 'eno2'],
-                'server_node>MACH_ID2>s3_instances':                1,
+                'cortx>software>s3>service>instances':                1,
                 'server_node>MACH_ID3>storage>cvg_count': '2',
                 'server_node>MACH_ID3>storage>cvg[0]>data_devices': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
                 'server_node>MACH_ID3>storage>cvg[1]>data_devices': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
@@ -365,7 +365,7 @@ class TestCDF(unittest.TestCase):
                 'server_node>MACH_ID3>network>data>private_fqdn':
                     'srvnode-3.data.private',
                 'server_node>MACH_ID3>network>data>private_interfaces':                ['eth1', 'eno2'],
-                'server_node>MACH_ID3>s3_instances':                1,
+                'cortx>software>s3>service>instances':                1,
             }
             return data.get(value)
 
@@ -411,7 +411,7 @@ class TestCDF(unittest.TestCase):
                     'srvnode-1.data.private',
                 'server_node>srvnode_1>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'server_node>srvnode_1>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'server_node>srvnode_1>storage>cvg_count':
                 2,
@@ -468,7 +468,7 @@ class TestCDF(unittest.TestCase):
                 'o2ib',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'server_node>MACH_ID>storage>cvg_count':
                 2,
@@ -523,7 +523,7 @@ class TestCDF(unittest.TestCase):
                 'o2ib',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'cortx>software>motr>service>client_instances':
                 2,
@@ -573,7 +573,7 @@ class TestCDF(unittest.TestCase):
                     'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'server_node>MACH_ID>storage>cvg_count':
                 2,
@@ -638,7 +638,7 @@ class TestCDF(unittest.TestCase):
                     'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'server_node>MACH_ID>storage>cvg_count':
                 2,
@@ -693,7 +693,7 @@ class TestCDF(unittest.TestCase):
                 ['/dev/sdc'],
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'cortx>software>motr>service>client_instances':
                 2,
@@ -758,7 +758,7 @@ class TestCDF(unittest.TestCase):
                     'srvnode-1.data.private',
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1'],
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'cortx>software>motr>service>client_instances':
                 2,
@@ -775,7 +775,7 @@ class TestCDF(unittest.TestCase):
                     'srvnode-2.data.private',
                 'server_node>MACH_2_ID>network>data>private_interfaces':
                 ['eno1'],
-                'server_node>MACH_2_ID>s3_instances':                5,
+                'cortx>software>s3>service>instances':                1,
                 'cortx>software>motr>service>client_instances':                2,
                 'server_node>MACH_2_ID>storage>cvg':
                 [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta']}],
@@ -799,7 +799,7 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(2, ret[0].client_instances)
         self.assertEqual(Text('srvnode-2.data.private'), ret[1].hostname)
         self.assertEqual(Text('eno1'), ret[1].data_iface)
-        self.assertEqual(5, ret[1].s3_instances)
+        self.assertEqual(1, ret[1].s3_instances)
         self.assertEqual(2, ret[1].client_instances)
         self.assertEqual('Some (P.o2ib)', str(ret[0].data_iface_type))
         self.assertEqual('Some (P.tcp)', str(ret[1].data_iface_type))
@@ -823,7 +823,7 @@ class TestCDF(unittest.TestCase):
                 None,
                 'server_node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
-                'server_node>MACH_ID>s3_instances':
+                'cortx>software>s3>service>instances':
                 1,
                 'cortx>software>motr>service>client_instances':
                 2,


### PR DESCRIPTION
EOS-21210: Modify s3 key path according to changes in confstore

Solution :
Refer to Conf store KV `cortx>software>s3>service>instances` to populate number of
s3 client instances while generating CDF in hare mini-provisioner's `config` phase.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>