### PR TITLE
Problem: hare mini-provisioner doesn not generate motr confd.xc

### DIFF
--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -114,17 +114,18 @@ class Utils:
                                str(item_data['value']))
 
 
-def execute(cmd: List[str], env=None) -> str:
+def execute(cmd: List[str], encoding=None, env=None, stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, inp=None) -> str:
     process = subprocess.Popen(cmd,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
+                               stdin=stdin,
+                               stdout=stdout,
                                stderr=subprocess.PIPE,
-                               encoding='utf8',
+                               encoding=encoding,
                                env=env)
-    out, err = process.communicate()
+    result, err = process.communicate(input=inp)
     if process.returncode:
         raise Exception(
             f'Command {cmd} exited with error code {process.returncode}. '
             f'Command output: {err}')
 
-    return out
+    return result


### PR DESCRIPTION
Hare mini provisioners config stage generates all the required configuration
files for Motr and Hare but does not convert confd.dhall to confd.xc (Motr
configuration file in Motr xcode grammar.

Solution:
- Convert generated confd.dhall in text using `dhall text` command.
- Pass the output of `dhall text` to m0confgen to generate confd.xc.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>