### PR TITLE
EOS-24730: If Consul is down, hax will not exit

### DIFF
--- a/hax/hax/common/__init__.py
+++ b/hax/hax/common/__init__.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+import inject
+
+
+class HaxGlobalState:
+    """
+    Global state of whole HaX application.
+    """
+    def __init__(self):
+        self.stopping: bool = False
+
+    def is_stopping(self) -> bool:
+        """Whether the application is stopping now"""
+        return self.stopping
+
+    def set_stopping(self):
+        """Switches the current state to 'stopping' state"""
+        self.stopping = True
+
+
+def di_configuration(binder: inject.Binder):
+    """
+    Configures Dependency Injection (DI) engine.
+    """
+    binder.bind(HaxGlobalState, HaxGlobalState())

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -31,6 +31,7 @@ from hax.message import (BaseMessage, BroadcastHAStates, SnsDiskAttach,
                          SnsRebalanceStart, SnsRebalanceStatus,
                          SnsRebalanceStop, SnsRepairPause, SnsRepairResume,
                          SnsRepairStart, SnsRepairStatus, SnsRepairStop)
+from hax.common import HaxGlobalState
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.planner import WorkPlanner
 from hax.queue import BQProcessor
@@ -197,10 +198,12 @@ class ServerRunner:
         planner: WorkPlanner,
         herald: DeliveryHerald,
         consul_util: ConsulUtil,
+        hax_state: HaxGlobalState
     ):
         self.consul_util = consul_util
         self.herald = herald
         self.planner = planner
+        self.hax_state = hax_state
 
     def _create_server(self) -> web.Application:
         return web.Application(middlewares=[encode_exception])
@@ -259,6 +262,7 @@ class ServerRunner:
             self._start(web_address, port)
             LOG.debug('Server stopped normally')
         finally:
+            self.hax_state.set_stopping()
             LOG.debug('Stopping the threads')
             self.planner.shutdown()
             for thread in threads_to_wait:

--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -25,3 +25,4 @@ python-consul==1.1.0
 simplejson==3.17.2
 pytest-cov
 coverage
+inject==4.3.1

--- a/hax/test/integration/test_consul_util.py
+++ b/hax/test/integration/test_consul_util.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Any
+
+import inject
+import pytest
+from hax.common import HaxGlobalState
+from hax.exception import HAConsistencyException
+
+
+@pytest.fixture
+def hax_state() -> HaxGlobalState:
+    return HaxGlobalState()
+
+
+@pytest.fixture(autouse=True)
+def inject_support(hax_state: HaxGlobalState):
+    def configure(binder: inject.Binder):
+        binder.bind(HaxGlobalState, hax_state)
+
+    inject.clear_and_configure(configure)
+    yield ''
+    inject.clear()
+
+
+def new_kv(key: str, val: Any):
+    return {
+        'Key': key,
+        'CreateIndex': 1793,
+        'ModifyIndex': 1793,
+        'LockIndex': 0,
+        'Flags': 0,
+        'Value': val,
+        'Session': ''
+    }
+
+
+def test_get_leader_node_raises_ha_consistency_when_no_key(
+        mocker, consul_util):
+    state: HaxGlobalState = inject.instance(HaxGlobalState)
+    state.set_stopping()
+    mocker.patch.object(consul_util.kv, 'kv_get', side_effect=[None])
+    with pytest.raises(HAConsistencyException):
+        consul_util.get_leader_node()
+
+
+def test_get_leader_node_raises_ha_consistency_when_no_value(
+        mocker, consul_util):
+    state: HaxGlobalState = inject.instance(HaxGlobalState)
+    state.set_stopping()
+    mocker.patch.object(consul_util.kv,
+                        'kv_get',
+                        side_effect=[new_kv('leader', None)])
+    with pytest.raises(HAConsistencyException):
+        consul_util.get_leader_node()

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -17,11 +17,13 @@
 #
 
 import ctypes
+import inject
 import json
 import logging
 from typing import Any, Callable
 
 import pytest
+from hax.common import HaxGlobalState
 from hax.handler import ConsumerThread
 from hax.message import BaseMessage, Die, FirstEntrypointRequest
 from hax.motr import Motr, WorkPlanner
@@ -47,6 +49,21 @@ def planner(mocker) -> WorkPlanner:
     planner = WorkPlanner()
     mocker.patch.object(planner, 'add_command', side_effect=RuntimeError())
     return planner
+
+
+@pytest.fixture
+def hax_state() -> HaxGlobalState:
+    return HaxGlobalState()
+
+
+@pytest.fixture(autouse=True)
+def logging_support(hax_state: HaxGlobalState):
+    def configure(binder: inject.Binder):
+        binder.bind(HaxGlobalState, hax_state)
+
+    inject.clear_and_configure(configure)
+    yield ''
+    inject.clear()
 
 
 def ha_note_failed() -> TraceMatcher:

--- a/hax/test/test_offset_storage.py
+++ b/hax/test/test_offset_storage.py
@@ -17,10 +17,12 @@
 #
 
 # flake8: noqa
+import inject
 import logging
 import unittest
 from time import sleep
 
+from hax.common import di_configuration
 from hax.queue.offset import OffsetStorage
 from hax.util import KVAdapter
 from unittest.mock import Mock, MagicMock
@@ -29,6 +31,7 @@ from unittest.mock import Mock, MagicMock
 class TestOffsetStorage(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        inject.configure(di_configuration)
         logging.basicConfig(
             level=logging.DEBUG,
             format='%(asctime)s {%(threadName)s} [%(levelname)s] %(message)s')

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -21,6 +21,7 @@
 
 import argparse
 import asyncio
+import inject
 import json
 import logging
 import os
@@ -35,6 +36,7 @@ from urllib.parse import urlparse
 
 import yaml
 from cortx.utils.product_features import unsupported_features
+from hax.common import di_configuration
 from hax.types import KeyDelete
 from hax.util import ConsulUtil, repeat_if_fails, KVAdapter
 
@@ -611,6 +613,7 @@ def add_factory_argument(parser):
 
 
 def main():
+    inject.configure(di_configuration)
     p = argparse.ArgumentParser(description='Configure hare settings')
     subparser = p.add_subparsers()
 

--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -19,11 +19,13 @@
 
 # :help: stop the cluster or local node
 
+import inject
 import logging
 import argparse
 from typing import Dict, List, Tuple
 
 from consul import Consul
+from hax.common import di_configuration
 from hax.util import ConsulUtil, repeat_if_fails
 
 import utils
@@ -108,7 +110,7 @@ def node_shutdown():
 
 
 def main() -> None:
-
+    inject.configure(di_configuration)
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose",
                         help="Increase output verbosity",

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -21,6 +21,7 @@
 
 import json
 import argparse
+import inject
 import io
 import logging
 import simplejson
@@ -29,6 +30,7 @@ from subprocess import PIPE, Popen
 from typing import Any, Dict, List, NamedTuple, Optional
 
 from consul import Consul, ConsulException
+from hax.common import di_configuration
 from hax.exception import HAConsistencyException
 from hax.util import repeat_if_fails
 from requests.exceptions import RequestException
@@ -302,6 +304,7 @@ def show_text_status(cns: Consul, devices_requested: bool) -> None:
 
 
 def main(argv=None):
+    inject.configure(di_configuration)
     setup_logging()
     opts = parse_opts(argv)
     cns = Consul()


### PR DESCRIPTION
JIRA ticket: [EOS-24730](https://jts.seagate.com/browse/EOS-24730)

The existing retries mechanism (`@repeat_if_fails` decorator) will force
Consul-related operations to be retried forever even in case Consul
agent is not accessible and/or raft leader is not available. That will
become a problem when hax is no more controlled by systemd because hax
stop may be delayed forever in case of Consul connectivity problems.

Solution:
1. Introduce dependency injection (DI) mechanism
2. Add a global hax state object (used to store 'stopping' flag)
3. Make @repeat_if_fails decorator be aware of the global state object
(by means of DI) so that no retries happen if the application is going
to shutdown.