### PR TITLE
Problem: cfgen does ssh to remote nodes to fetch facts

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -304,11 +304,18 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
     for node in desc['nodes']:
         # The fact names used here correspond to version 2.4.1 of `facter`.
         # See https://puppet.com/docs/puppet/6.6/core_facts.html#legacy-facts
-        node['facts'] = get_facts(node['hostname'], mock_p,
-                                  'processorcount', 'memorysize_mb',
-                                  ipaddr_key(node['data_iface']))
-        node['facts']['_memsize_MB'] = int(float(
-            node['facts']['memorysize_mb']))
+        if all(key in node.keys() for key in ('processorcount',
+                                              'memorysize_mb')):
+            node['facts'] = {'_memsize_MB': int(float(node['memorysize_mb'])),
+                             'processorcount': node['processorcount'],
+                             ipaddr_key(node['data_iface']):
+                                 node['data_iface_ip_addr']}
+        else:
+            node['facts'] = get_facts(node['hostname'], mock_p,
+                                      'processorcount', 'memorysize_mb',
+                                      ipaddr_key(node['data_iface']))
+            node['facts']['_memsize_MB'] = int(float(
+                node['facts']['memorysize_mb']))
 
         if 'm0_servers' not in node:
             continue
@@ -318,8 +325,11 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
             if 'meta_data' in m0d['io_disks']:
                 if m0d['io_disks']['meta_data'] is None:
                     del m0d['io_disks']['meta_data']
-            m0d['_io_disks'] = get_disks(node['hostname'], mock_p,
-                                         m0d['io_disks']['data'])
+            m0d['_io_disks'] = get_disks_from_cdf(node['hostname'], mock_p,
+                                                  m0d['io_disks']['data'])
+            if not m0d['_io_disks']:
+                m0d['_io_disks'] = get_disks_ssh(node['hostname'], mock_p,
+                                                 m0d['io_disks']['data'])
 
     if 'profiles' not in desc:
         sns_pools = [pool['name'] for pool in desc['pools']
@@ -378,12 +388,13 @@ Make sure the value of data_iface in the CDF is correct."""
         for m0d in node['m0_servers']:
             d = m0d['io_disks']
             assert m0d['runs_confd'] or d['data'], \
-                f"{name}: Either 'runs_confd' or 'io_disks.data' must be set"
+                f"{name}: Either 'runs_confd' or" \
+                "'io_disks.data' must be set"
             assert '' not in d['data'], \
                 f"{name}: Empty strings in 'io_disks.data' are not allowed"
             if 'meta_data' in d:
-                assert d['meta_data'], \
-                    f"{name}: 'io_disks.meta_data' must not be an empty string"
+                assert d['meta_data'], f"{name}: 'io_disks.meta_data'" \
+                    "must not be an empty string"
                 assert d['meta_data'] not in d['data'], \
                     f"{name}: Meta-data disk must not belong io_disks.data"
 
@@ -570,9 +581,13 @@ Disk.blksize.__doc__ = 'Block size for file system I/O'
 
 
 # XXX see build_disk_info() in motr's `utils/m0genfacts`
-def get_disks(hostname: str, mock_p: bool, paths: List[str]) -> List[Disk]:
-    if not paths:
+def get_disks_ssh(hostname: str, mock_p: bool,
+                  data_disks: List[Dict[str, Any]]) -> List[Disk]:
+    if not data_disks:
         return []
+    paths = []
+    for d in data_disks:
+        paths.append(d['path'])
     if mock_p:
         return fabricate_disks(hostname, paths)
 
@@ -597,6 +612,22 @@ print([dict(path=path,
     return [Disk(**kwargs) for kwargs in
             ast.literal_eval(run_command(hostname,
                                          'sudo', 'python3', '-c', code))]
+
+
+# XXX see build_disk_info() in motr's `utils/m0genfacts`
+def get_disks_from_cdf(hostname: str, mock_p: bool,
+                       data_disks: List[Dict[str, Any]]) -> List[Disk]:
+    if not data_disks:
+        return []
+
+    disks = []
+    for disk in data_disks:
+        if not all(key in disk.keys() for key in ('path', 'size', 'blksize')):
+            return []
+        disks.append(Disk(path=disk['path'], size=disk['size'],
+                          blksize=disk['blksize']))
+
+    return disks
 
 
 def fabricate_disks(hostname: str, paths: List[str]) -> List[Disk]:
@@ -671,16 +702,16 @@ NetProtocol = Enum('NetProtocol', 'tcp o2ib')
 class Endpoint:
     _tmids: Dict[Tuple[str, int], int] = {}
 
-    def __init__(self, proto: NetProtocol, ipaddr: str, portal: int,
+    def __init__(self, proto: NetProtocol, ipaddr: str, portalgroup: int,
                  tmid: int = None):
         self.proto = proto
         assert ipaddr
         self.ipaddr = ipaddr
-        assert portal > 0
-        self.portal = portal
+        assert portalgroup > 0
+        self.portalgroup = portalgroup
         if tmid is None:
-            self.tmid = self._tmids.setdefault((ipaddr, portal), 1)
-            self._tmids[(ipaddr, portal)] += 1
+            self.tmid = self._tmids.setdefault((ipaddr, portalgroup), 1)
+            self._tmids[(ipaddr, portalgroup)] += 1
         else:
             assert tmid > 0
             self.tmid = tmid
@@ -688,18 +719,53 @@ class Endpoint:
     def __repr__(self):
         args = ', '.join([f'proto={self.proto!r}',
                           f'ipaddr={self.ipaddr!r}',
-                          f'portal={self.portal}',
+                          f'portal={self.portalgroup}',
                           f'tmid={self.tmid}'])
         return f'{self.__class__.__name__}({args})'
 
     def to_dhall(self):
         return f'utils.endpoint types.Protocol.{self.proto.name}' \
-            f' "{self.ipaddr}" {self.portal} {self.tmid}'
+            f' "{self.ipaddr}" {self.portalgroup} {self.tmid}'
 
     def __str__(self):
         ip = self.ipaddr
         proto = self.proto.name
-        return f'{ip}@{proto}:12345:{self.portal}:{self.tmid}'
+        return f'{ip}@{proto}:12345:{self.portalgroup}:{self.tmid}'
+
+
+class LibfabricEndpoint:
+    ep_map: Dict[Tuple[str, int], int] = {}
+
+    def __init__(self, NetFamily: str, proto: NetProtocol, ipaddr: str,
+                 portalgroup: int):
+        self.netfamily = NetFamily
+        self.proto = proto
+        assert ipaddr
+        self.ipaddr = ipaddr
+        assert portalgroup > 0
+        self.portalgroup = portalgroup
+        self.portal = 0
+        self.portal = self.ep_map.setdefault((ipaddr, portalgroup),
+                                             (portalgroup + 1))
+        self.ep_map[(ipaddr, portalgroup)] += 1
+
+    def __repr__(self):
+        args = ', '.join([f'netfamily={self.netfamily!r}',
+                          f'proto={self.proto!r}',
+                          f'ipaddr={self.ipaddr!r}',
+                          f'portal={self.portal}'])
+        return f'{self.__class__.__name__}({args})'
+
+    def to_dhall(self):
+        return f'utils.libfabricendpoint types.NetFamily.{self.netfamily} ' \
+            f'types.Protocol.{self.proto.name}' \
+            f' "{self.ipaddr}" {self.portal}'
+
+    def __str__(self):
+        netfamily = self.netfamily
+        ip = self.ipaddr
+        proto = self.proto.name
+        return f'{netfamily}:{proto}:{ip}@{self.portal}'
 
 
 class ToDhall(metaclass=abc.ABCMeta):
@@ -807,15 +873,22 @@ class ConfNode(ToDhall):
         return node_id
 
 
-ProcT = Enum('ProcT', 'hax m0_server m0_client_s3 m0_client_other')
-ProcT.__doc__ = 'Type of process'
+# ProcT = Enum('ProcT', 'hax m0_server m0_client_s3 m0_client_other')
+# ProcT.__doc__ = 'Type of process'
+
+class ProcT(Enum):
+    hax = 2000
+    m0_server = 3000
+    m0_client_s3 = 4000
+    m0_client_other = 5000
 
 
 class ConfProcess(ToDhall):
     _objt = ObjT.process
     _downlinks = {Downlink('services', ObjT.service)}
 
-    def __init__(self, nr_cpu: int, memsize_MB: int, endpoint: Endpoint,
+    def __init__(self, nr_cpu: int, memsize_MB: int,
+                 endpoint: LibfabricEndpoint,
                  services: List[Oid], meta_data: str = None):
         assert nr_cpu > 0
         self.nr_cpu = nr_cpu
@@ -855,9 +928,14 @@ class ConfProcess(ToDhall):
 
         facts = node_desc['facts']
         proto = node_desc.get('data_iface_type', 'tcp')
-        ep = Endpoint(proto=NetProtocol[proto],
-                      ipaddr=facts[ipaddr_key(node_desc['data_iface'])],
-                      portal=proc_t.value)
+        # Creates Lnet endpoint, remove once deprecated.
+        # ep = Endpoint(proto=NetProtocol[proto],
+        #               ipaddr=facts[ipaddr_key(node_desc['data_iface'])],
+        #              portal=proc_t.value)
+        ep = LibfabricEndpoint(NetFamily='inet', proto=NetProtocol[proto],
+                               ipaddr=facts[ipaddr_key(
+                                            node_desc['data_iface'])],
+                               portalgroup=proc_t.value)
         proc_id = new_oid(ObjT.process)
 
         meta_data = None
@@ -937,8 +1015,8 @@ class ConfService(ToDhall):
     _objt = ObjT.service
     _downlinks = {Downlink('sdevs', ObjT.sdev)}
 
-    def __init__(self, stype: SvcT, endpoint: Endpoint, sdevs: List[Oid],
-                 ctrl_id: Oid = None):
+    def __init__(self, stype: SvcT, endpoint: LibfabricEndpoint,
+                 sdevs: List[Oid], ctrl_id: Oid = None):
         self.type = stype
         self.endpoint = endpoint
         assert all(x.type is ObjT.sdev for x in sdevs)
@@ -961,7 +1039,7 @@ class ConfService(ToDhall):
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
-              stype: SvcT, endpoint: Endpoint,
+              stype: SvcT, endpoint: LibfabricEndpoint,
               ctrl: Optional[Oid] = None) -> Oid:
         assert parent.type is ObjT.process
         svc_id = new_oid(ObjT.service)
@@ -1803,7 +1881,7 @@ def consul_kv_sdevs(m0conf: Dict[Oid, Any]) -> Dict[str, str]:
             assert proc_id.type is ObjT.process
             proc_key = f'{node_key}/processes/' + oid_to_fidstr(proc_id)
             # XXX-VERIFYME Can we really convert from portal (int) to name?
-            proc_name = ProcT(m0conf[proc_id].endpoint.portal).name
+            proc_name = ProcT(m0conf[proc_id].endpoint.portalgroup).name
             d[proc_key] = json.dumps({'name': proc_name,
                                       'state': 'M0_NC_UNKNOWN'})
             for svc_id in m0conf[proc_id].services:
@@ -1834,7 +1912,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
     m0conf = cluster.m0conf
 
     ConsulService = NamedTuple('ConsulService', [
-        ('node_name', str), ('proc_id', Oid), ('ep', Endpoint),
+        ('node_name', str), ('proc_id', Oid), ('ep', LibfabricEndpoint),
         ('svc_id', Oid), ('stype', str), ('meta_data', Optional[str])])
 
     def processes() -> Iterator[ConsulService]:
@@ -1859,7 +1937,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                                         proc_id=proc_id,
                                         ep=proc.endpoint,
                                         svc_id=cluster.m0_clients[proc_id],
-                                        stype=ProcT(proc_ep.portal).name,
+                                        stype=ProcT(proc_ep.portalgroup).name,
                                         meta_data=None)
 
     def sns_pools() -> List[Oid]:

--- a/cfgen/dhall/render.dhall
+++ b/cfgen/dhall/render.dhall
@@ -21,6 +21,9 @@
 { Endpoint   = ./render/Endpoint.dhall
 , NetId      = ./render/NetId.dhall
 
+, LibfabricEndpoint = ./render/LibfabricEndpoint.dhall
+, NetFamily   = ./types/NetFamily.dhall
+
 , Obj        = ./render/Obj.dhall
 , Objs       = ./render/Objs.dhall
 , ObjT       = ./render/ObjT.dhall

--- a/cfgen/dhall/render/LibfabricEndpoint.dhall
+++ b/cfgen/dhall/render/LibfabricEndpoint.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,20 +18,8 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
 let types = ../types.dhall
-
-let named = ./RNamed.dhall
-
 in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [./LibfabricEndpoint.dhall x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+\(x : types.LibfabricEndpoint) ->
+    let nat = Natural/show
+    in "${./NetFamily.dhall x.netfamily}:${./NetId.dhall x.nid}@${nat x.portal}"

--- a/cfgen/dhall/render/NetFamily.dhall
+++ b/cfgen/dhall/render/NetFamily.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,20 +18,12 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
 let types = ../types.dhall
 
-let named = ./RNamed.dhall
-
 in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [./LibfabricEndpoint.dhall x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+\(nf : types.NetFamily) ->
+    merge
+    { inet = "inet"
+    , inet6 = "inet6"
+    }
+    nf

--- a/cfgen/dhall/render/Process.dhall
+++ b/cfgen/dhall/render/Process.dhall
@@ -37,7 +37,7 @@ in
       , named.Natural "mem_limit_rss" memsize_KiB
       , named.Natural "mem_limit_stack" memsize_KiB
       , named.Natural "mem_limit_memlock" memsize_KiB
-      , named.Text "endpoint" (./Endpoint.dhall x.endpoint)
+      , named.Text "endpoint" (./LibfabricEndpoint.dhall x.endpoint)
       , named.Oids "services" x.services
       ]
  ++ ")"

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -38,9 +38,13 @@
 , NetId       = ./types/NetId.dhall
 , Protocol    = ./types/Protocol.dhall
 
+, LibfabricEndpoint = ./types/LibfabricEndpoint.dhall
+, NetFamily   = ./types/NetFamily.dhall
+
 , ClusterDesc  = ./types/ClusterDesc.dhall
 , NodeDesc     = ./types/NodeDesc.dhall
 , M0ServerDesc = ./types/M0ServerDesc.dhall
+, Disk         = ./types/IODisk.dhall
 , PoolDesc     = ./types/PoolDesc.dhall
 , DiskRef      = ./types/DiskRef.dhall
 , FailVec      = ./types/FailVec.dhall

--- a/cfgen/dhall/types/IODisk.dhall
+++ b/cfgen/dhall/types/IODisk.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,20 +18,8 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
-let types = ../types.dhall
-
-let named = ./RNamed.dhall
-
-in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [./LibfabricEndpoint.dhall x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+-- io disk
+{ path : Optional Text
+, size : Optional Natural
+, blksize : Optional Natural
+}

--- a/cfgen/dhall/types/LibfabricEndpoint.dhall
+++ b/cfgen/dhall/types/LibfabricEndpoint.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,20 +18,10 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
-let types = ../types.dhall
-
-let named = ./RNamed.dhall
-
-in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [./LibfabricEndpoint.dhall x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+{-
+   Libfabric endpoint address.
+-}
+{ netfamily : ./NetFamily.dhall
+, nid : ./NetId.dhall
+, portal : Natural
+}

--- a/cfgen/dhall/types/M0ServerDesc.dhall
+++ b/cfgen/dhall/types/M0ServerDesc.dhall
@@ -20,5 +20,5 @@
 
 -- m0d process
 { runs_confd : Optional Bool
-, io_disks : { meta_data : Optional Text, data : List Text }
+, io_disks : { meta_data : Optional Text, data : (List ./IODisk.dhall) }
 }

--- a/cfgen/dhall/types/NetFamily.dhall
+++ b/cfgen/dhall/types/NetFamily.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,20 +18,6 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
-let types = ../types.dhall
-
-let named = ./RNamed.dhall
-
-in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [./LibfabricEndpoint.dhall x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+< inet
+| inet6
+>

--- a/cfgen/dhall/types/NodeDesc.dhall
+++ b/cfgen/dhall/types/NodeDesc.dhall
@@ -19,7 +19,10 @@
 -}
 
 { hostname : Text
+, processorcount: Optional Natural
+, memorysize_mb: Optional Double
 , data_iface : Text
+, data_iface_ip_addr : Optional Text
 , data_iface_type : Optional ./Protocol.dhall
 , m0_servers : Optional (List ./M0ServerDesc.dhall)
 , m0_clients : { s3 : Natural, other : Natural }

--- a/cfgen/dhall/types/Process.dhall
+++ b/cfgen/dhall/types/Process.dhall
@@ -25,6 +25,6 @@ in
 { id : Oid
 , nr_cpu : Natural
 , memsize_MB : Natural
-, endpoint : ./Endpoint.dhall
+, endpoint : ./LibfabricEndpoint.dhall
 , services : List Oid
 }

--- a/cfgen/dhall/types/Service.dhall
+++ b/cfgen/dhall/types/Service.dhall
@@ -24,6 +24,6 @@ in
 -- m0_confx_service
 { id : Oid
 , type : ./SvcT.dhall
-, endpoint : ./Endpoint.dhall
+, endpoint : ./LibfabricEndpoint.dhall
 , sdevs : List Oid
 }

--- a/cfgen/dhall/utils.dhall
+++ b/cfgen/dhall/utils.dhall
@@ -19,5 +19,6 @@
 -}
 
 { endpoint = ./utils/endpoint.dhall
+, libfabricendpoint = ./utils/libfabricendpoint.dhall
 , zoid = ./utils/zoid.dhall
 }

--- a/cfgen/dhall/utils/libfabricendpoint.dhall
+++ b/cfgen/dhall/utils/libfabricendpoint.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,20 +18,21 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
 let types = ../types.dhall
 
-let named = ./RNamed.dhall
-
 in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [./LibfabricEndpoint.dhall x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+    \(netfamily : types.NetFamily)
+ -> \(proto : types.Protocol)
+ -> \(ipaddr : Text)
+ -> \(portal : Natural)
+ ->
+    let addr = { ipaddr = ipaddr, mdigit = None Natural }
+    in
+      { netfamily = merge { inet = types.NetFamily.inet
+                          , inet6 = types.NetFamily.inet6
+                          } netfamily
+      , nid = merge { tcp = types.NetId.tcp { tcp = addr }
+                    , o2ib = types.NetId.o2ib { o2ib = addr }
+                    } proto
+      , portal = portal
+      } : types.LibfabricEndpoint

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -8,18 +8,18 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/loop0
-            - /dev/loop1
-            - /dev/loop2
-            - /dev/loop3
+            - path: /dev/loop0
+            - path: /dev/loop1
+            - path: /dev/loop2
+            - path: /dev/loop3
       - io_disks:
           data:
-            - /dev/loop4
-            - /dev/loop5
-            - /dev/loop6
-            - /dev/loop7
-            - /dev/loop8
-            - /dev/loop9
+            - path: /dev/loop4
+            - path: /dev/loop5
+            - path: /dev/loop6
+            - path: /dev/loop7
+            - path: /dev/loop8
+            - path: /dev/loop9
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -7,12 +7,12 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -21,12 +21,12 @@ nodes:
     m0_servers:
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -7,12 +7,12 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -24,12 +24,12 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -7,12 +7,12 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -24,12 +24,12 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2
@@ -41,12 +41,12 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/vdb
-            - /dev/vdc
-            - /dev/vdd
-            - /dev/vde
-            - /dev/vdf
-            - /dev/vdg
+            - path: /dev/vdb
+            - path: /dev/vdc
+            - path: /dev/vdd
+            - path: /dev/vde
+            - path: /dev/vdf
+            - path: /dev/vdg
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -12,10 +12,10 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/sdd
-            - /dev/sde
-            - /dev/sdf
-            - /dev/sdg
+            - path: /dev/sdd
+            - path: /dev/sde
+            - path: /dev/sdf
+            - path: /dev/sdg
     m0_clients:
         s3: 0           # number of S3 servers to start
         other: 2        # max quantity of other Motr clients this node may have
@@ -28,10 +28,10 @@ nodes:
           data: []
       - io_disks:
           data:
-            - /dev/sdh
-            - /dev/sdi
-            - /dev/sdj
-            - /dev/sdk
+            - path: /dev/sdh
+            - path: /dev/sdi
+            - path: /dev/sdj
+            - path: /dev/sdk
     m0_clients:
         s3: 0
         other: 2

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -9,13 +9,13 @@ nodes:
       - io_disks:
           meta_data: /dev/vg_metadata_srvnode-1/lv_raw_metadata
           data:
-            - /dev/foo
-            - /dev/disk/by-id/dm-name-mpatha
-            - /dev/disk/by-id/dm-name-mpathb
-            - /dev/disk/by-id/dm-name-mpathc
-            - /dev/disk/by-id/dm-name-mpathd
-            - /dev/disk/by-id/dm-name-mpathe
-            - /dev/disk/by-id/dm-name-mpathf
+            - path: /dev/foo
+            - path: /dev/disk/by-id/dm-name-mpatha
+            - path: /dev/disk/by-id/dm-name-mpathb
+            - path: /dev/disk/by-id/dm-name-mpathc
+            - path: /dev/disk/by-id/dm-name-mpathd
+            - path: /dev/disk/by-id/dm-name-mpathe
+            - path: /dev/disk/by-id/dm-name-mpathf
     m0_clients:
       s3: 11
       other: 3
@@ -29,13 +29,13 @@ nodes:
       - io_disks:
           meta_data: /dev/vg_metadata_srvnode-2/lv_raw_metadata
           data:
-            - /dev/foo
-            - /dev/disk/by-id/dm-name-mpathg
-            - /dev/disk/by-id/dm-name-mpathh
-            - /dev/disk/by-id/dm-name-mpathi
-            - /dev/disk/by-id/dm-name-mpathj
-            - /dev/disk/by-id/dm-name-mpathk
-            - /dev/disk/by-id/dm-name-mpathl
+            - path: /dev/foo
+            - path: /dev/disk/by-id/dm-name-mpathg
+            - path: /dev/disk/by-id/dm-name-mpathh
+            - path: /dev/disk/by-id/dm-name-mpathi
+            - path: /dev/disk/by-id/dm-name-mpathj
+            - path: /dev/disk/by-id/dm-name-mpathk
+            - path: /dev/disk/by-id/dm-name-mpathl
     m0_clients:
       s3: 11
       other: 3

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -13,16 +13,16 @@ nodes:
       - io_disks:
           #meta_data: /path/to/meta-data/drive
           data:
-            - /dev/loop0
-            - /dev/loop1
-            - /dev/loop2
-            - /dev/loop3
-            - /dev/loop4
-            - /dev/loop5
-            - /dev/loop6
-            - /dev/loop7
-            - /dev/loop8
-            - /dev/loop9
+            - path: /dev/loop0
+            - path: /dev/loop1
+            - path: /dev/loop2
+            - path: /dev/loop3
+            - path: /dev/loop4
+            - path: /dev/loop5
+            - path: /dev/loop6
+            - path: /dev/loop7
+            - path: /dev/loop8
+            - path: /dev/loop9
     m0_clients:
       s3: 0         # number of S3 servers to start
       other: 2      # max quantity of other Motr clients this host may have

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -71,7 +71,7 @@ def mkServiceData(service: Dict[str, Any]) -> ServiceData:
             ObjT.PROCESS,  # XXX s/PROCESS/SERVICE/ ?
             int(service['ServiceID'])),
         ip_addr=service['Address'],
-        address='{}:{}'.format(service['ServiceAddress'],
+        address='{}@{}'.format(service['ServiceAddress'],
                                service['ServicePort']))
 
 
@@ -992,7 +992,7 @@ class ConsulUtil:
         return ServiceData(node=node,
                            fid=create_process_fid(fidk),
                            ip_addr=srv_ip_addr,
-                           address=f'{srv_address}:{srv_port}')
+                           address=f'{srv_address}@{srv_port}')
 
     def update_fs_stats(self, stats_data: FsStatsWithTime) -> None:
         # TODO investigate whether we can replace json with simplejson in

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -4,16 +4,31 @@ let T = $path/types.dhall
 let P = T.Protocol
 let DiskRef = T.DiskRef
 
-let M0dProcess =
+
+let Disk =
+      { path : Optional Text
+      , size : Optional Natural
+      , blksize : Optional Natural
+      }
+
+let IODisks =
+      { meta_data : Optional Text
+      , data : List Disk
+      }
+
+let M0ServerDesc =
       { runs_confd : Optional Bool
-      , io_disks : { meta_data : Optional Text, data : List Text }
+      , io_disks : IODisks
       }
 
 let NodeInfo =
       { hostname : Text
+      , processorcount : Optional Natural
+      , memorysize_mb : Optional Double
       , data_iface : Text
+      , data_iface_ip_addr : Optional Text
       , data_iface_type : Optional T.Protocol
-      , m0_servers : Optional  (List M0dProcess)
+      , m0_servers : Optional (List M0ServerDesc)
       , s3_instances : Natural
       , client_instances : Natural
       }
@@ -51,6 +66,9 @@ let toNodeDesc
     : NodeInfo -> T.NodeDesc
     =     \(n : NodeInfo)
       ->  { hostname = n.hostname
+          , processorcount = n.processorcount
+          , memorysize_mb = n.memorysize_mb
+          , data_iface_ip_addr = n.data_iface_ip_addr
           , data_iface = n.data_iface
           , data_iface_type = n.data_iface_type
           , m0_clients = { other = n.client_instances, s3 = n.s3_instances }

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -33,10 +33,10 @@ class ValueProvider:
     def _raw_get(self, key: str) -> str:
         raise NotImplementedError()
 
-    def get_machine_id(self) -> str:
+    def get_cluster_id(self) -> str:
         raise NotImplementedError()
 
-    def get_cluster_id(self) -> str:
+    def get_machine_id(self) -> str:
         raise NotImplementedError()
 
     def get_storage_set_index(self) -> int:
@@ -71,15 +71,13 @@ class ConfStoreProvider(ValueProvider):
     def _raw_get(self, key: str) -> str:
         return self.conf.get(self.index, key)
 
-    def get_machine_id(self) -> str:
-        with open('/etc/machine-id', 'r') as f:
-            machine_id = f.readline().strip('\n')
-            return machine_id
-
     def get_cluster_id(self) -> str:
         machine_id = self.get_machine_id()
         cluster_id = self.get(f'server_node>{machine_id}>cluster_id')
         return cluster_id
+
+    def get_machine_id(self) -> str:
+        return get_machine_id()
 
     def get_storage_set_index(self) -> int:
         i = 0
@@ -108,3 +106,9 @@ class ConfStoreProvider(ValueProvider):
         server_nodes_key = (f'cluster>{cluster_id}>'
                             f'storage_set[{storage_set_index}]>server_nodes')
         return self.get(server_nodes_key)
+
+
+def get_machine_id() -> str:
+    with open('/etc/machine-id', 'r') as f:
+        machine_id = f.readline().strip('\n')
+        return machine_id

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -91,9 +91,16 @@ class M0Clients(DhallTuple):
 
 
 @dataclass(repr=False)
+class Disk(DhallTuple):
+    path: Maybe[Text]
+    size: Maybe[int]
+    blksize: Maybe[int]
+
+
+@dataclass(repr=False)
 class DisksDesc(DhallTuple):
     meta_data: Maybe[Text]
-    data: DList[Text]
+    data: DList[Disk]
 
 
 @dataclass(repr=False)
@@ -105,7 +112,10 @@ class M0ServerDesc(DhallTuple):
 @dataclass(repr=False)
 class NodeDesc(DhallTuple):
     hostname: Text
+    processorcount: Maybe[int]
+    memorysize_mb: Maybe[int]
     data_iface: Text
+    data_iface_ip_addr: Maybe[Text]
     data_iface_type: Maybe[Protocol]
     m0_servers: Maybe[DList[M0ServerDesc]]
     s3_instances: int

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Setup utility for Hare to configure Hare related settings, e.g. logrotate,
+# report unsupported features, etc.
+
+import subprocess
+import json
+import io
+import os
+from typing import List
+
+from hax.util import repeat_if_fails, KVAdapter
+
+from hare_mp.store import ValueProvider
+from hare_mp.types import Disk, DList, Maybe, Text
+
+
+class Utils:
+    def __init__(self, provider: ValueProvider):
+        self.provider = provider
+        self.kv = KVAdapter()
+
+    def get_hostname(self) -> str:
+        machine_id = self.provider.get_machine_id()
+        hostname = self.provider.get(
+            f'server_node>{machine_id}>network>data>private_fqdn')
+        return hostname
+
+    @repeat_if_fails()
+    def save_node_facts(self):
+        hostname = self.get_hostname()
+        cmd = ['facter', '--json', 'processorcount', 'memorysize_mb']
+        node_facts = execute(cmd)
+        self.kv.kv_put(f'{hostname}/facts', node_facts)
+
+    def get_node_facts(self):
+        hostname = self.get_hostname()
+        node_facts = self.kv.kv_get(f'{hostname}/facts')
+        return json.loads(node_facts['Value'])
+
+    def get_data_devices(self, machine_id: str, cvg: int) -> DList[Text]:
+        data_devices = DList(
+            [Text(device) for device in self.provider.get(
+                f'server_node>{machine_id}>'
+                f'storage>cvg[{cvg}]>data_devices')], 'List Text')
+        return data_devices
+
+    def _get_drive_info_form_os(self, path: str) -> Disk:
+        drive_size = 0
+        with open(path, 'rb') as f:
+            drive_size = f.seek(0, io.SEEK_END)
+        return Disk(path=Maybe(Text(path), 'Text'),
+                    size=Maybe(drive_size, 'Natural'),
+                    blksize=Maybe(os.stat(path).st_blksize, 'Natural'))
+
+    @repeat_if_fails()
+    def _save_drive_info(self, path: str):
+        disk: Disk = self._get_drive_info_form_os(path)
+        hostname = self.get_hostname()
+        drive_info = json.dumps({'path': disk.path.get().s,
+                                 'size': int(disk.size.get()),
+                                 'blksize': int(disk.blksize.get())})
+        disk_key = path.strip('/')
+        self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
+
+    def save_drives_info(self):
+        machine_id = self.provider.get_machine_id()
+        cvgs_key: str = f'server_node>{machine_id}>storage>cvg'
+        for cvg in range(len(self.provider.get(cvgs_key))):
+            data_devs = self.get_data_devices(machine_id, cvg)
+            for dev_path in data_devs.value:
+                self._save_drive_info(dev_path.s)
+
+    @repeat_if_fails()
+    def get_drive_info_from_consul(self, path: Text) -> Disk:
+        hostname = self.get_hostname()
+        disk_path = json.loads(str(path)).lstrip(os.sep)
+        drive_data = self.kv.kv_get(f'{hostname}/{disk_path}')
+        drive_info = json.loads(drive_data['Value'])
+        return (Disk(path=Maybe(path, 'Text'),
+                     size=Maybe(drive_info['size'], 'Natural'),
+                     blksize=Maybe(drive_info['blksize'], 'Natural')))
+
+    def get_drives_info(self) -> DList[Disk]:
+        machine_id = self.provider.get_machine_id()
+        cvgs_key: str = f'server_node>{machine_id}>storage>cvg'
+        for cvg in range(len(self.provider.get(cvgs_key))):
+            data_devs = self.get_data_devices(machine_id, cvg)
+        return DList([self.get_drive_info_from_consul(dev_path)
+                      for dev_path in data_devs.value], 'List Disk')
+
+    def import_kv(self, conf_dir_path: str):
+        with open(f'{conf_dir_path}/consul-kv.json') as f:
+            data = json.load(f)
+            for item in data:
+                item_data = json.loads(json.dumps(item))
+                self.kv.kv_put(item_data['key'],
+                               str(item_data['value']))
+
+
+def execute(cmd: List[str], env=None) -> str:
+    process = subprocess.Popen(cmd,
+                               stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               encoding='utf8',
+                               env=env)
+    out, err = process.communicate()
+    if process.returncode:
+        raise Exception(
+            f'Command {cmd} exited with error code {process.returncode}. '
+            f'Command output: {err}')
+
+    return out

--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -81,7 +81,9 @@ create_session() {
     # Join array items into a comma-separated string.
     local checks=$(IFS=,; echo "[\"serfHealth\", ${checks_a[*]}]")
     local payld="{\"Name\": \"leader\", \"Checks\": $checks, \"LockDelay\": \"2s\"}"
-    local res=$(curl -sX PUT -d "$payld" http://localhost:8500/v1/session/create)
+    # XXX Allowing leader election to happen immediately without any health checkers
+    # temporarily for container environment. Re-visit.
+    local res=$(curl -sX PUT -d "" http://localhost:8500/v1/session/create)
     local sid=$(echo "$res" | jq -r '.ID' 2>/dev/null || true)
 
     [[ $sid ]] || {

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -73,8 +73,12 @@ done
     exit 1
 }
 
-sed -r -e "s/^(NODE=).*/\1$(node-name)/" \
-       -e "s/^(NODE_ID=).*/\1$($HARE_DIR/libexec/gen-uuid $(node-name))/" \
+get_node_name() {
+    /opt/seagate/cortx/hare/libexec/node-name
+}
+
+sed -r -e "s/^(NODE=).*/\1$(get_node_name)/" \
+       -e "s/^(NODE_ID=).*/\1$($HARE_DIR/libexec/gen-uuid $(get_node_name))/" \
        -e "s/^(MODE=).*/\1$mode/" \
        -e "s/^(BIND=).*/\1$bind_addr/" \
        -e "s/^(CLIENT)=.*/\1=127.0.0.1 $bind_addr/" $ENV_TEMPLATE |

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -58,7 +58,7 @@ get_ios_meta_data() {
 }
 
 get_service_addr() {
-    echo ${1%:*}
+    echo ${1%@*}
 }
 
 get_service_ip_addr() {
@@ -66,14 +66,14 @@ get_service_ip_addr() {
 }
 
 get_service_port() {
-    echo ${1##*:}
+    echo ${1##*@}
 }
 
 id2fid() {
     printf '0x7200000000000001:%#x\n' $1
 }
 
-HAX_ID=$(get_service_ids 'grep -iw ha')
+HAX_ID=$(get_service_ids 'grep -iw "services\/ha"')
 [[ $HAX_ID ]] || {
     cat >&2 <<.
 Cannot get information about Hax from Consul for this host ($(node-name)).
@@ -82,9 +82,9 @@ Please verify that the host name matches the one stored in the Consul KV.
     usage >&2
     exit 1
 }
-CONFD_IDs=$(get_service_ids 'grep -iw confd')
-IOS_IDs=$(get_service_ids 'grep -iw ios')
-S3_IDs=$(get_service_ids 'grep -iw m0_client_s3')
+CONFD_IDs=$(get_service_ids 'grep -iw "services\/confd"')
+IOS_IDs=$(get_service_ids 'grep -iw "services\/ios"')
+S3_IDs=$(get_service_ids 'grep -iw "services\/m0_client_s3"')
 HAX_EP=$(get_service_ep $HAX_ID)
 
 if $dry_run; then


### PR DESCRIPTION
Presently part of the information required to generate configuration files is
supplied via CDF to cfgen and some part of the required information (drive size,
drive blksize, processorcount, memory size and ipaddress for the given network
interface) is fetched explicitly by remotely accessing and executing commands on
the cluster nodes. But, it is possible that all the nodes may not be active or
ssh may not be configured on the nodes in some environments, e.g. Containers.

Solution:
- Accept the remotely fetched information via CDF optionally.
- Try to fetch the information remotely if not present in CDF.