### PR TITLE
Problem: bootstrap fails with multiple ioservices per node

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1349,7 +1349,7 @@ class ConfPool(ToDhall):
         encls_nr = len(cluster_encls(m0conf))
         ctrls_per_encl = floor(len(cluster_ctrls(m0conf)) / encls_nr)
         encl_failures = encls_nr - 1
-        ctrl_failures = ctrls_per_encl * encl_failures
+        ctrl_failures = min(encl_failures, (ctrls_per_encl * encl_failures))
         return Failures(0, 0, encl_failures, ctrl_failures, encl_failures)
 
     @classmethod


### PR DESCRIPTION
The default tolerance vector generated for dix and md pools in case of
multiple ioservice per node causes tolerance check to fail for m0d
during bootstrap.
For example,
If #encls = 3, #ctrls = 3 (2 per encl/node), #sdevs = 2 per ctrl,
data_units = 4, parity_units = 2 and spare_units = 0. Thus pool width = 6.
Default DIX or MD layout parameters are, data_units = 1, parity_units = 2
and spare_units = 0.
In such a case the allowed failure vector presently generated for the DIX and
MD pool is, [0, 0, 2, 4, 2] ([S, R, E, C, D]), where number of controller failures
allowed are 4 which is more and 2 (K) tolerated failures.
Thus in this case it is possible that more than K units can be lost due to failure
of 4 controllers in a particualr combination across multiple nodes. Which cannot
be tolerated, hence the tolerance check fails.

Solution:
Take the minimum of K and calculated controller failures. Don't allow more than
K controller failures in the cluster.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>