### PR TITLE
EOS-24483: Added CONF_HA_RECOVERED() message and corresponding HA states

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -359,7 +359,8 @@ def all_services_started(url: str, nr_svcs: int) -> bool:
     for val in status_data:
         state = val['Value']
         statuses.append(json.loads(state.decode('utf8'))['state'])
-    started = [status == 'M0_CONF_HA_PROCESS_STARTED' for status in statuses]
+    started = [status == 'M0_CONF_HA_PROCESS_DTM_RECOVERED'
+               for status in statuses]
     if len(started) != nr_svcs:
         return False
     return all(started)

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -135,7 +135,7 @@ wait_active() {
 
 process_started() {
     local fid=$1
-    if [[ $(get-process-state $fid) == M0_CONF_HA_PROCESS_STARTED ]]; then
+    if [[ $(get-process-state $fid) == M0_CONF_HA_PROCESS_DTM_RECOVERED ]]; then
         return 0
     fi
     return 1


### PR DESCRIPTION
 - Added CONF_HA_RECOVERED() sent from the motr side to hax
 - The reaction on the previous message is the transition
   of motr processes into ONLINE state
 - The reaction on CONF_HA_STARTED() message is the transition to
   RECOVERING state