### PR TITLE
Merge main to fault_tolerance 0818

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,15 @@
+output-format: json
+strictness: medium
+test-warnings: true
+doc-warnings: false
+member-warnings: false
+inherits:
+  - default
+ignore-paths:
+  - docs
+autodetect: true
+max-line-length: 80
+
+pep257:
+  disable:
+    - D212

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ and health-checking mechanisms.
   sudo yum -y install python3 python3-devel
   ```
 
+* Install puppet-agent (&ge; 6.13.0)
+  ```sh
+  sudo yum localinstall -y https://yum.puppetlabs.com/puppet/el/7/x86_64/puppet-agent-7.0.0-1.el7.x86_64.rpm
+  ```
+
 * Install Consul.
   ```sh
   sudo yum -y install yum-utils

--- a/hare.spec
+++ b/hare.spec
@@ -47,7 +47,7 @@ BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
 Requires: consul >= 1.7.0, consul < 1.10.0
-Requires: facter >= 3.14.8
+Requires: puppet-agent >= 6.13.0
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}
 Requires: cortx-py-utils


### PR DESCRIPTION
Merging fresh main branch to fault_tolerance. 

Commits to be merged:
```
commit a9d179d068e51df41c6d3fb4289905ff1dbcad43 (HEAD -> main-to-fault_tolerance-0818, mein/main-to-fault_tolerance-0818)
Author: vaibhavparatwar <vaibhav.paratwar@seagate.com>
Date:   Wed Aug 4 10:09:35 2021 -0600

    EOS-21367 : Facter rpm doesn't exist

    Solution:
    - We replace facter with puppet agent.
    - Updated README with puppet-agent installation step.

    Signed-off-by: vaibhavparatwar <vaibhav.paratwar@seagate.com>

commit fc5e04f76c5f871f1c813942036e6d5103cb1e73
Author: Mandar Sawant <mandar.sawant@seagate.com>
Date:   Tue Aug 10 13:57:06 2021 -0600

    EOS-23252: Codacy blocking merge because of a dead lock condition

    Codacy uses Python code analysis tool prospector which in turn uses Static analysis
    tool pep257 that checks the docstring style in Python code and is configured for Cortx
    repositories in github. This tool by default implements rules D212 and D213 which
    conflict each other.
    e.g.
    ```
    """Summary.

    Documentation.
    """
    leads to "Multi-line docstring summary should start at the second line pydocstyle(D213)".

    """
    Summary.

    Documentation.
    """
    leads to "Multi-line docstring summary should start at the first line pydocstyle(D212)".
    ```
    Same issue is reproduced at PR https://github.com/Seagate/cortx-hare/pull/1725

    Solution:
    As we don't want to disable tool pep257 entirely but we can configure prospector by disabling
    the specific rule D212 from the tool using .prospector.yml.

    Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>
```

-----
[View rendered README.md](https://github.com/knekrasov/cortx-hare/blob/main-to-fault_tolerance-0818/README.md)