### PR TITLE
EOS-15788: Node failure events handling

### DIFF
--- a/ha-simulator/README.md
+++ b/ha-simulator/README.md
@@ -1,0 +1,72 @@
+## Purpose
+
+This folder contains the dockerized environment to debug and test HA Events. HA Events are sent by means of:
+
+*   Kafka
+*   MessageBus (wrapper for Kafka in cortx-py-utils)
+*   Consul KV (used by cortx-ha to subscribe the components)
+*   EventManager (cortx-ha).
+
+The components above require additional configuration which is rather time-consuming.
+
+Containerized environment helps to avoid configuration issues and concentrate on real coding instead.
+
+## How to use
+
+This section describes how this docker environment can be used.
+
+### Pre-requisites
+
+1.  Docker should be installed, see docs [here](https://docs.docker.com/get-docker/)
+
+2.  docker-compose should be installed, see docs [here](https://docs.docker.com/compose/install/)
+
+3.  cortx-ha (with EventManager support - see `fault_tolerance` branch) must be installed:
+
+    *   either install the RPM from [here](http://cortx-storage.colo.seagate.com/releases/cortx/github/integration-custom-ci/centos-7.8.2003/custom-build-2434/cortx_iso/)
+
+    *   or install cortx-ha into your virtualenv (this approach assumes that you run Hare from virtualenv environment, i.e. you had used `make devinstall`):
+
+        1.  Activate Hare virtualenv: `source ./.py3venv/bin/activate`
+
+        2.  Checkout cortx-ha sources: `git clone https://github.com/Seagate/cortx-ha.git`
+
+        3.  `cd cortx-ha && git checkout fault_tolerance`
+
+        4.  `python ./setup.py develop` - this will make sure that Hare virtualenv contains cortx-ha types and modules.
+
+4.  Have local configuration files for MessageBus and HA are generated.
+
+    *   Don't worry, just run `./prepare-host.sh` script.
+
+### Get the environment
+
+1.  Go to ha-simulator/ folder: `cd ha-simulator`
+
+2.  Modify `./.env` file. CONSUL_HOSTNAME should point to the private IP address of your host machine. In other words, this is an IP address where Consul would respond (note that in Hare Consul is not listening to broad 0.0.0.0, usually it is bound to an address like 192.168.63.107 instead)
+
+*   Normally, you can check this IP address like this:
+    *   Setup the cluster with `hctl bootstrap cfgen/examples/singlenode.yaml`
+    *   Run `consul members` to see the IP address.
+
+3.  Run Kafka: `docker-compose up kafka`
+
+4.  Run Hare cluster at your host machine: `hctl bootstrap <..>`
+
+    *   If everything goes well, in journalctl logs from hax process there will be lines like these:
+
+    <!---->
+
+        2021-08-12 10:16:14,804 [INFO] {ha-event-listener} [subscribe] Received a subscribe request from hare
+        2021-08-12 10:16:14,819 [INFO] {ha-event-listener} [__init__] MessageBus initialized as kafka
+        2021-08-12 10:16:14,979 [INFO] {ha-event-listener} [subscribe] Successfully Subscribed component hare with message_type ha_event_hare
+
+### Send simulated HA event
+
+1.  Go to `ha-simulator/` folder
+
+2.  Run `docker-compose up emitter`
+
+    *   This container runs `./emitter.py` script. Feel free to edit it to send another events.
+
+3.  Look into journalctl for new messages from `{ha-event-listener}` thread.

--- a/ha-simulator/docker-compose.yml
+++ b/ha-simulator/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.8"
+
+services:
+  zookeeper:
+    image: docker.io/bitnami/zookeeper:3.7
+    ports:
+      - "2181:2181"
+    volumes:
+      - "zookeeper_data:/bitnami"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: docker.io/bitnami/kafka:2
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    volumes:
+      - "kafka_data:/bitnami"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes        
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
+      #- KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://ssc-vm-g2-rhev4-0175.colo.seagate.com:9093
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+  consul:
+    image: consul:latest
+    command: "agent -server -bootstrap -retry-join \"127.0.0.1\" -client 0.0.0.0"
+  emitter:
+    build:
+      context: docker/
+      dockerfile: Dockerfile
+      target: dev
+    environment:
+      - CONSUL_HOSTNAME=consul
+
+    volumes:
+      - "./emitter.py:/app/emitter.py"
+      - "./docker/etc/ha.conf:/etc/cortx/ha/ha.conf"
+      - "./docker/etc/message_bus.conf:/etc/cortx/message_bus.conf"
+
+volumes:
+  zookeeper_data:
+    driver: local
+  kafka_data:
+    driver: local

--- a/ha-simulator/docker-compose.yml
+++ b/ha-simulator/docker-compose.yml
@@ -21,22 +21,20 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes        
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
       - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
-      #- KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://ssc-vm-g2-rhev4-0175.colo.seagate.com:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
       - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
     depends_on:
       - zookeeper
   consul:
     image: consul:latest
     command: "agent -server -bootstrap -retry-join \"127.0.0.1\" -client 0.0.0.0"
+
   emitter:
     build:
       context: docker/
       dockerfile: Dockerfile
       target: dev
-    environment:
-      - CONSUL_HOSTNAME=consul
-
+    env_file: .env
     volumes:
       - "./emitter.py:/app/emitter.py"
       - "./docker/etc/ha.conf:/etc/cortx/ha/ha.conf"

--- a/ha-simulator/docker/Dockerfile
+++ b/ha-simulator/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM centos:7 as build
+RUN yum install -y epel-release \
+                   python3 \
+                   python3-pip \
+                   git \
+                   gcc \
+                   #libyaml \
+                   #libyaml-devel \
+                   telnet \
+                   hostname \
+                   python3-devel
+WORKDIR /app
+COPY ./requirements.txt /app/requirements.txt
+COPY ./patches/ /app/patches/
+
+# --system-site-packages are required to make cortx-py-utils be visible from within of the virtualenv
+RUN    python3 -m venv --system-site-packages .py-venv/ \
+    && source ./.py-venv/bin/activate \
+    && pip install -r ./requirements.txt
+RUN    pip3 install -r https://raw.githubusercontent.com/Seagate/cortx-utils/main/py-utils/python_requirements.txt \
+    && pip3 install -r https://raw.githubusercontent.com/Seagate/cortx-utils/main/py-utils/python_requirements.ext.txt \
+    && yum install -y http://cortx-storage.colo.seagate.com/releases/cortx/github/stable/centos-7.8.2003/last_successful/cortx-py-utils-2.0.0-125_3fc14c6.noarch.rpm
+RUN    git config --global user.name "Konstantin Nekrasov" \
+    && git config --global user.email "konstantin.nekrasov@seagate.com" \
+    && git clone --branch fault_tolerance https://github.com/Seagate/cortx-ha.git
+WORKDIR /app/cortx-ha/
+RUN find /app/patches -type f -print0 | xargs -0 -n1 git am
+RUN source ../.py-venv/bin/activate && python ./setup.py install
+
+FROM build as dev
+WORKDIR /app
+COPY ./run.sh /app/run.sh
+CMD ["/bin/bash", "/app/run.sh"]

--- a/ha-simulator/docker/etc/ha.conf
+++ b/ha-simulator/docker/etc/ha.conf
@@ -1,0 +1,3 @@
+LOG:
+    path: /var/log/seagate/cortx/ha
+    level: INFO

--- a/ha-simulator/docker/etc/message_bus.conf
+++ b/ha-simulator/docker/etc/message_bus.conf
@@ -1,0 +1,11 @@
+{
+  "message_broker": {
+    "type": "kafka",
+    "cluster": [
+      {
+        "server": "kafka",
+        "port": "9092"
+      }
+    ]
+  }
+}

--- a/ha-simulator/docker/patches/0001-Consul-hostname-altered-via-env-variable.patch
+++ b/ha-simulator/docker/patches/0001-Consul-hostname-altered-via-env-variable.patch
@@ -1,0 +1,35 @@
+From 94349eb7f777735e0d73fd2c64a6fdaa72c3454f Mon Sep 17 00:00:00 2001
+From: Konstantin Nekrasov <konstantin.nekrasov@seagate.com>
+Date: Fri, 6 Aug 2021 03:14:44 -0600
+Subject: [PATCH] Consul hostname altered via env variable
+
+Signed-off-by: Konstantin Nekrasov <konstantin.nekrasov@seagate.com>
+---
+ ha/core/config/config_manager.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/ha/core/config/config_manager.py b/ha/core/config/config_manager.py
+index 1ff91eb..de2b322 100644
+--- a/ha/core/config/config_manager.py
++++ b/ha/core/config/config_manager.py
+@@ -28,6 +28,7 @@ from cortx.utils.conf_store.conf_store import Conf
+ from ha import const
+ from ha.util.consul_kv_store import ConsulKvStore
+ from ha.const import _DELIM
++import os
+ 
+ # TODO: redefine class as per config manager module design
+ class ConfigManager:
+@@ -68,7 +69,8 @@ class ConfigManager:
+         Used by config manager methods to check and initalize confstore if needed.
+         """
+         if ConfigManager._cluster_confstore is None:
+-            ConfigManager._cluster_confstore = ConsulKvStore(prefix=const.CLUSTER_CONFSTORE_PREFIX)
++            host = os.environ.get('CONSUL_HOSTNAME') or 'localhost'
++            ConfigManager._cluster_confstore = ConsulKvStore(host=host, prefix=const.CLUSTER_CONFSTORE_PREFIX)
+         return ConfigManager._cluster_confstore
+ 
+     @staticmethod
+-- 
+1.8.3.1
+

--- a/ha-simulator/docker/requirements.txt
+++ b/ha-simulator/docker/requirements.txt
@@ -1,0 +1,3 @@
+mypy
+flake8
+pudb

--- a/ha-simulator/docker/run.sh
+++ b/ha-simulator/docker/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+source ./.py-venv/bin/activate
+
+# Disabled for now because of errors in cortx-ha sources
+#MYPYPATH=cortx-ha/ mypy ./emitter.py
+flake8 ./emitter.py
+python ./emitter.py

--- a/ha-simulator/emitter.py
+++ b/ha-simulator/emitter.py
@@ -1,0 +1,29 @@
+from ha.core.action_handler.action_handler import NodeFailureActionHandler
+from ha.core.event_manager.event_manager import EventManager
+from ha.core.event_manager.subscribe_event import SubscribeEvent
+from ha.core.system_health.const import HEALTH_STATUSES
+from ha.core.system_health.model.health_event import HealthEvent
+
+
+def main():
+    component = "hare"
+    resource_type = "node"
+    state = "offline"
+    # import pudb.remote
+    # pudb.remote.set_trace(term_size=(130, 40), port=9998)
+
+    # Before submitting a fake event, we need to register the component
+    # (just to make sure that the message will be sent)
+    EventManager.get_instance().subscribe(
+        component, [SubscribeEvent(resource_type, [state])])
+    handler = NodeFailureActionHandler()
+
+    event = HealthEvent("event_id", HEALTH_STATUSES.OFFLINE.value, "severity",
+                        "1", "1", "e766bd52-c19c-45b6-9c91-663fd8203c2e",
+                        "storage-set-1", "localhost", "srvnode-1.mgmt.public",
+                        "node", "16215009572", "iem", "Description")
+    handler.publish_event(event)
+
+
+if __name__ == "__main__":
+    main()

--- a/ha-simulator/prepare-host.sh
+++ b/ha-simulator/prepare-host.sh
@@ -25,9 +25,9 @@ cat <<EOF | sudo tee /etc/cortx/message_bus.conf > /dev/null
   "message_broker": {
     "type": "kafka",
     "message_bus": {
-      "recv_message_timeout": "100000",
-      "controller_socket_timeout": "100000",
-      "send_message_timeout": "100000"
+      "recv_message_timeout": "1000",
+      "controller_socket_timeout": "1000",
+      "send_message_timeout": "1000"
     },
     "cluster": [
       {

--- a/ha-simulator/prepare-host.sh
+++ b/ha-simulator/prepare-host.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script performs all the necessary actions to get Hare working against simulated HA and dockerized Kafka.
+
+set -e -x
+
+if [[ ! -f /etc/cortx/ha/ha.conf ]]; then
+  sudo mkdir -p /etc/cortx/ha/
+  sudo cp -fv docker/etc/ha.conf /etc/cortx/ha/ha.conf
+fi
+
+
+if [[ ! -f /etc/cortx/ha/ha.conf ]]; then
+  sudo mkdir -p /etc/cortx/ha/
+  sudo cp -f docker/etc/ha.conf /etc/cortx/ha/ha.conf
+fi
+
+#if [[ -f /etc/cortx/message_bus.conf ]]; then
+  #echo '/etc/cortx/message_bus.conf already exists. Please rename or remove it' >&2
+  #exit 1
+#fi
+
+cat <<EOF | sudo tee /etc/cortx/message_bus.conf > /dev/null
+{
+  "message_broker": {
+    "type": "kafka",
+    "message_bus": {
+      "recv_message_timeout": "100000",
+      "controller_socket_timeout": "100000",
+      "send_message_timeout": "100000"
+    },
+    "cluster": [
+      {
+        "server": "ssc-vm-g2-rhev4-0175.colo.seagate.com",
+        "port": "9093"
+      }
+    ]
+  }
+}
+EOF

--- a/ha-simulator/run-containers.sh
+++ b/ha-simulator/run-containers.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e -x
+#docker-compose up -d consul
+docker-compose up -d kafka zookeeper

--- a/hax/hax/ha/__init__.py
+++ b/hax/hax/ha/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#

--- a/hax/hax/ha/events.py
+++ b/hax/hax/ha/events.py
@@ -62,12 +62,13 @@ class EventListener():
           4. After event is received in queue, user will read it, process it
              and acknowledge it
     """
-    def __init__(self, event_list: List[SubscribeEvent]):
-        '''
-
-        We will subscribe to events passes as 'event_list'.
-        We will also create consumer for events
-        '''
+    def __init__(self,
+                 event_list: List[SubscribeEvent],
+                 group_id: str = COMPONENT_ID):
+        """
+        event_list - list of events to subscribe to.
+        group_id - the group_id to pass to KafkaConsumer.
+        """
         logging.debug('Inside EventListener')
         self.event_manager = EventManager.get_instance()
 
@@ -79,7 +80,7 @@ class EventListener():
         self.consumer = MessageConsumer(
             message_bus=message_bus,
             consumer_id=COMPONENT_ID,
-            consumer_group=COMPONENT_ID,
+            consumer_group=group_id,
             message_types=[topic],
             # Why is it 'str' in cortx-py-utils??
             auto_ack=str(False),
@@ -97,11 +98,11 @@ class EventListener():
         self.event_manager.unsubscribe(COMPONENT_ID, event_list)
 
     def get_next_message(self, time_out) -> Optional[Event]:
-        '''
+        """
         Listen for events from event manager
         Once user gets message using below command user needs to call ack() to
         acknowledge that message is already processed
-        '''
+        """
         logging.debug('Listening......')
         message = self.consumer.receive(time_out)
         # FIXME: it seems like receive() returns bytes, not str
@@ -129,10 +130,10 @@ class EventListener():
                      timestamp=data['timestamp'])
 
     def ack(self):
-        '''
+        """
         1. This method will commit last read message offset for confirming
            which messages the consumer has already processed
         2. Consumer will read message using 'listen' and will acknowledge
            that message using ack method
-        '''
+        """
         self.consumer.ack()

--- a/hax/hax/ha/handler/__init__.py
+++ b/hax/hax/ha/handler/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+"""The module contains HA Event handlers."""
+
+from abc import abstractmethod
+
+from hax.ha.events import Event
+
+
+class EventHandler:
+    """Base class (effectively - interface) for all HA event handlers"""
+    @abstractmethod
+    def handle(self, msg: Event) -> None:
+        """Handle the given HA event."""
+        ...

--- a/hax/hax/ha/handler/node.py
+++ b/hax/hax/ha/handler/node.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+
+from hax.ha.events import Event
+from hax.ha.handler import EventHandler
+from hax.message import BroadcastHAStates
+from hax.motr.planner import WorkPlanner
+from hax.types import HAState, ServiceHealth
+from hax.util import ConsulUtil
+
+LOG = logging.getLogger('hax')
+
+
+class NodeEventHandler(EventHandler):
+    """
+    Handles HA events with resource_type == 'node'.
+
+    As a result of such HA event the corresponding BroadcastHAStates is
+    offered to WorkPlanner.
+    """
+    def __init__(self, consul: ConsulUtil, planner: WorkPlanner):
+        """Constructor."""
+        self.cns = consul
+        self.planner = planner
+
+    def handle(self, msg: Event) -> None:
+        node_fid = self.cns.get_node_fid(msg.node_id)
+        if not node_fid:
+            LOG.warn('Unknown [node_id=%s] provided. HA event is ignored',
+                     msg.node_id)
+            return
+
+        get_health = self._get_status_by_text
+
+        self.planner.add_command(
+            BroadcastHAStates(states=[
+                HAState(fid=node_fid, status=get_health(msg.event_type))
+            ],
+                              reply_to=None))
+
+    def _get_status_by_text(self, status: str):
+        if status == 'online':
+            return ServiceHealth.OK
+        elif status == 'offline':
+            return ServiceHealth.FAILED
+        else:
+            return ServiceHealth.UNKNOWN

--- a/hax/hax/ha/thread.py
+++ b/hax/hax/ha/thread.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+import threading as thr
+from typing import Dict, Optional
+
+from hax.ha.events import Event, EventListener
+from hax.ha.handler import EventHandler
+from hax.ha.handler.node import NodeEventHandler
+from hax.motr.planner import WorkPlanner
+from hax.types import StoppableThread
+from hax.util import ConsulUtil, InterruptedException, wait_for_event
+
+from ha.core.event_manager.subscribe_event import SubscribeEvent
+
+LOG = logging.getLogger('hax')
+
+
+class EventPollingThread(StoppableThread):
+
+    '''
+    Thread which polls the HA events from Kafka by means of EventListenerr
+    class.
+    '''
+    def __init__(self,
+                 planner: WorkPlanner,
+                 consul: ConsulUtil,
+                 listener: Optional[EventListener] = None,
+                 interval_sec: float = 1.0):
+        '''Constructor.'''
+
+        super().__init__(target=self._execute,
+                         name='ha-event-listener',
+                         args=())
+        self.stopped = False
+        self.event = thr.Event()
+        self.interval_sec = interval_sec
+        self.receive_timeout = 0.1
+        self.cns = consul
+        self.raw_listener = listener
+        self.planner = planner
+        self.handlers: Dict[str, EventHandler] = self._register_handlers()
+
+    def stop(self) -> None:
+        LOG.debug('Stop signal received')
+        self.stopped = True
+        self.event.set()
+
+    def _execute(self):
+        LOG.debug('Event polling thread started')
+        self.listener = self.raw_listener or self._create_listener()
+        try:
+            while not self.stopped:
+                self._handle_next_messages()
+                wait_for_event(self.event, self.interval_sec)
+        except InterruptedException:
+            # Shutting down normally
+            pass
+        except Exception:
+            LOG.exception('Aborting due to an error')
+        finally:
+            LOG.debug('HA event listener thread exited')
+
+    def _handle_next_messages(self) -> None:
+        timeout = self.receive_timeout
+
+        # Read out and process as many messages we can in a row
+        # Once we get no message, the function returns.
+        while not self.stopped:
+            # TODO one listener listens to one topic only
+            # How we're going to listen to a number of topics at the same time?
+            # Have multiple listeners?
+            msg = self.listener.get_next_message(timeout)
+            if not msg:
+                break
+            self._process(msg)
+            self.listener.ack()
+
+    def _register_handlers(self) -> Dict[str, EventHandler]:
+        return {'node': NodeEventHandler(self.cns, self.planner)}
+
+    def _process(self, message: Event):
+        handlers = self.handlers
+        resource_type = message.resource_type
+        try:
+            LOG.debug('Got message from HA: %s', message)
+            if resource_type not in handlers:
+                LOG.debug('Message %s is not supported; skipped', message)
+                return
+            handlers[resource_type].handle(message)
+
+        except Exception as e:
+            LOG.warn("Message %s wasn't processed. Reason: %s. Skipped",
+                     message, e)
+            LOG.debug("Error details:", exc_info=True)
+
+    def _create_listener(self) -> EventListener:
+        # TODO: how to stop propagating HA types like this SubscribeEvent
+        # throughout hax sources?
+        return EventListener([SubscribeEvent('node', ['offline', 'online'])])

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -23,7 +23,6 @@ import re
 from typing import List, NamedTuple
 
 from hax.filestats import FsStatsUpdater
-from hax.ha.thread import EventPollingThread
 from hax.handler import ConsumerThread
 from hax.log import setup_logging
 from hax.motr import Motr
@@ -34,6 +33,7 @@ from hax.motr.rconfc import RconfcStarter
 from hax.server import ServerRunner
 from hax.types import Fid, Profile, StoppableThread
 from hax.util import ConsulUtil, repeat_if_fails
+from hax.ha import create_ha_thread
 
 __all__ = ['main']
 
@@ -148,7 +148,7 @@ def main():
         rconfc_starter = _run_rconfc_starter_thread(motr, consul_util=util)
 
         stats_updater = _run_stats_updater_thread(motr, consul_util=util)
-        event_poller = _run_thread(EventPollingThread(planner, util))
+        event_poller = _run_thread(create_ha_thread(planner, util))
         # [KN] This is a blocking call. It will work until the program is
         # terminated by signal
 

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -664,6 +664,19 @@ class ConsulUtil:
         return None
 
     @repeat_if_fails()
+    def get_node_name_by_fid(self, node_fid: Fid) -> Optional[str]:
+        """
+        Returns the node name by its FID value or None if the given FID doesn't
+        correspond to any node.
+        """
+        node_data = self.kv.kv_get(f'm0conf/nodes/{node_fid}')
+        if node_data:
+            parsed = json.loads(node_data['Value'])
+            name: str = parsed['name']
+            return name
+        return None
+
+    @repeat_if_fails()
     def get_node_ctrl_fids(self, node: str) -> Optional[List[Fid]]:
         """
         Parameters:

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -651,9 +651,15 @@ class ConsulUtil:
         #                         "state": "M0_NC_UNKNOWN"}
         node_items = self.kv.kv_get('m0conf/nodes', recurse=True)
         for item in node_items:
+            key = item['Key']
+            key_split = key.split('/')
+            if len(key_split) != 3:
+                # Although we make a recurse scan, we don't need anything
+                # deeper than 1 level down (see Example above).
+                continue
             item_value = json.loads(item['Value'])
             if 'name' in item_value and item_value['name'] == node:
-                node_fid: str = str(item['Key'].split('/')[2])
+                node_fid: str = str(key_split[2])
                 return Fid.parse(node_fid)
         return None
 

--- a/hax/mypy.ini
+++ b/hax/mypy.ini
@@ -6,5 +6,8 @@ check_untyped_defs = True
 [mypy-urllib3]
 ignore_missing_imports = True
 
+[mypy-ha.*]
+ignore_missing_imports = True
+
 [mypy-urllib3.exceptions]
 ignore_missing_imports = True


### PR DESCRIPTION
JIRA ticket: [EOS-15788](https://jts.seagate.com/browse/EOS-15788)

This PR adds integration with HA EventManager. By the result of this integration node state events ("offline", "online") will be received by hax and translated into Motr-specific broadcast messages.

Partial problems resolved by this PR:
1. No dev environment to debug against HA component. As a solution, the HA simulator is implemented (see `ha-simulator/` folder for more details). Hare developers don't need to deploy Kafka, Zookeeper, configure MessageBus etc to trigger HA events to happen.
2. The task itself leads to coupling with cortx-ha component (Reason: in order to receive HA events, Hare side needs to import cortx-ha types like EventManager, SubscribeEvent etc). The proposed solution identifies such issues and handles them gracefully (so Hare will be built and ran even in the environments without cortx-ha support).
