### PR TITLE
EOS-24917: Update QSG with verification info

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,3 +300,4 @@ Solution: install cortx-py-utils RPM and retry.
 
 * [Hare RFCs](rfc/README.md)
 * [Hare wiki](https://github.com/Seagate/cortx-hare/wiki)
+* [QSG_Test_History](Testing_Verification_History.md)

--- a/Testing_Verification_History.md
+++ b/Testing_Verification_History.md
@@ -1,0 +1,11 @@
+# Page Info
+
+  This file is used to keep the history of test summary.
+  
+  Steps mentioned in following document/s are verified, unless specifically mentioned in the summary :
+  
+  [hare README.md](https://github.com/Seagate/cortx-hare/blob/main/README.md)
+
+# Tested by
+    
+* Sep 14, 2021: Pavan Krishna Thunuguntla, tested using CentOS Linux release 7.9.2009, verified with git tag CORTX-2.0.0-77 (#4737a8f8411bd6311f86dbd75a59b8b704e26929) on main branch.


### PR DESCRIPTION
Problem: Quick-Start-Guide(QSG) page missing with page verification info.

Solution: Added a Testing_Verification_History page and linked it to QSG page.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>

-----
[View rendered README.md](https://github.com/pavankrishnat/cortx-hare/blob/patch-2/README.md)