### PR TITLE
EOS-23169: Factory Reset - Call Hare init stage in Hare 'reset' stage

### DIFF
--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
@@ -1,1 +1,70 @@
-{}
+{
+  "cluster": {
+    "TMPL_CLUSTER_ID": {
+      "site": {
+        "storage_set_count": "TMPL_STORAGESET_COUNT"
+      },
+      "storage_set": [
+        {
+          "durability": {
+            "TMPL_POOL_TYPE": {
+              "data": "TMPL_DATA_UNITS_COUNT",
+              "parity": "TMPL_PARITY_UNITS_COUNT",
+              "spare": "TMPL_SPARE_UNITS_COUNT"
+            }
+          },
+          "name": "TMPL_STORAGESET_NAME",
+          "server_nodes": [
+            "TMPL_MACHINE_ID"
+          ]
+        }
+      ]
+    }
+  },
+    "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
+  "server_node": {
+    "TMPL_MACHINE_ID": {
+      "cluster_id": "TMPL_CLUSTER_ID",
+      "hostname": "TMPL_HOSTNAME",
+      "name": "TMPL_SERVER_NODE_NAME",
+      "network": {
+        "data": {
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN",
+          "private_interfaces": [
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
+          ]
+        }
+      },
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
+      "storage": {
+        "cvg_count": "TMPL_CVG_COUNT",
+        "cvg": [
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_1",
+              "TMPL_DATA_DEVICE_2"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
@@ -1,1 +1,159 @@
-{}
+{
+  "cluster": {
+    "TMPL_CLUSTER_ID": {
+      "site": {
+        "storage_set_count": "TMPL_STORAGESET_COUNT"
+      },
+      "storage_set": [
+        {
+          "durability": {
+            "TMPL_POOL_TYPE": {
+              "data": "TMPL_DATA_UNITS_COUNT",
+              "parity": "TMPL_PARITY_UNITS_COUNT",
+              "spare": "TMPL_SPARE_UNITS_COUNT"
+            }
+          },
+          "name": "TMPL_STORAGESET_NAME",
+          "server_nodes": [
+            "TMPL_MACHINE_ID_1",
+            "TMPL_MACHINE_ID_2",
+            "TMPL_MACHINE_ID_3"
+          ]
+        }
+      ]
+    }
+  },
+  "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "TMPL_S3SERVER_INSTANCES_COUNT"
+        }
+      }
+    }
+  },
+  "server_node": {
+    "TMPL_MACHINE_ID_1": {
+      "cluster_id": "TMPL_CLUSTER_ID",
+      "hostname": "TMPL_HOSTNAME",
+      "name": "TMPL_SERVER_NODE_NAME",
+      "network": {
+        "data": {
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_1",
+          "private_interfaces": [
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
+          ]
+        }
+      },
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
+      "storage": {
+        "cvg_count": "TMPL_CVG_COUNT",
+        "cvg": [
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
+          },
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        ]
+      }
+    },
+    "TMPL_MACHINE_ID_2": {
+      "cluster_id": "TMPL_CLUSTER_ID",
+      "hostname": "TMPL_HOSTNAME",
+      "name": "TMPL_SERVER_NODE_NAME",
+      "network": {
+        "data": {
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_2",
+          "private_interfaces": [
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
+          ]
+        }
+      },
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
+      "storage": {
+        "cvg_count": "TMPL_CVG_COUNT",
+        "cvg": [
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
+          },
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        ]
+      }
+    },
+    "TMPL_MACHINE_ID_3": {
+      "cluster_id": "TMPL_CLUSTER_ID",
+      "hostname": "TMPL_HOSTNAME",
+      "name": "TMPL_SERVER_NODE_NAME",
+      "network": {
+        "data": {
+          "interface_type": "TMPL_DATA_INTERFACE_TYPE",
+          "private_fqdn": "TMPL_PRIVATE_FQDN_3",
+          "private_interfaces": [
+            "TMPL_PRIVATE_DATA_INTERFACE_1",
+            "TMPL_PRIVATE_DATA_INTERFACE_2"
+          ]
+        }
+      },
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
+      "storage": {
+        "cvg_count": "TMPL_CVG_COUNT",
+        "cvg": [
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
+          },
+          {
+            "data_devices": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata_devices": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/provisioning/miniprov/test/test_templates.py
+++ b/provisioning/miniprov/test/test_templates.py
@@ -24,7 +24,7 @@ from typing import Dict, List
 import pkg_resources
 import pytest
 from hare_mp.cdf import CdfGenerator
-from hare_mp.store import ConfStoreProvider
+from hare_mp.store import ConfStoreProvider, ValueProvider
 
 
 def substitute(content: str, replacement: Dict[str, str]) -> str:
@@ -60,10 +60,12 @@ def is_content_ok(content: str, mocker) -> bool:
 
         store = ConfStoreProvider(f'json://{path}')
         mocker.patch.object(store, 'get_machine_id', return_value='machine-id')
+        motr_store = ValueProvider()
+        mocker.patch.object(motr_store, '_raw_get', return_value='/dev/dummy')
         #
         # the method will raise an exception if either
         # Dhall is unhappy or some values are not found in ConfStore
-        CdfGenerator(provider=store).generate()
+        CdfGenerator(provider=store, motr_provider=motr_store).generate()
         return True
 
     finally:


### PR DESCRIPTION
For motr reset, to restart the cluster, hare init needs to be called.
So Hare reset needs to call the 'Init' stage.

Solution:
Updated hare.reset.conf.tmpl.1-node and hare.reset.conf.tmpl.3-node.
Call 'Init' stage into Hare reset stage.
Addressed review comments on PR #1727 and removed /var/motr/hax , /etc/sysconfig/m0d-*
and /etc/sysconfig/s3server-* files in cleanup stage with pre-factory arguement.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>