### PR TITLE
EOS-24507: bootstrap failed with RuntimeError Unsupported facter version found 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,22 @@ and health-checking mechanisms.
   ```
 
 * Install puppet-agent (&ge; 6.13.0)
+  
+  Check facter version details, if already installed / exist in system
+  ```sh
+  facter -v
+  ```
+  Supported version is **facter >= 3.14.8**, If the facter version is **< 3.14.8** then follow the steps below: 
+  ```sh
+  yum erase -y $(rpm -q --whatprovides $(readlink -f /usr/bin/facter)) || rm -fv /usr/bin/facter
+  ```
+  Now install puppet-agent
   ```sh
   sudo yum localinstall -y https://yum.puppetlabs.com/puppet/el/7/x86_64/puppet-agent-7.0.0-1.el7.x86_64.rpm
+  ```
+  Create symlink to facter binary, if not
+  ```sh
+  [ ! -f /usr/bin/facter ] && sudo ln -s /opt/puppetlabs/bin/facter /usr/bin/facter
   ```
 
 * Install Consul.


### PR DESCRIPTION
## Problem
hctl bootstrap failed with Unsupported facter version found. 
Issue caused because facter is already installed by another application/Package with unsupported version.

## Solution
Before installing puppet-agent, added steps to check and remove the unsupported facter binary, if already installed.

Closes #1779