### PR TITLE
Problem: node drive failure events are sent on node restart

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -278,9 +278,6 @@ class Motr:
                 continue
             note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st))
             notes.append(note)
-            if (st.fid.container == ObjT.PROCESS.value
-                    and st.status == ServiceHealth.STOPPED):
-                notify_devices = False
             notes += self._generate_sub_services(note, self.consul_util,
                                                  notify_devices)
             # For process failure, we report failure for the corresponding

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -561,9 +561,9 @@ class ConsulUtil:
             pfid = self.get_service_process_fid(svc_fid)
         else:
             pfid = create_process_fid(fidk)
-        if self.get_process_status(pfid).proc_status in (
-                'M0_CONF_HA_PROCESS_STARTING', 'M0_CONF_HA_PROCESS_STARTED',
-                'M0_CONF_HA_PROCESS_STOPPING', 'Unknown'):
+        proc_node = self.get_process_node(pfid)
+        if (self.get_service_health(proc_node, fidk) in
+                (ServiceHealth.OK, ServiceHealth.UNKNOWN)):
             return HaNoteStruct.M0_NC_ONLINE
         else:
             return HaNoteStruct.M0_NC_FAILED


### PR DESCRIPTION
If a node is shutdown or rebooted in that case the corresponding node
processes are shutdown. In this case no drive failure events are sent
if the status of processes corresponding to the stopped node is
M0_CONF_HA_PROCESS_STOPPED in consul kv.
As the node's devices remain online, s3servers don't get any failure
notification which leads to dgread failures.

Solution:
Send OFFLINE notifications for the devices corresponding to the stopped
or restarted node.

Addresses: https://jts.seagate.com/browse/EOS-23165

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>