### PR TITLE
EOS-23005: Updating node, enclosure and controllers status in consul KV

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -297,6 +297,33 @@ class m0HaProcessType(IntEnum):
         return self.name
 
 
+class m0HaObjState(IntEnum):
+    M0_NC_UNKNOWN = HaNoteStruct.M0_NC_UNKNOWN
+    M0_NC_ONLINE = HaNoteStruct.M0_NC_ONLINE
+    M0_NC_FAILED = HaNoteStruct.M0_NC_FAILED
+    M0_NC_TRANSIENT = HaNoteStruct.M0_NC_TRANSIENT
+    M0_NC_REPAIRED = HaNoteStruct.M0_NC_REPAIRED
+    M0_NC_REBALANCE = HaNoteStruct.M0_NC_REBALANCE
+    M0_NC_NR = HaNoteStruct.M0_NC_NR
+
+    def __repr__(self):
+        return self.name
+
+    @staticmethod
+    def parse(state: str) -> 'm0HaObjState':
+
+        states = {
+            'M0_NC_UNKNOWN': m0HaObjState.M0_NC_UNKNOWN,
+            'M0_NC_ONLINE': m0HaObjState.M0_NC_ONLINE,
+            'M0_NC_FAILED': m0HaObjState.M0_NC_FAILED,
+            'M0_NC_TRANSIENT': m0HaObjState.M0_NC_TRANSIENT,
+            'M0_NC_REPAIRED': m0HaObjState.M0_NC_REPAIRED,
+            'M0_NC_REBALANCE': m0HaObjState.M0_NC_REBALANCE,
+            'M0_NC_NR': m0HaObjState.M0_NC_NR
+        }
+        return states[state]
+
+
 class Profile(NamedTuple):
     fid: Fid
     name: str

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -351,6 +351,11 @@ def test_broadcast_node_failure(mocker, motr, consul_util):
                   json.dumps({
                       "name": "ios",
                       "state": "failed"
+                  })),
+                 ('m0conf/nodes/0x6e00000000000001:0x3',
+                  json.dumps({
+                      "name": "localhost",
+                      "state": "M0_NC_FAILED"
                   }))]
             ]
         elif key == 'm0conf/sites' and recurse:
@@ -359,11 +364,11 @@ def test_broadcast_node_failure(mocker, motr, consul_util):
                 [('m0conf/sites/0x5300000000000001:0x1/racks'
                   '/0x6100000000000001:0x2/encls/0x6500000000000001:0x4'
                   '/ctrls/0x6300000000000001:0x5',
-                  json.dumps({"state": "M0_NC_UNKNOWN"})),
+                  json.dumps({"state": "M0_NC_FAILED"})),
                  ('m0conf/sites/0x5300000000000001:0x1/racks'
                   '/0x6100000000000001:0x2/encls/0x6500000000000001:0x4'
                   '/ctrls/0x6300000000000001:0x6',
-                  json.dumps({"state": "M0_NC_UNKNOWN"}))]
+                  json.dumps({"state": "M0_NC_FAILED"}))]
             ]
         elif (key == 'm0conf/nodes/0x6e00000000000001:0x3'
               '/processes' and recurse):
@@ -447,6 +452,7 @@ def test_broadcast_node_failure(mocker, motr, consul_util):
     mocker.patch.object(consul_util,
                         'get_node_fid',
                         return_value=Fid(0x6e00000000000001, 0x3))
+
     mocker.patch.object(consul_util,
                         'get_node_encl_fid',
                         return_value=Fid(0x6500000000000001, 0x4))


### PR DESCRIPTION
### Description: 
Presently on node failure/online, the corresponding process status
is updated but Enclosure, Node and controller status update is missed in
consul KV.

### Solution: 
The states of node and enclosure are updated based on the node
failure/online event.
The controllers are updated based on the corresponding ios services
states.
HANote takes updated states from consul kv.

### Output:
```
[root@ssc-vm-g2-rhev4-0399 test]# hctl status -d
Data pool:
    # fid name
    0x6f00000000000001:0x39 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x60 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x7   10.230.246.59@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0xa   10.230.246.59@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xd   10.230.246.59@tcp:12345:2:2
    [started]  ioservice  0x7200000000000001:0x1e  10.230.246.59@tcp:12345:2:3
    [unknown]  m0_client  0x7200000000000001:0x33  10.230.246.59@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x36  10.230.246.59@tcp:12345:4:2
```
```
[root@ssc-vm-g2-rhev4-0399 test]# consul kv get -recurse 
m0conf/nodes/0x6e00000000000001:0x3:{"name": "localhost", "state": "online"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4:{"node": "0x6e00000000000001:0x3", "state": "online"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/0x6300000000000001:0x5:{"state": "online"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/0x6300000000000001:0x6:{"state": "online"}
```
Down with 1 ios process
```
[root@ssc-vm-g2-rhev4-0399 test]# hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x39 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x60 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x7   10.230.246.59@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0xa   10.230.246.59@tcp:12345:2:1
    [offline]  ioservice  0x7200000000000001:0xd   10.230.246.59@tcp:12345:2:2
    [started]  ioservice  0x7200000000000001:0x1e  10.230.246.59@tcp:12345:2:3
    [unknown]  m0_client  0x7200000000000001:0x33  10.230.246.59@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x36  10.230.246.59@tcp:12345:4:2
    
[root@ssc-vm-g2-rhev4-0399 test]# consul kv get -recurse | grep ctrl
m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/0x6300000000000001:0x5:{"state": "failed"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/0x6300000000000001:0x6:{"state": "online"}

```
In case of node failure.
```
[root@ssc-vm-g2-rhev4-0399 test]# hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x6f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xb1 'default': 'the pool' None None
Services:
    ssc-vm-g2-rhev4-0399.colo.seagate.com  (RC)
    [started]  hax        0x7200000000000001:0x7   10.230.246.59@tcp:12345:1:1
    [started]  confd      0x7200000000000001:0xa   10.230.246.59@tcp:12345:2:1
    [started]  ioservice  0x7200000000000001:0xd   10.230.246.59@tcp:12345:2:2
    [started]  ioservice  0x7200000000000001:0x1e  10.230.246.59@tcp:12345:2:3
    [unknown]  m0_client  0x7200000000000001:0x33  10.230.246.59@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x36  10.230.246.59@tcp:12345:4:2
    ssc-vm-g2-rhev4-0471.colo.seagate.com
    [offline]  hax        0x7200000000000001:0x3d  10.230.244.63@tcp:12345:1:1
    [offline]  confd      0x7200000000000001:0x40  10.230.244.63@tcp:12345:2:1
    [offline]  ioservice  0x7200000000000001:0x43  10.230.244.63@tcp:12345:2:2
    [offline]  ioservice  0x7200000000000001:0x54  10.230.244.63@tcp:12345:2:3
    [unknown]  m0_client  0x7200000000000001:0x69  10.230.244.63@tcp:12345:4:1
    [unknown]  m0_client  0x7200000000000001:0x6c  10.230.244.63@tcp:12345:4:2

m0conf/nodes/0x6e00000000000001:0x39:{"name": "ssc-vm-g2-rhev4-0471.colo.seagate.com", "state": "failed"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x3a:{"node": "0x6e00000000000001:0x39", "state": "failed"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x3a/ctrls/0x6300000000000001:0x3b:{"state": "failed"}

m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x3a/ctrls/0x6300000000000001:0x3c:{"state": "failed"}

m0conf/nodes/0x6e00000000000001:0x3:{"name": "ssc-vm-g2-rhev4-0399.colo.seagate.com", "state": "online"}
m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4:{"node": "0x6e00000000000001:0x3", "state": "online"}
m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/0x6300000000000001:0x5:{"state": "online"}
m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/0x6300000000000001:0x6:{"state": "online"}
```