### PR TITLE
EOS-19065: Revert the feature temporarily

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -31,7 +31,6 @@ from enum import Enum
 from sys import exit
 from time import sleep
 from typing import Any, Callable, Dict, List
-from urllib.parse import urlparse
 
 import yaml
 from cortx.utils.product_features import unsupported_features
@@ -480,13 +479,8 @@ def check_cluster_status(path_to_cdf: str):
     return 0
 
 
-def generate_cdf(url: str, motr_md_url: str) -> str:
-    # ConfStoreProvider creates an empty file, if file does not exist.
-    # So, we are validating the file is present or not.
-    if not os.path.isfile(urlparse(motr_md_url).path):
-        raise FileNotFoundError(f'config file: {motr_md_url} does not exist')
-    motr_provider = ConfStoreProvider(motr_md_url, index='motr_md')
-    generator = CdfGenerator(ConfStoreProvider(url), motr_provider)
+def generate_cdf(url: str) -> str:
+    generator = CdfGenerator(ConfStoreProvider(url))
     return generator.generate()
 
 
@@ -523,9 +517,7 @@ def config(args):
     try:
         url = args.config[0]
         filename = args.file[0] or '/var/lib/hare/cluster.yaml'
-        motr_md_path = '/opt/seagate/cortx/motr/conf/motr_hare_keys.json'
-        motr_md_url = 'json://' + motr_md_path
-        save(filename, generate_cdf(url, motr_md_url))
+        save(filename, generate_cdf(url))
         update_hax_unit('/usr/lib/systemd/system/hare-hax.service')
         generate_config(url, filename)
     except Exception as error:

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -27,7 +27,7 @@ class ValueProvider:
     def get(self, key: str, allow_null: bool = False) -> Any:
         ret = self._raw_get(key)
         if ret is None and not allow_null:
-            raise MissingKeyError(key, self.url)
+            raise MissingKeyError(key)
         return ret
 
     def _raw_get(self, key: str) -> str:
@@ -47,7 +47,7 @@ class ValueProvider:
 
 
 class ConfStoreProvider(ValueProvider):
-    def __init__(self, url: str, index='hare'):
+    def __init__(self, url: str):
         self.url = url
         # Note that we don't instantiate Conf class on purpose.
         #
@@ -64,12 +64,11 @@ class ConfStoreProvider(ValueProvider):
         # That state is also static...
 
         conf = Conf
-        conf.load(index, url, fail_reload=False)
+        conf.load('hare', url, fail_reload=False)
         self.conf = conf
-        self.index = index
 
     def _raw_get(self, key: str) -> str:
-        return self.conf.get(self.index, key)
+        return self.conf.get('hare', key)
 
     def get_machine_id(self) -> str:
         with open('/etc/machine-id', 'r') as f:

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -154,10 +154,9 @@ class ClusterDesc(DhallTuple):
 @dataclass(repr=False)
 class MissingKeyError(Exception):
     key: str
-    url: str
 
     def __str__(self):
-        return f"Required key '{self.key}' not found in '{self.url}'"
+        return f"Required key '{self.key}' not found"
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -98,15 +98,12 @@ class TestCDF(unittest.TestCase):
             #
             # the method will raise an exception if either
             # Dhall is unhappy or some values are not found in ConfStore
-            cdf = CdfGenerator(provider=store, motr_provider=Mock())
-            cdf._get_m0d_per_cvg = Mock(return_value=1)
-            cdf.generate()
+            CdfGenerator(provider=store).generate()
         finally:
             os.unlink(path)
 
     def test_it_works(self):
         store = ValueProvider()
-        motr_store = ValueProvider()
 
         def ret_values(value: str) -> Any:
             data = {
@@ -163,26 +160,10 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
 
-        def ret_motr_mdvalues(value: str) -> Any:
-            data = {
-                'server>myhost>cvg[0]>m0d':
-                ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
-                'server>myhost>cvg[0]>m0d[0]>md_seg1':
-                '/dev/vg_srvnode-1_md1/lv_raw_md1',
-                'server>myhost>cvg[1]>m0d':
-                ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
-                'server>myhost>cvg[1]>m0d[0]>md_seg1':
-                '/dev/vg_srvnode-1_md2/lv_raw_md2'
-            }
-            return data.get(value)
-
-        motr_store._raw_get = Mock(side_effect=ret_motr_mdvalues)
-
-        CdfGenerator(provider=store, motr_provider=motr_store).generate()
+        CdfGenerator(provider=store).generate()
 
     def test_provided_values_respected(self):
         store = ValueProvider()
-        motr_store = ValueProvider()
 
         def ret_values(value: str) -> Any:
             data = {
@@ -221,23 +202,7 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
 
-        def ret_motr_mdvalues(value: str) -> Any:
-            data = {
-                'server>mynodename>cvg[0]>m0d':
-                ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
-                'server>mynodename>cvg[0]>m0d[0]>md_seg1':
-                '/dev/vg_srvnode-1_md1/lv_raw_md1',
-                'server>mynodename>cvg[1]>m0d':
-                ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
-                'server>mynodename>cvg[1]>m0d[0]>md_seg1':
-                '/dev/vg_srvnode-1_md2/lv_raw_md2'
-            }
-            return data.get(value)
-
-        motr_store._raw_get = Mock(side_effect=ret_motr_mdvalues)
-
-        ret = CdfGenerator(provider=store,
-                           motr_provider=motr_store)._create_node_descriptions()
+        ret = CdfGenerator(provider=store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
@@ -245,9 +210,7 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(1, ret[0].s3_instances)
         self.assertEqual(2, ret[0].client_instances)
 
-
-        ret = CdfGenerator(provider=store,
-                           motr_provider=Mock())._create_pool_descriptions()
+        ret = CdfGenerator(provider=store)._create_pool_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('StorageSet-1__sns'), ret[0].name)
@@ -265,8 +228,7 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(0, ret[0].allowed_failures.value.ctrl)
         self.assertEqual(0, ret[0].allowed_failures.value.disk)
 
-        ret = CdfGenerator(provider=store,
-                           motr_provider=Mock())._create_profile_descriptions(ret)
+        ret = CdfGenerator(provider=store)._create_profile_descriptions(ret)
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('Profile_the_pool'), ret[0].name)
@@ -373,8 +335,7 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID1')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID1', 'MACH_ID2', 'MACH_ID3'])
 
-        ret = CdfGenerator(provider=store,
-                           motr_provider=Mock())._create_pool_descriptions()
+        ret = CdfGenerator(provider=store)._create_pool_descriptions()
         self.assertIsInstance(ret, list)
         return ret
 
@@ -429,9 +390,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
-        cdf = CdfGenerator(provider=store, motr_provider=Mock())
-        cdf._get_m0d_per_cvg = Mock(return_value=1)
-        cdf.generate()
+        ret = CdfGenerator(provider=store).generate()
 
     def test_invalid_storage_set_configuration_rejected(self):
         ''' This test case checks whether exception will be raise if total
@@ -489,8 +448,7 @@ class TestCDF(unittest.TestCase):
 
         with self.assertRaisesRegex(RuntimeError,
                                     r'Invalid storage set configuration'):
-            CdfGenerator(provider=store,
-                         motr_provider=Mock())._create_pool_descriptions()
+            CdfGenerator(provider=store)._create_pool_descriptions()
 
     def test_md_pool_ignored(self):
         store = ValueProvider()
@@ -535,8 +493,7 @@ class TestCDF(unittest.TestCase):
             return data.get(value)
 
         store._raw_get = Mock(side_effect=ret_values)
-        ret = CdfGenerator(provider=store,
-                           motr_provider=Mock())._create_pool_descriptions()
+        ret = CdfGenerator(provider=store)._create_pool_descriptions()
         self.assertEqual(0, len(ret))
 
     def test_dix_pool_uses_metadata_devices(self):
@@ -593,8 +550,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
-        ret = CdfGenerator(provider=store,
-                           motr_provider=Mock())._create_pool_descriptions()
+        ret = CdfGenerator(provider=store)._create_pool_descriptions()
         self.assertEqual(1, len(ret))
         diskrefs = ret[0].disk_refs.get()
         self.assertEqual(2, len(diskrefs))
@@ -658,8 +614,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
-        ret = CdfGenerator(provider=store,
-                           motr_provider=Mock())._create_pool_descriptions()
+        ret = CdfGenerator(provider=store)._create_pool_descriptions()
         self.assertEqual(['sns', 'dix'], [t.type.name for t in ret])
         self.assertEqual(['StorageSet-1__sns', 'StorageSet-1__dix'],
                          [t.name.s for t in ret])
@@ -674,7 +629,6 @@ class TestCDF(unittest.TestCase):
 
     def test_metadata_is_hardcoded(self):
         store = ValueProvider()
-        motr_store = ValueProvider()
 
         def ret_values(value: str) -> Any:
             data = {
@@ -685,12 +639,9 @@ class TestCDF(unittest.TestCase):
                 'myhost',
                 'server_node>MACH_ID>name': 'mynodename',
                 'server_node>MACH_ID>storage>cvg':
-                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta1']},
-                 {'data_devices': ['/dev/sdc'], 'metadata_devices': ['/dev/meta2']}],
+                [{'data_devices': ['/dev/sdb'], 'metadata_devices': ['/dev/meta']}],
                 'server_node>MACH_ID>storage>cvg[0]>data_devices':
                 ['/dev/sdb'],
-                'server_node>MACH_ID>storage>cvg[1]>data_devices':
-                ['/dev/sdc'],
                 'server_node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'server_node>MACH_ID>s3_instances':
@@ -706,30 +657,11 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
 
-        def ret_motr_mdvalues(value: str) -> Any:
-            data = {
-                'server>mynodename>cvg[0]>m0d':
-                ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
-                'server>mynodename>cvg[0]>m0d[0]>md_seg1':
-                '/dev/vg_srvnode-1_md1/lv_raw_md1',
-                'server>mynodename>cvg[1]>m0d':
-                ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
-                'server>mynodename>cvg[1]>m0d[0]>md_seg1':
-                '/dev/vg_srvnode-1_md2/lv_raw_md2'
-            }
-            return data.get(value)
-
-        motr_store._raw_get = Mock(side_effect=ret_motr_mdvalues)
-
-
-        ret = CdfGenerator(provider=store,
-                           motr_provider=motr_store)._create_node_descriptions()
+        ret = CdfGenerator(provider=store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(1, len(ret))
-        self.assertEqual(Text('/dev/vg_srvnode-1_md1/lv_raw_md1'),
+        self.assertEqual(Text('/dev/vg_mynodename_md1/lv_raw_md1'),
                          (ret[0].m0_servers.value.value)[0].io_disks.meta_data.value)
-        self.assertEqual(Text('/dev/vg_srvnode-1_md2/lv_raw_md2'),
-                         (ret[0].m0_servers.value.value)[1].io_disks.meta_data.value)
 
 
     def test_multiple_nodes_supported(self):
@@ -788,9 +720,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
 
-        cdf = CdfGenerator(provider=store, motr_provider=Mock())
-        cdf._get_m0d_per_cvg = Mock(return_value=1)
-        ret = cdf._create_node_descriptions()
+        ret = CdfGenerator(provider=store)._create_node_descriptions()
         self.assertIsInstance(ret, list)
         self.assertEqual(2, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
@@ -833,7 +763,6 @@ class TestCDF(unittest.TestCase):
             return data[value]
 
         store._raw_get = Mock(side_effect=ret_values)
-        cdf = CdfGenerator(provider=store, motr_provider=Mock())
-        cdf._get_m0d_per_cvg = Mock(return_value=1)
-        ret = cdf._create_node_descriptions()
+
+        ret = CdfGenerator(provider=store)._create_node_descriptions()
         self.assertEqual('None P', str(ret[0].data_iface_type))


### PR DESCRIPTION
Problem: this feature requires support from Motr side as well (in other
words, as of #1721 Hare assumes that Motr provides additional JSON
file). The feature is not fully implemented by Motr side,

Solution: revert the feature temporarily

