### PR TITLE
EOS-22569: Integrate with new support bundle framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,8 @@ install: install-dirs install-cfgen install-hax install-miniprov install-systemd
 	@$(call _log,copying m0trace-prune -> $(ETC_CRON_DIR))
 	@install utils/m0trace-prune $(ETC_CRON_DIR)
 	@for f in provisioning/miniprov/hare_mp/templates/hare.* \
-		  provisioning/setup.yaml ; do \
+		  provisioning/setup.yaml \
+                provisioning/support.yaml ; do \
 	     $(call _log,copying $$f -> $(MINIPROV_TMPL_DIR)); \
 	     install $$f $(MINIPROV_TMPL_DIR); \
 	 done

--- a/provisioning/support.yaml
+++ b/provisioning/support.yaml
@@ -1,0 +1,2 @@
+support_bundle:
+  - /opt/seagate/cortx/hare/bin/hare_setup support_bundle


### PR DESCRIPTION
A new Support Framework has been rolled out. This requires every component to have support.yaml
file, which will provide interfaces for it. This support.yaml should be present at location -
`/opt/seagate/cortx/hare/conf/support.yaml`

Solution:
Added support.yaml file at `/provisioning` location.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>