### PR TITLE
Unable to fetch the actual statuses for SDEVS and DRIVES from consul KV.

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -370,10 +370,8 @@ class Motr:
                   len(event.nvec))
         notes: List[HaNoteStruct] = []
         for n in event.nvec:
-            n.note.no_state = HaNoteStruct.M0_NC_ONLINE
-            if (n.obj_t in (ObjT.PROCESS.name, ObjT.SERVICE.name)):
-                n.note.no_state = self.consul_util.get_conf_obj_status(
-                    ObjT[n.obj_t], n.note.no_id.f_key)
+            n.note.no_state = self.consul_util.get_conf_obj_status(
+                ObjT[n.obj_t], n.note.no_id.f_key)
             notes.append(n.note)
 
         LOG.debug('Replying ha nvec of length ' + str(len(event.nvec)))


### PR DESCRIPTION
### Decription:
In nvec reply, there was a condition which limited to only
process and service objects to fetch corresponding states from consul.
For remaining configuration objects(sdevs, drives), by default ONLINE
state is sent back to motr.
This resulted in failure of IO after node failure.

### Solution:
Removed the condition of explicit check for process and
services.

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>