### PR TITLE
cfgen: fix automatic pool disk_refs generation

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2120,6 +2120,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
             # in pool description
             if not get_pool_diskrefs(pool):
                 for node in cluster_desc['nodes']:
+                    if not node.get('m0_servers'):
+                        continue
                     for m0d in node['m0_servers']:
                         if m0d['runs_confd']:
                             continue


### PR DESCRIPTION
If there are pure client nodes (without m0_servers) in the
cluster configuration, the automatic disk_refs generation for
the pools fails:

    2021-09-15 16:23:30: Generating cluster configuration...Traceback (most recent call last):
      File "/opt/seagate/cortx/hare/bin/../bin/cfgen", line 2164, in <module>
        main()
      File "/opt/seagate/cortx/hare/bin/../bin/cfgen", line 223, in main
        cluster = build_cluster(cluster_desc)
      File "/opt/seagate/cortx/hare/bin/../bin/cfgen", line 2123, in build_cluster
        for m0d in node['m0_servers']:
    KeyError: 'm0_servers'

Solution: add explicit check for m0_servers section present
in the node configuration before including it in disk_refs
generation.