### PR TITLE
Problem: cfgen does not populate correct libfabric endpoints in confd.xc

### DIFF
--- a/cfgen/dhall/render/LibfabricNetId.dhall
+++ b/cfgen/dhall/render/LibfabricNetId.dhall
@@ -19,7 +19,16 @@
 -}
 
 let types = ../types.dhall
+
+let renderAddr = \(label : Text) -> \(addr : types.Addr)
+ ->
+    "${label}:${addr.ipaddr}"
+
 in
-\(x : types.LibfabricEndpoint) ->
-    let nat = Natural/show
-    in "${./NetFamily.dhall x.netfamily}:${./LibfabricNetId.dhall x.nid}@${nat x.portal}"
+\(nid : types.NetId) ->
+    merge
+    { lo = "0@lo"
+    , tcp = \(x : { tcp : types.Addr }) -> renderAddr "tcp" x.tcp
+    , o2ib = \(x : { o2ib : types.Addr }) -> renderAddr "o2ib" x.o2ib
+    }
+    nid


### PR DESCRIPTION
Hare cfgen uses dhall configuration files to generate motr configuration,
confd.xc. Motr endpoint format changed from lnet to libfabric, which is
different than that used presently by dhall for Motr endpoint rendering.

Solution:
Use a Libfabric specific rendering dhall configuration file and update
the endpoint rendering accordingly.