### PR TITLE
EOS-15788: No auto test for ServiceHealth<>ha_note present

### DIFF
--- a/hax/hax/ha/handler/node.py
+++ b/hax/hax/ha/handler/node.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger('hax')
 
 __all__ = ['NodeEventHandler']
 
-statusMap: Dict[str, ServiceHealth] = {
+status_map: Dict[str, ServiceHealth] = {
     'online': ServiceHealth.OK,
     'offline': ServiceHealth.OFFLINE,
     'failed': ServiceHealth.FAILED,
@@ -65,4 +65,4 @@ class NodeEventHandler(EventHandler):
                               reply_to=None))
 
     def _get_status_by_text(self, status: str) -> ServiceHealth:
-        return statusMap.get(status, ServiceHealth.UNKNOWN)
+        return status_map.get(status, ServiceHealth.UNKNOWN)

--- a/hax/test/test_types.py
+++ b/hax/test/test_types.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+import pytest
+from hax.types import HaNoteStruct, ServiceHealth
+
+h = HaNoteStruct
+s = ServiceHealth
+
+
+@pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, s.OK),
+                                            (h.M0_NC_FAILED, s.FAILED),
+                                            (h.M0_NC_TRANSIENT, s.OFFLINE),
+                                            (h.M0_NC_UNKNOWN, s.UNKNOWN)])
+def test_service_health_to_ha_note(ha_note: int, health: ServiceHealth):
+    assert ha_note == health.to_ha_note_status()
+
+
+@pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, s.OK),
+                                            (h.M0_NC_FAILED, s.FAILED),
+                                            (h.M0_NC_TRANSIENT, s.OFFLINE),
+                                            (h.M0_NC_UNKNOWN, s.UNKNOWN),
+                                            (h.M0_NC_REPAIRED, s.UNKNOWN)])
+def test_ha_note_to_service_health_works(ha_note: int, health: ServiceHealth):
+    assert ServiceHealth.from_ha_note_state(ha_note) == health


### PR DESCRIPTION
Solution: implement a unit test that verifies that the conversions
between ServiceHealth and ha_note constants are correct (and as a side
effect - prove that Codacy error 'self.value is unsubscriptable' is
invalid).

Signed-off-by: Konstantin Nekrasov <konstantin.nekrasov@seagate.com>