### PR TITLE
Change in Alex workflow

### DIFF
--- a/.github/workflows/alex_reviewdog.yml
+++ b/.github/workflows/alex_reviewdog.yml
@@ -16,12 +16,13 @@
 #
 
 # Configuration for alex - https://github.com/get-alex/alex
+
 name: CORTX inclusive words scan
 on:
   # Trigger the workflow on pull request labeled as cla-signed
   # and synchronize for the main branch
   pull_request:
-    types: [ labeled, synchronize ]
+    types: [ opened, synchronize ]
     branches:
       - main
   # Trigger the workflow on demand
@@ -30,7 +31,7 @@ jobs:
   # Let's start the alex to scan
   alex:
     name: Alex report
-    if: ${{ github.event.label.name == 'cla-signed' || github.event.action == 'synchronize' }}
+    #if: ${{ github.event.label.name == 'alex' || github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,4 +40,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: added
           reporter: github-pr-review
-          fail_on_error: false
+          fail_on_error: true
+          level: warning
+          


### PR DESCRIPTION
Problem : Alex is not getting triggered on raising a new PR
 
Solution: Changes are done so that Alex event will get triggered whenever the PR is opened (pull_request). 

Kindly refer Alex documentation https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/584778705/Alex+Workflow.

Signed-off-by: Venkatesh K <venkatesh.k@seagate.com>
