### PR TITLE
EOS-24507: bootstrap failed with RuntimeError Unsupported facter version found 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ and health-checking mechanisms.
   ```sh
   sudo yum localinstall -y https://yum.puppetlabs.com/puppet/el/7/x86_64/puppet-agent-7.0.0-1.el7.x86_64.rpm
   ```
+   * **Note:**   
+     Check facter version details, if already installed / exist in system
+     ```sh
+     facter -v
+     ls -ll /usr/bin/facter
+     ```
+     Supported version is **facter >= 3.14.8**, If the facter version is **< 3.14.8** then follow the steps below: 
+     ```sh
+     rm -rf /usr/bin/facter
+     yum list installed | grep "puppet-agent"
+     yum remove puppet-agent.x86_64
+     ```
+     Now install puppet-agent (above command in README), then create softlink to facter binary
+     ```sh
+     ln -s /opt/puppetlabs/bin/facter /usr/bin/facter
+     ```
 
 * Install Consul.
   ```sh

--- a/README.md
+++ b/README.md
@@ -53,25 +53,22 @@ and health-checking mechanisms.
   ```
 
 * Install puppet-agent (&ge; 6.13.0)
+  
+  Check facter version details, if already installed / exist in system
+  ```sh
+  facter -v
+  ls -ll /usr/bin/facter
+  ```
+  Supported version is **facter >= 3.14.8**, If the facter version is **< 3.14.8** then follow the steps below: 
+  ```sh
+  yum erase -y $(rpm -q --whatprovides /usr/bin/facter) || rm -fv /usr/bin/facter
+  yum list installed | grep "puppet-agent"
+  yum remove puppet-agent.x86_64
+  ```
+  Now install puppet-agent
   ```sh
   sudo yum localinstall -y https://yum.puppetlabs.com/puppet/el/7/x86_64/puppet-agent-7.0.0-1.el7.x86_64.rpm
   ```
-   * **Note:**   
-     Check facter version details, if already installed / exist in system
-     ```sh
-     facter -v
-     ls -ll /usr/bin/facter
-     ```
-     Supported version is **facter >= 3.14.8**, If the facter version is **< 3.14.8** then follow the steps below: 
-     ```sh
-     rm -rf /usr/bin/facter
-     yum list installed | grep "puppet-agent"
-     yum remove puppet-agent.x86_64
-     ```
-     Now install puppet-agent (above command in README), then create softlink to facter binary
-     ```sh
-     ln -s /opt/puppetlabs/bin/facter /usr/bin/facter
-     ```
 
 * Install Consul.
   ```sh


### PR DESCRIPTION
Problem: 
hctl bootstrap failed with Unsupported facter version found. 
Issue caused because facter is already installed by another application/Package with unsupported version.
Will Closes #1779 once PR Merge.

Solution:
Before installing puppet-agent, added steps to check and remove the unsupported facter binary, if already installed.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>