### PR TITLE
Problem: hare configure does not populate services information

### DIFF
--- a/hax/helper/configure.py
+++ b/hax/helper/configure.py
@@ -130,7 +130,14 @@ class ConfGenerator:
 
         self.executor.run(Program([
             'mk-consul-env', '--mode', 'server', '--bind', join_ip,
-            *join_peers_opt, '--extra-options', '-ui -bootstrap-expect 1'
+            *join_peers_opt, '--extra-options', '-ui -bootstrap-expect 1',
+            '--conf-dir', f'{self.conf_dir}'
+        ]),
+                          env=self._get_pythonic_env())
+
+        self.executor.run(Program([
+            'update-consul-conf', '--conf-dir', f'{self.conf_dir}',
+            '--kv-file', f'{self.conf_dir}/consul-kv.json'
         ]),
                           env=self._get_pythonic_env())
 

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -527,12 +527,6 @@ def generate_config(url: str, path_to_cdf: str) -> None:
     execute(cmd, env={'PYTHONPATH': python_path, 'PATH': path,
                       'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
     utils.import_kv(conf_dir)
-    cmd = ['update-consul-conf']
-    execute(cmd, env={'PYTHONPATH': python_path, 'PATH': path,
-                      'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
-    conf = ConfStoreProvider(url)
-    hostname = conf.get_hostname()
-    save(f'{conf_dir}/node-name', hostname)
 
 
 def update_hax_unit(filename: str) -> None:

--- a/utils/mk-consul-env
+++ b/utils/mk-consul-env
@@ -40,6 +40,7 @@ Options:
   -b, --bind IP             IP address to bind to.
   -j, --join IP             IP address to join.
   -e, --extra-options STR   Additional options.
+  -c, --conf-dir STR        Configuration directory path.
   -h, --help                Show this help and exit.
 EOF
 }
@@ -48,9 +49,10 @@ mode=
 bind_addr=
 join_addr=
 extra_opts=
+conf_dir=
 
-TEMP=$(getopt --options hm:b:j:e: \
-              --longoptions help,mode:,bind:,join:,extra-options: \
+TEMP=$(getopt --options hm:b:j:e:c: \
+              --longoptions help,mode:,bind:,join:,extra-options:,conf-dir: \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -59,6 +61,7 @@ eval set -- "$TEMP"
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
+        -c|--conf-dir)       conf_dir=$2; shift 2 ;;
         -m|--mode)           mode=$2; shift 2 ;;
         -b|--bind)           bind_addr=$2; shift 2 ;;
         -j|--join)           join_addr="$join_addr $2"; shift 2 ;;
@@ -103,7 +106,7 @@ fi
 # Prepare for consul-agent startup:
 sudo rm -rf /var/lib/hare/consul-data-$bind_addr
 
-conf_dir=consul-$mode-conf
-sudo mkdir -p /var/lib/hare/$conf_dir
-sudo cp $HARE_DIR/share/consul/$conf_dir.json.in \
-     /var/lib/hare/$conf_dir/$conf_dir.json
+consul_conf_dir=consul-$mode-conf
+sudo mkdir -p $conf_dir/$consul_conf_dir
+sudo cp $HARE_DIR/share/consul/$consul_conf_dir.json.in \
+     $conf_dir/$consul_conf_dir/$consul_conf_dir.json

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -21,9 +21,23 @@ set -eu -o pipefail
 # set -x
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
+PROG=${0##*/}
+
+die() {
+    echo "$PROG: $*" >&2
+    exit 1
+}
+
 usage() {
     cat <<EOF
-Usage: . ${BASH_SOURCE[0]##*/} [-n | --dry-run]
+Usage: . $PROG [-n | --dry-run]
+         $PROG [<option>]... --conf-dir <dir>
+         $PROG [<option>]... --kv-file <dir>
+
+Positional arguments:
+  --conf-dir <dir>  Configuration directory path to read configuration
+                    from or write to.
+  --kv-file <kv>    Hare-Motr configuration key values file path.
 
 Create Consul agent configuration file.
 
@@ -32,29 +46,81 @@ Create Consul agent configuration file.
 EOF
 }
 
-case "$*" in
-    '') dry_run=false;;
-    '-n'|'--dry-run') dry_run=true;;
-    *) usage >&2; exit 1;;
-esac
+TEMP=$(getopt --options hn: \
+              --longoptions help,dry-run,conf-dir:,kv-file: \
+              --name "$PROG" -- "$@" || true)
+
+(($? == 0)) || { usage >&2; exit 1; }
+
+eval set -- "$TEMP"
+
+conf_dir=
+kv_file=
+dry_run=false
+
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        -c|--conf-dir)       conf_dir=$2; shift 2 ;;
+        -k|--kv-file)        kv_file=$2; shift 2 ;;
+        --dry-run)           dry_run=true; shift ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
+
+if [[ -z $conf_dir ]]; then
+    conf_dir=/etc
+fi
+
+[[ -d $conf_dir ]] || die "'--conf-dir' argument is not a directory"
+
+
+sysconfig_dir='sysconfig'
+
+get_node_name() {
+    /opt/seagate/cortx/hare/libexec/node-name
+}
 
 get_service_ids() {
     local filter=$1
-    local cmd="consul kv get -recurse m0conf/nodes/$(node-name)/processes/ |
+    local cmd="consul kv get -recurse m0conf/nodes/$(get_node_name)/processes/ |
                   $filter | sed 's/.*processes.//' | cut -d/ -f1"
     eval $cmd || true
 }
 
 get_service_ep() {
     local process_fidk=$1
-    consul kv get m0conf/nodes/$(node-name)/processes/$process_fidk/endpoint
+    consul kv get m0conf/nodes/$(get_node_name)/processes/$process_fidk/endpoint
 }
 
 get_ios_meta_data() {
     local process_fidk=$1
     consul kv export \
-           m0conf/nodes/$(node-name)/processes/$process_fidk/meta_data |
+           m0conf/nodes/$(get_node_name)/processes/$process_fidk/meta_data |
         jq -r '.[].value | @base64d'
+}
+
+get_service_ids_from_kv_file() {
+    local filter=$1
+    local key="m0conf/nodes/$(get_node_name)/processes/*"
+    local cmd="jq -r '.[] | select(.key|test(\"$key\"))' $kv_file |
+                  $filter | sed 's/.*processes.//' | cut -d/ -f1"
+    eval $cmd || true
+}
+
+get_service_ep_from_kv_file() {
+    local process_fidk=$1
+    local key="m0conf/nodes/$(get_node_name)/processes/$process_fidk/endpoint"
+    local cmd="jq -r '.[] | select(.key==\"$key\") |
+                  .value' $kv_file | head -n 1"
+    eval $cmd || true
+}
+
+get_profile_from_kv_file() {
+    local cmd="jq -r '.[].key | select(test(\"m0conf/profiles/*\"))' $kv_file |
+                   head -1 | cut -d/ -f3"
+    eval $cmd || true
 }
 
 get_service_addr() {
@@ -69,43 +135,66 @@ get_service_port() {
     echo ${1##*@}
 }
 
+install_motr_conf() {
+    local motr_conf_file=$1
+    sudo install $motr_conf_file $conf_dir/$sysconfig_dir/motr/$(get_node_name)/
+}
+
+install_s3_conf() {
+    local s3_conf_file=$1
+    sudo install $s3_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
+}
+
+create_motr_conf_dir() {
+    mkdir -p $conf_dir/$sysconfig_dir/motr/$(get_node_name)
+}
+
+create_s3_conf_dir() {
+    mkdir -p $conf_dir/$sysconfig_dir/s3/$(get_node_name)
+}
+
+create_motr_conf_dir
+create_s3_conf_dir
+
+[ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
+
 id2fid() {
     printf '0x7200000000000001:%#x\n' $1
 }
 
-HAX_ID=$(get_service_ids 'grep -iw "services\/ha"')
+HAX_ID=$(get_service_ids_from_kv_file 'grep -iw "services\/ha"')
 [[ $HAX_ID ]] || {
     cat >&2 <<.
-Cannot get information about Hax from Consul for this host ($(node-name)).
+Cannot get information about Hax from Consul for this host ($(get_node_name)).
 Please verify that the host name matches the one stored in the Consul KV.
 .
     usage >&2
     exit 1
 }
-CONFD_IDs=$(get_service_ids 'grep -iw "services\/confd"')
-IOS_IDs=$(get_service_ids 'grep -iw "services\/ios"')
-S3_IDs=$(get_service_ids 'grep -iw "services\/m0_client_s3"')
-HAX_EP=$(get_service_ep $HAX_ID)
+CONFD_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/confd"')
+IOS_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/ios"')
+S3_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/m0_client_s3"')
+HAX_EP=$(get_service_ep_from_kv_file $HAX_ID)
 
 if $dry_run; then
     return 0  # we must not `exit`, because the script is sourced
 fi
 # --------------------------------------------------------------------
 
+mkdir -p $conf_dir/consul-server-conf/
+mkdir -p $conf_dir/consul-client-conf/
+
 if [[ $CONFD_IDs ]]; then
-    CONF_FILE=/var/lib/hare/consul-server-conf/consul-server-conf.json
+    CONF_FILE=$conf_dir/consul-server-conf/consul-server-conf.json
 else
-    CONF_FILE=/var/lib/hare/consul-client-conf/consul-client-conf.json
+    CONF_FILE=$conf_dir/consul-client-conf/consul-client-conf.json
 fi
 
 SVCS_CONF=''
 
-sysconfig_dir='/etc/sysconfig'
-[ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'
-
 append_hax_svc() {
     local id=$1
-    local ep=$(get_service_ep $id)
+    local ep=$(get_service_ep_from_kv_file $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
     SVCS_CONF+="${SVCS_CONF:+,}{
@@ -126,7 +215,7 @@ append_hax_svc() {
 append_confd_svc() {
     local id=$1
     local fid=$(id2fid $id)
-    local ep=$(get_service_ep $id)
+    local ep=$(get_service_ep_from_kv_file $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
     SVCS_CONF+="${SVCS_CONF:+,}{
@@ -143,18 +232,19 @@ append_confd_svc() {
           }
         ]
     }"
-    cat <<EOF | sudo tee $sysconfig_dir/m0d-$fid > /dev/null
+    cat <<EOF | sudo tee /tmp/m0d-$fid > /dev/null
 MOTR_M0D_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 MOTR_CONF_XC='/etc/motr/confd.xc'
 EOF
+    install_motr_conf /tmp/m0d-$fid
 }
 
 append_ios_svc() {
     local id=$1
     local fid=$(id2fid $id)
-    local ep=$(get_service_ep $id)
+    local ep=$(get_service_ep_from_kv_file $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
     local meta_data=$(get_ios_meta_data $id)
@@ -172,22 +262,23 @@ append_ios_svc() {
           }
         ]
     }"
-    cat <<EOF | sudo tee $sysconfig_dir/m0d-$fid > /dev/null
+    cat <<EOF | sudo tee /tmp/m0d-$fid > /dev/null
 MOTR_M0D_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 EOF
     if [[ $meta_data ]]; then
-        cat <<EOF | sudo tee -a $sysconfig_dir/m0d-$fid > /dev/null
+        cat <<EOF | sudo tee -a /tmp/m0d-$fid > /dev/null
 MOTR_BE_SEG_PATH='$meta_data'
 EOF
     fi
+    install_motr_conf /tmp/m0d-$fid
 }
 
 append_s3_svc() {
     local id=$1
     local fid=$(id2fid $id)
-    local ep=$(get_service_ep $id)
+    local ep=$(get_service_ep_from_kv_file $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
     local s3port=$2
@@ -206,16 +297,16 @@ append_s3_svc() {
           }
         ]
     }"
-    local first_profile_fid=$(
-        consul kv get -keys 'm0conf/profiles/' | head -1 | cut -d/ -f3)
+    local first_profile_fid=$(get_profile_from_kv_file)
     [[ -n $first_profile_fid ]]  # assert
-    cat <<EOF | sudo tee $sysconfig_dir/s3server-$fid > /dev/null
+    cat <<EOF | sudo tee /tmp/s3server-$fid > /dev/null
 MOTR_PROFILE_FID=$first_profile_fid
 MOTR_S3SERVER_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 MOTR_S3SERVER_PORT=$s3port
 EOF
+    install_s3_conf /tmp/s3server-$fid
 }
 
 for id in $HAX_ID; do
@@ -240,6 +331,9 @@ tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)
 trap "rm -f $tmpfile" EXIT # delete automatically on exit
 jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
 sudo cp $tmpfile $CONF_FILE
+# Copy consul-server-conf for this node to consul dir.
+mkdir -p /etc/consul.d/
+sudo cp $CONF_FILE /etc/consul.d/
 
 sudo sed -r "s;(http://)localhost;\1$(get_service_ip_addr $HAX_EP);" \
          -i $CONF_FILE


### PR DESCRIPTION
Hare mini provisioner config stage generate Hare and Motr configuration, which
also comprises of information to register Hare and Motr services with Consul.
This information is not populated by hare configure utility.

Solution:
- Accept configuration directory path as an argument to Hare scripts.
- Fetch required services information from offline key values generated as
  part of Hare configuration.