### PR TITLE
EOS-23252: Codacy blocking merge because of a dead lock condition

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,15 @@
+output-format: json
+strictness: medium
+test-warnings: true
+doc-warnings: false
+member-warnings: false
+inherits:
+  - default
+ignore-paths:
+  - docs
+autodetect: true
+max-line-length: 80
+
+pep257:
+  disable:
+    - D212


### PR DESCRIPTION
Codacy uses Python code analysis tool prospector which in turn uses Static analysis
tool, pep257 that checks the docstring style in Python code
is configured for Cortx repositories in github. This tool by default implements
rules D212 and D213 which conflict each other.
e.g.
```
"""Summary.

    Documentation.
"""
leads to "Multi-line docstring summary should start at the second line pydocstyle(D213)".

"""
    Summary.

    Documentation.
"""
leads to "Multi-line docstring summary should start at the first line pydocstyle(D212)".
```
Same issue is reproduced at PR https://github.com/Seagate/cortx-hare/pull/1725

Solution:
As we don't want to disable tool pep257 entirely we can configure prospector by disabling
the specific rules, D212, from the tool using .prospector.yml.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>