### PR TITLE
EOS-23252: Disable D212 pattern for pep257 tool for Codacy

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -1,0 +1,18 @@
+output-format: json
+
+strictness: medium
+test-warnings: true
+doc-warnings: false
+member-warnings: false
+inherits:
+  - default
+ignore-paths:
+  - docs
+ignore-patterns:
+  - (^|/)skip(this)?(/|$)
+autodetect: true
+max-line-length: 88
+
+pep257:
+  disable:
+    - D212


### PR DESCRIPTION
Problem that was bumped into: https://github.com/Seagate/cortx-hare/pull/1725#issuecomment-889066153
where both D212 and D213 warnings are enabled in Codacy (https://github.com/PyCQA/pydocstyle/issues/475) but they are mutually exclusive which makes the situation more curious is that this is about position of the first line in a multiline docstring as,

![image](https://user-images.githubusercontent.com/65269273/128812227-5657eec6-3818-4c5a-9173-582f3775bbb8.png)