### PR TITLE
EOS-15788: Hare needs to subscribe to 'failed' node status as well

### DIFF
--- a/ha-simulator/docker-compose.yml
+++ b/ha-simulator/docker-compose.yml
@@ -25,9 +25,6 @@ services:
       - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
     depends_on:
       - zookeeper
-  consul:
-    image: consul:latest
-    command: "agent -server -bootstrap -retry-join \"127.0.0.1\" -client 0.0.0.0"
 
   emitter:
     build:

--- a/ha-simulator/emitter.py
+++ b/ha-simulator/emitter.py
@@ -1,4 +1,4 @@
-from ha.core.action_handler.action_handler import NodeFailureActionHandler
+from ha.core.action_handler.action_handler import NodeActionHandler
 from ha.core.event_manager.event_manager import EventManager
 from ha.core.event_manager.subscribe_event import SubscribeEvent
 from ha.core.system_health.const import HEALTH_STATUSES
@@ -16,7 +16,7 @@ def main():
     # (just to make sure that the message will be sent)
     EventManager.get_instance().subscribe(
         component, [SubscribeEvent(resource_type, [state])])
-    handler = NodeFailureActionHandler()
+    handler = NodeActionHandler()
 
     event = HealthEvent("event_id", HEALTH_STATUSES.OFFLINE.value, "severity",
                         "1", "1", "e766bd52-c19c-45b6-9c91-663fd8203c2e",

--- a/ha-simulator/prepare-host.sh
+++ b/ha-simulator/prepare-host.sh
@@ -15,11 +15,7 @@ if [[ ! -f /etc/cortx/ha/ha.conf ]]; then
   sudo cp -f docker/etc/ha.conf /etc/cortx/ha/ha.conf
 fi
 
-#if [[ -f /etc/cortx/message_bus.conf ]]; then
-  #echo '/etc/cortx/message_bus.conf already exists. Please rename or remove it' >&2
-  #exit 1
-#fi
-
+HOST=$(hostname)
 cat <<EOF | sudo tee /etc/cortx/message_bus.conf > /dev/null
 {
   "message_broker": {
@@ -31,7 +27,7 @@ cat <<EOF | sudo tee /etc/cortx/message_bus.conf > /dev/null
     },
     "cluster": [
       {
-        "server": "ssc-vm-g2-rhev4-0175.colo.seagate.com",
+        "server": "${HOST}",
         "port": "9093"
       }
     ]

--- a/ha-simulator/run-containers.sh
+++ b/ha-simulator/run-containers.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 set -e -x
-#docker-compose up -d consul
 docker-compose up -d kafka zookeeper

--- a/hax/hax/ha/handler/node.py
+++ b/hax/hax/ha/handler/node.py
@@ -17,6 +17,7 @@
 #
 
 import logging
+from typing import Dict
 
 from hax.ha.events import Event
 from hax.ha.handler import EventHandler
@@ -26,6 +27,14 @@ from hax.types import HAState, ServiceHealth
 from hax.util import ConsulUtil
 
 LOG = logging.getLogger('hax')
+
+__all__ = ['NodeEventHandler']
+
+statusMap: Dict[str, ServiceHealth] = {
+    'online': ServiceHealth.OK,
+    'offline': ServiceHealth.OFFLINE,
+    'failed': ServiceHealth.FAILED,
+}
 
 
 class NodeEventHandler(EventHandler):
@@ -55,10 +64,5 @@ class NodeEventHandler(EventHandler):
             ],
                               reply_to=None))
 
-    def _get_status_by_text(self, status: str):
-        if status == 'online':
-            return ServiceHealth.OK
-        elif status == 'offline':
-            return ServiceHealth.FAILED
-        else:
-            return ServiceHealth.UNKNOWN
+    def _get_status_by_text(self, status: str) -> ServiceHealth:
+        return statusMap.get(status, ServiceHealth.UNKNOWN)

--- a/hax/hax/ha/thread.py
+++ b/hax/hax/ha/thread.py
@@ -118,5 +118,6 @@ class EventPollingThread(StoppableThread):
         # the messages that another hax instance receives (so every hax reads
         # the whole history of messages even if they process the messages with
         # different speed).
-        return EventListener([SubscribeEvent('node', ['offline', 'online'])],
-                             group_id=group)
+        return EventListener(
+            [SubscribeEvent('node', ['offline', 'online', 'failed'])],
+            group_id=group)

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -427,7 +427,7 @@ class Motr:
             new_state: ServiceHealth
             ) -> List[HaNoteStruct]:
 
-        state_int = new_state.value
+        state_int = new_state.to_ha_note_status()
         return [
             HaNoteStruct(no_id=node_fid.to_c(), no_state=state_int)
         ]
@@ -448,7 +448,7 @@ class Motr:
         LOG.debug('node_fid: %s encl_fid: %s ctrl_fids: %s with state: %s',
                   node_fid, encl_fid, ctrl_fids, new_state)
 
-        state_int = new_state.value
+        state_int = new_state.to_ha_note_status()
         notes = []
         if encl_fid:
             notes = [
@@ -464,7 +464,7 @@ class Motr:
     def notify_node_status_by_process(
             self, proc_note: HaNoteStruct) -> List[HaNoteStruct]:
         # proc_note.no_state is of int type
-        new_state = ServiceHealth(proc_note.no_state)
+        new_state = ServiceHealth.from_ha_note_state(proc_note.no_state)
         proc_fid = Fid.from_struct(proc_note.no_id)
         assert ObjT.PROCESS.value == proc_fid.container
         LOG.debug('Notifying node status for process_fid=%s state=%s',

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -216,15 +216,35 @@ class HaLinkMessagePromise:
 
 
 class ServiceHealth(Enum):
-    FAILED = 0
-    OK = 1
-    UNKNOWN = 2
-    OFFLINE = 3
-    STOPPED = 4
+    FAILED = (0, HaNoteStruct.M0_NC_FAILED)
+    OK = (1, HaNoteStruct.M0_NC_ONLINE)
+    UNKNOWN = (2, HaNoteStruct.M0_NC_UNKNOWN)
+    OFFLINE = (3, HaNoteStruct.M0_NC_TRANSIENT)
+    STOPPED = (4, HaNoteStruct.M0_NC_TRANSIENT)
 
     def __repr__(self):
         """Return human-readable constant name (useful in log output)."""
         return self.name
+
+    @staticmethod
+    def from_ha_note_state(state: int) -> 'ServiceHealth':
+        """
+        Converts the int constant from HaNoteStruct into the corresponding
+        ServiceHealth.
+        """
+        for i in list(ServiceHealth):
+            (_, note) = i.value
+            if note == state:
+                return i
+        return ServiceHealth.UNKNOWN
+
+    def to_ha_note_status(self) -> int:
+        """
+        Converts the given ServiceHealth to the most suitable HaNoteStruct
+        status.
+        """
+        ha_note: int = self.value[1]
+        return ha_note
 
 
 HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])


### PR DESCRIPTION
JIRA ticket: [EOS-15788](https://jts.seagate.com/browse/EOS-15788)

During the integration meeting it turned out that cortx-ha sends not only 'offline' and 'online' statuses but 'failed' also. Hare needs to handle this status as well.