### PR TITLE
EOS-23252: Created prospector.yml for disabling D212 pattern for pep257 tool in Codacy

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -1,5 +1,4 @@
 output-format: json
-
 strictness: medium
 test-warnings: true
 doc-warnings: false

--- a/prospector.yml
+++ b/prospector.yml
@@ -1,0 +1,18 @@
+output-format: json
+
+strictness: medium
+test-warnings: true
+doc-warnings: false
+member-warnings: false
+inherits:
+  - default
+ignore-paths:
+  - docs
+ignore-patterns:
+  - (^|/)skip(this)?(/|$)
+autodetect: true
+max-line-length: 88
+
+pep257:
+  disable:
+    - D212


### PR DESCRIPTION
**Description:**
EOS-23252: Created prospector.yml for disabling D212 pattern for pep257 tool in Codacy

**Problem:**
Problem that was bumped into: #1725 (comment)
where both D212 and D213 warnings are enabled in Codacy (PyCQA/pydocstyle#475) but they are mutually exclusive which makes the situation more curious is that this is about position of the first line in a multiline docstring as,

![image](https://user-images.githubusercontent.com/65269273/128828249-e4d1edca-fbd8-475a-aeed-73a5e28fb003.png)