### PR TITLE
EOS-24053: conf generation is impossible outside of hare-bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,9 @@ install: install-dirs install-cfgen install-hax install-miniprov install-systemd
 	     $(call _log,copying $$f -> $(MINIPROV_TMPL_DIR)); \
 	     install $$f $(MINIPROV_TMPL_DIR); \
 	 done
+	@$(call _info,Altering generated executables to make Python imports work)
+	@$(call _fix_hare_imports,hare_setup)
+	@$(call _fix_hare_imports,configure)
 
 .PHONY: install-dirs
 install-dirs:
@@ -634,4 +637,17 @@ define _log
     echo "$${YELLOW}    $(1)$${NC}"
 endef
 
+define _fix_hare_imports_ex
+    sed -i "7i sys.path.insert(1, '$(1)/lib64/python3.6/site-packages') # Added by Makefile" $(2) ;\
+    sed -i "8i sys.path.insert(2, '$(1)/lib/python3.6/site-packages') # Added by Makefile" $(2)
+endef
+
+# This function does't use DESTDIR intentionally.
+# DESTDIR will point to a temporary RPM BUILDROOT folder when make install is
+# invoked while building the RPM.
+#
+define _fix_hare_imports
+    $(call _log,Fixing /$(PREFIX)/bin/$(1)) ;\
+    $(call _fix_hare_imports_ex,/$(PREFIX),/$(DESTDIR)/$(PREFIX)/bin/$(1))
+endef
 # vim: textwidth=80 nowrap foldmethod=marker

--- a/Makefile
+++ b/Makefile
@@ -422,6 +422,7 @@ devinstall-hax: hax/requirements.txt $(HAX_EGG_LINK)
 	@$(call _info,Creating symlinks for hax executables)
 	@ln -v -sf $(PY_VENV_DIR)/bin/hax $(DESTDIR)/$(PREFIX)/bin
 	@ln -v -sf $(PY_VENV_DIR)/bin/q $(DESTDIR)/$(PREFIX)/bin
+	@ln -v -sf $(PY_VENV_DIR)/bin/configure $(DESTDIR)/$(PREFIX)/bin
 
 .PHONY: devinstall-miniprov
 devinstall-miniprov: MP_INSTALL_CMD = $(SETUP_PY) develop
@@ -503,6 +504,7 @@ test-hax: $(PY_VENV_DIR)
 
 .PHONY: lint-hax
 lint-hax: $(PY_VENV_DIR)
+	@$(call _info,Running static analysis of hax sources)
 	@cd hax &&\
 	  $(PY_VENV) &&\
 	  MYPYPATH=../stubs $(PYTHON) setup.py flake8 mypy

--- a/hare.spec
+++ b/hare.spec
@@ -68,8 +68,6 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
 sed -i -e 's@^#!.*\.py3venv@#!/usr@' %{buildroot}/opt/seagate/cortx/hare/bin/*
-sed -i "7i sys.path.insert(1, '/opt/seagate/cortx/hare/lib64/python3.6/site-packages')" %{buildroot}/opt/seagate/cortx/hare/bin/hare_setup
-sed -i "8i sys.path.insert(2, '/opt/seagate/cortx/hare/lib/python3.6/site-packages')" %{buildroot}/opt/seagate/cortx/hare/bin/hare_setup
 
 %clean
 rm -rf %{buildroot}

--- a/hax/helper/__init__.py
+++ b/hax/helper/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# empty

--- a/hax/helper/configure.py
+++ b/hax/helper/configure.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import click
+
+from helper.exec import CliException, Executor, Program, two_columns
+
+
+@dataclass
+class AppCtx:
+    """
+    A storage for application context.
+    Conains the parameters to run the current application.
+    """
+    cdf_path: str
+    conf_dir: str
+
+
+def _setup_logging():
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s [%(levelname)s] %(message)s')
+
+
+@click.command()
+@click.argument('cdf', type=click.Path(exists=True), required=True)
+@click.option('--conf-dir',
+              '-c',
+              type=str,
+              default='/var/lib/hare/',
+              help='Target folder where Hare-related configuration will '
+              'be written to.',
+              show_default=True)
+@click.pass_context
+def parse_opts(ctx, cdf: str, conf_dir: str):
+    """Generate Hare configuration according to the given CDF file.
+
+    CDF   Full path to the Cluster Description File (CDF)."""
+    ctx.ensure_object(dict)
+    ctx.obj['result'] = AppCtx(cdf_path=cdf, conf_dir=conf_dir)
+    return ctx.obj
+
+
+class ConfGenerator:
+    def __init__(self, cdf_path: str, conf_dir: str):
+        self.cdf_path = cdf_path
+        self.conf_dir = conf_dir
+        self.executor = Executor()
+
+    def generate(self) -> None:
+        p = Program
+        executor = self.executor
+        conf_dir = self.conf_dir
+
+        env = self._get_pythonic_env()
+        executor.run(p(['cfgen', '-o', self.conf_dir, self.cdf_path]), env=env)
+        xcode = executor.run(p(['cat', f'{conf_dir}/confd.dhall'])
+                             | p(['dhall', 'text'])
+                             | p(['m0confgen']),
+                             env=env)
+        self._write_file(f'{conf_dir}/confd.xc', xcode)
+
+        node_name = self._create_node_name(f'{conf_dir}/consul-agents.json')
+        self._update_consul_conf(node_name)
+
+    def _get_pythonic_env(self) -> Dict[str, str]:
+        path = os.environ['PATH']
+
+        # Make sure that cfgen will be able to import the same modules
+        # that the current script can
+        py_path = ':'.join(sys.path)
+        if 'PYTHONPATH' in os.environ:
+            env_var = os.environ['PYTHONPATH']
+            py_path = f'{env_var}:{py_path}'
+        env = {
+            'PATH':
+            ':'.join([
+                '/opt/seagate/cortx/hare/bin',
+                '/opt/seagate/cortx/hare/libexec', path
+            ]),
+            'PYTHONPATH':
+            py_path
+        }
+        return env
+
+    def _write_file(self, path: str, contents: str):
+        with open(path, 'w') as f:
+            f.write(contents)
+
+    def _read_file(self, path: str) -> str:
+        with open(path, 'r') as f:
+            return f.read()
+
+    def _update_consul_conf(self, node_name) -> None:
+        cns_file = f'{self.conf_dir}/consul-agents.json'
+
+        def get_join_ip() -> str:
+            for node, ip in self._get_server_nodes(cns_file):
+                if node == node_name:
+                    return ip
+            raise RuntimeError(f'Logic error: node_name={node_name}'
+                               f' not found in {cns_file}')
+
+        join_ip = get_join_ip()
+        join_peers_opt: List[str] = []
+        for node, ip in self._get_server_nodes(cns_file):
+            if node == node_name:
+                continue
+            join_peers_opt += ['--join', ip]
+
+        self.executor.run(Program([
+            'mk-consul-env', '--mode', 'server', '--bind', join_ip,
+            *join_peers_opt, '--extra-options', '-ui -bootstrap-expect 1'
+        ]),
+                          env=self._get_pythonic_env())
+
+    def _create_node_name(self, consul_agents_file: str) -> str:
+        path = f'{self.conf_dir}/node-name'
+        for node, _ in self._get_nodes(consul_agents_file):
+            if self._is_localhost(node):
+                logging.debug('Writing %s to file %s', node, path)
+                self._write_file(path, node)
+                return node
+        raise RuntimeError('Failed to find the current node inthe node list')
+
+    def _is_localhost(self, hostname: str) -> bool:
+        runner = self.executor
+        p = Program
+        if hostname in ('localhost', '127.0.0.1'):
+            return True
+        if hostname == runner.run(p(['hostname'])):
+            return True
+        if hostname == runner.run(p(['hostname', '--fqdn'])):
+            return True
+
+        all_ips = runner.run(p(['hostname', '-I']))
+        if all_ips.find(hostname) > -1:
+            return True
+
+        minion_file = '/etc/salt/minion_id'
+        if not os.path.exists(minion_file):
+            return False
+
+        return hostname == self._read_file(minion_file).strip()
+
+    def _get_server_nodes(self,
+                          consul_agents_file: str) -> List[Tuple[str, str]]:
+        return self._get_nodes_ex(consul_agents_file,
+                                  '.servers[] | "\\(.node_name) \\(.ipaddr)"')
+
+    def _get_nodes(self, consul_agents_file: str) -> List[Tuple[str, str]]:
+        return self._get_nodes_ex(
+            consul_agents_file,
+            '(.servers + .clients)[] | "\\(.node_name) \\(.ipaddr)"')
+
+    def _get_nodes_ex(self, consul_agents_file: str,
+                      jq_selector: str) -> List[Tuple[str, str]]:
+        executor = self.executor
+
+        return executor.run_ex(
+            Program(['jq', '-r', jq_selector, consul_agents_file]),
+            two_columns)
+
+
+def main():
+    _setup_logging()
+    try:
+        raw_ctx = parse_opts(args=sys.argv[1:], standalone_mode=False, obj={})
+        if not isinstance(raw_ctx, dict):
+            # --help was invoked
+            sys.exit(1)
+        app_context = raw_ctx['result']
+        ConfGenerator(app_context.cdf_path, app_context.conf_dir).generate()
+    except CliException as e:
+        logging.error('Exiting due to a failure: %s', e)
+        logging.debug('Failed command: %s', e.cmd)
+        logging.debug('Environment: %s', e.env)
+        sys.exit(e.code)
+    except Exception as e:
+        logging.error('Exiting due to a failure: %s', e)
+        logging.debug('Details on the error:', exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/hax/helper/exec.py
+++ b/hax/helper/exec.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+import logging
+import re
+from subprocess import PIPE, Popen
+from typing import Callable, Dict, List, Optional, Tuple, TypeVar
+
+
+class Program:
+    """
+    Holds the command (or chain of commands if pipe `|` is used)
+    to be executed by Executor class.
+    """
+    def __init__(self, cmd: List[str], stdin: Optional['Program'] = None):
+        self.cmd = cmd
+        self.stdin = stdin
+
+    def __or__(self, other):
+        if not isinstance(other, Program):
+            return NotImplemented
+        other.stdin = self
+        return other
+
+    def __repr__(self):
+        return f'Program({self.cmd}, stdin={self.stdin})'
+
+
+class CliException(RuntimeError):
+    """
+    Main exception class used by the Executor class.
+    """
+    def __init__(self, stderr: str, code: int, env: Optional[Dict[str, str]],
+                 cmd: List[str]):
+        """
+        stderr - Error output of the CLI command.
+        code   - Exit code returned by the command.
+        env    - Environment variables used when running the given command.
+        cmd    - Failed command.
+        """
+
+        super().__init__(stderr)
+        self.stderr = stderr
+        self.code = code
+        self.env = env
+        self.cmd = cmd
+
+
+R = TypeVar('R')
+T = TypeVar('T')
+
+OutputConverter = Callable[[str], R]
+
+
+def as_is(in_value: str) -> str:
+    if in_value.endswith('\n'):
+        # Cut the final newline
+        count = len(in_value)
+        return in_value[:count - 1]
+
+    return in_value
+
+
+def two_columns(in_value: str) -> List[Tuple[str, str]]:
+    result: List[Tuple[str, str]] = []
+    for line in in_value.splitlines():
+        match = re.match(r'^[\s]*([^\s]*)[\s]+([^\s]*)$', line)
+        if not match:
+            result.append(('', ''))
+        else:
+            result.append((match.group(1), match.group(2)))
+    return result
+
+
+class Executor:
+    """
+    CLI Executor. Abstracts from subprocess.Popen and supports single
+    commands as well as piped chain of commands.
+    """
+    def run(self, p: Program, env: Optional[Dict[str, str]] = None) -> str:
+        return self.run_ex(p, as_is, env=env)
+
+    def run_ex(self,
+               p: Program,
+               converter: OutputConverter[T],
+               env: Optional[Dict[str, str]] = None) -> T:
+        """
+        Central method of the executor. Returns either stdout of the executed
+        command or raises CliException if the command didn't succeed.
+        """
+
+        proc_list: List[Program] = []
+
+        def get_previous(p: Program):
+            proc_list.insert(0, p)
+            return p.stdin
+
+        p = get_previous(p)
+        while p:
+            p = get_previous(p)
+
+        prev = None
+
+        for p in proc_list:
+            stdin = PIPE
+            if prev:
+                stdin = prev.stdout
+
+            try:
+                logging.debug('Issuing command: %s', p.cmd)
+                proc = Popen(p.cmd,
+                             stdin=stdin,
+                             stdout=PIPE,
+                             stderr=PIPE,
+                             encoding='utf-8',
+                             env=env)
+            except FileNotFoundError as e:
+                raise CliException(f'Failed to run {p}: {e}',
+                                   code=-1,
+                                   env=env,
+                                   cmd=p.cmd)
+            if prev:
+                prev.stdout.close()
+
+            prev = proc
+
+        out, err = proc.communicate()
+        code = proc.returncode
+        if code:
+            raise CliException(err, code, env, cmd=p.cmd)
+        return converter(out)

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -163,7 +163,10 @@ setup(
     setup_requires=reqs['build'],
     install_requires=reqs['runtime'],
     entry_points={
-        'console_scripts': ['hax=hax.hax:main', 'q=hax.queue.cli:main']
+        'console_scripts': [
+            'hax=hax.hax:main', 'q=hax.queue.cli:main',
+            'configure=helper.configure:main'
+        ]
     },
     ext_modules=[
         Extension(


### PR DESCRIPTION
Solution: Implement `configure` script that repeats the way how
hare-bootstrap script generates the configuration files.

Signed-off-by: Konstantin Nekrasov <konstantin.nekrasov@seagate.com>