### PR TITLE
cfgen: fix parity_units calc for dix and md pools

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2145,7 +2145,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     if conf[root_id].mdpool is None:  # no Metadata pool defined in the CDF
         ConfPool.build(conf, root_id, {'type': 'md'})
 
-    conf[root_id].mdredundancy = len(cluster_svcs(conf, SvcT.M0_CST_CAS))
+    conf[root_id].mdredundancy = len(cluster_svcs(conf, SvcT.M0_CST_IOS))
 
     for prof in cluster_desc['profiles']:
         prof['pools'] += [aux_pool['name']

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1261,10 +1261,10 @@ def pool_drives(m0conf: Dict[Oid, Any],
 
 def cluster_encls(m0conf: Dict[Oid, Any], svc_t) -> List[Oid]:
     return list({encl_id
-            for encl_id in m0conf if encl_id.type is ObjT.enclosure
-            for proc_id in m0conf[m0conf[encl_id].node].processes
-            for svc_id in m0conf[proc_id].services
-            if m0conf[svc_id].type is svc_t})
+                 for encl_id in m0conf if encl_id.type is ObjT.enclosure
+                 for proc_id in m0conf[m0conf[encl_id].node].processes
+                 for svc_id in m0conf[proc_id].services
+                 if m0conf[svc_id].type is svc_t})
 
 
 def cluster_ctrls(m0conf: Dict[Oid, Any]) -> List[Oid]:

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1192,19 +1192,21 @@ def pool_type(pool_desc: Dict[str, Any]) -> PoolT:
     return PoolT[pool_desc.get('type', 'sns')]
 
 
+def cluster_svcs(m0conf: Dict[Oid, Any], svc_t) -> List[Oid]:
+    return [svc_id
+            for encl_id in m0conf if encl_id.type is ObjT.enclosure
+            for proc_id in m0conf[m0conf[encl_id].node].processes
+            for svc_id in m0conf[proc_id].services
+            if m0conf[svc_id].type is svc_t]
+
+
 def pool_drives(m0conf: Dict[Oid, Any],
                 pool_desc: Dict[str, Any]) -> List[Oid]:
     ptype = pool_type(pool_desc)
 
     if ptype is PoolT.dix:
-        cas = []
-        for item in m0conf:
-            if item.type is ObjT.enclosure:
-                encl_id = item
-                for proc_id in m0conf[m0conf[encl_id].node].processes:
-                    for svc_id in m0conf[proc_id].services:
-                        if m0conf[svc_id].type is SvcT.M0_CST_CAS:
-                            cas.append((svc_id, m0conf[svc_id].ctrl_id))
+        cas = [(svc_id, m0conf[svc_id].ctrl_id)
+               for svc_id in cluster_svcs(m0conf, SvcT.M0_CST_CAS)]
 
         return [ConfDrive.build(m0conf, ctrl_id,
                                 ConfSdev.build(m0conf, svc_id,
@@ -1255,19 +1257,16 @@ def pool_drives(m0conf: Dict[Oid, Any],
 
 
 def cluster_encls(m0conf: Dict[Oid, Any]) -> List[Oid]:
-    encls: List[Oid] = []
-    for item in m0conf:
-        if item.type is ObjT.enclosure:
-            encls.append(item)
-    return encls
+    return [encl_id
+            for encl_id in m0conf if encl_id.type is ObjT.enclosure
+            for proc_id in m0conf[m0conf[encl_id].node].processes
+            for svc_id in m0conf[proc_id].services
+            if m0conf[svc_id].type is SvcT.M0_CST_IOS]
 
 
 def cluster_ctrls(m0conf: Dict[Oid, Any]) -> List[Oid]:
-    ctrls: List[Oid] = []
-    for item in m0conf:
-        if item.type is ObjT.controller:
-            ctrls.append(item)
-    return ctrls
+    return [m0conf[encl_id].ctrls
+            for encl_id in cluster_encls(m0conf)]
 
 
 def drives_per_node_and_ctrl(m0conf: Dict[Oid, Any]) -> faultToleranceInfo:
@@ -1410,11 +1409,11 @@ class ConfPool(ToDhall):
                 # indivisible pieces of data, the whole CAS record is
                 # always stored on one node.
                 data_units = 1
-                parity_units = len(cluster_encls(m0conf)) - 1
+                parity_units = len(cluster_svcs(m0conf, SvcT.M0_CST_CAS)) - 1
             else:
                 assert t is PoolT.md
                 data_units = 1
-                parity_units = len(cluster_encls(m0conf)) - 1
+                parity_units = len(cluster_svcs(m0conf, SvcT.M0_CST_IOS)) - 1
             pd_attrs = PDClustAttrs0(data_units=data_units,
                                      parity_units=parity_units,
                                      spare_units=0)

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -720,7 +720,7 @@ class ConfRoot(ToDhall):
                   Downlink('profiles', ObjT.profile)}  # XXX + fdmi_flt_grps
 
     def __init__(self, nodes: List[Oid], sites: List[Oid], pools: List[Oid],
-                 profiles: List[Oid], mdpool: Oid = None,
+                 profiles: List[Oid], mdpool: Oid = None, mdredundancy: int = 0,
                  imeta_pver: Oid = None):
         assert all(x.type is ObjT.node for x in nodes)
         assert all(x.type is ObjT.site for x in sites)
@@ -734,6 +734,7 @@ class ConfRoot(ToDhall):
         self.pools = pools
         self.profiles = profiles
         self.mdpool = mdpool
+        self.mdredundancy = mdredundancy
         self.imeta_pver = imeta_pver
 
     def __repr__(self):
@@ -742,6 +743,7 @@ class ConfRoot(ToDhall):
                           f'pools={self.pools}',
                           f'profiles={self.profiles}',
                           f'mdpool={self.mdpool}',
+                          f'mdredundancy={self.mdredundancy}',
                           f'imeta_pver={self.imeta_pver}'])
         return f'{self.__class__.__name__}({args})'
 
@@ -752,6 +754,7 @@ class ConfRoot(ToDhall):
         args = ', '.join([
             f'id = {oid_to_dhall(oid)}',
             f'mdpool = {oid_to_dhall(self.mdpool)}',
+            f'mdredundancy = {self.mdredundancy}',
             f'imeta_pver = Some ({oid_to_dhall(self.imeta_pver)})',
             f'nodes = {oids_to_dhall(self.nodes)}',
             f'sites = {oids_to_dhall(self.sites)}',
@@ -2141,6 +2144,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     if conf[root_id].mdpool is None:  # no Metadata pool defined in the CDF
         ConfPool.build(conf, root_id, {'type': 'md'})
+
+    conf[root_id].mdredundancy = len(cluster_svcs(conf, SvcT.M0_CST_CAS))
 
     for prof in cluster_desc['profiles']:
         prof['pools'] += [aux_pool['name']

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1260,11 +1260,11 @@ def pool_drives(m0conf: Dict[Oid, Any],
 
 
 def cluster_encls(m0conf: Dict[Oid, Any], svc_t) -> List[Oid]:
-    return [encl_id
+    return list({encl_id
             for encl_id in m0conf if encl_id.type is ObjT.enclosure
             for proc_id in m0conf[m0conf[encl_id].node].processes
             for svc_id in m0conf[proc_id].services
-            if m0conf[svc_id].type is svc_t]
+            if m0conf[svc_id].type is svc_t})
 
 
 def cluster_ctrls(m0conf: Dict[Oid, Any]) -> List[Oid]:

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -720,8 +720,8 @@ class ConfRoot(ToDhall):
                   Downlink('profiles', ObjT.profile)}  # XXX + fdmi_flt_grps
 
     def __init__(self, nodes: List[Oid], sites: List[Oid], pools: List[Oid],
-                 profiles: List[Oid], mdpool: Oid = None, mdredundancy: int = 0,
-                 imeta_pver: Oid = None):
+                 profiles: List[Oid], mdpool: Oid = None,
+                 mdredundancy: int = 0, imeta_pver: Oid = None):
         assert all(x.type is ObjT.node for x in nodes)
         assert all(x.type is ObjT.site for x in sites)
         assert all(x.type is ObjT.pool for x in pools)
@@ -1259,17 +1259,17 @@ def pool_drives(m0conf: Dict[Oid, Any],
     return [drive_id for drive_id, _ in drives]
 
 
-def cluster_encls(m0conf: Dict[Oid, Any]) -> List[Oid]:
+def cluster_encls(m0conf: Dict[Oid, Any], svc_t) -> List[Oid]:
     return [encl_id
             for encl_id in m0conf if encl_id.type is ObjT.enclosure
             for proc_id in m0conf[m0conf[encl_id].node].processes
             for svc_id in m0conf[proc_id].services
-            if m0conf[svc_id].type is SvcT.M0_CST_IOS]
+            if m0conf[svc_id].type is svc_t]
 
 
 def cluster_ctrls(m0conf: Dict[Oid, Any]) -> List[Oid]:
     return [m0conf[encl_id].ctrls
-            for encl_id in cluster_encls(m0conf)]
+            for encl_id in cluster_encls(m0conf, SvcT.M0_CST_IOS)]
 
 
 def drives_per_node_and_ctrl(m0conf: Dict[Oid, Any]) -> faultToleranceInfo:
@@ -1343,7 +1343,7 @@ class ConfPool(ToDhall):
     @classmethod
     def gen_sns_tolerance(cls, m0conf: Dict[Oid, Any],
                           pool_desc: Dict[str, Any]) -> Failures:
-        encls_nr = len(cluster_encls(m0conf))
+        encls_nr = len(cluster_encls(m0conf, SvcT.M0_CST_IOS))
         ctrls_per_encl = floor(len(cluster_ctrls(m0conf)) / encls_nr)
         data_units = pool_desc['data_units']
         parity_units = pool_desc['parity_units']
@@ -1374,7 +1374,7 @@ class ConfPool(ToDhall):
     @classmethod
     def gen_md_tolerance(cls, m0conf: Dict[Oid, Any],
                          pool_desc: Dict[str, Any]) -> Failures:
-        encls_nr = len(cluster_encls(m0conf))
+        encls_nr = len(cluster_encls(m0conf, SvcT.M0_CST_IOS))
         ctrls_per_encl = floor(len(cluster_ctrls(m0conf)) / encls_nr)
         encl_failures = encls_nr - 1
         ctrl_failures = min(encl_failures, (ctrls_per_encl * encl_failures))
@@ -1412,11 +1412,11 @@ class ConfPool(ToDhall):
                 # indivisible pieces of data, the whole CAS record is
                 # always stored on one node.
                 data_units = 1
-                parity_units = len(cluster_svcs(m0conf, SvcT.M0_CST_CAS)) - 1
+                parity_units = len(cluster_encls(m0conf, SvcT.M0_CST_CAS)) - 1
             else:
                 assert t is PoolT.md
                 data_units = 1
-                parity_units = len(cluster_svcs(m0conf, SvcT.M0_CST_IOS)) - 1
+                parity_units = len(cluster_encls(m0conf, SvcT.M0_CST_IOS)) - 1
             pd_attrs = PDClustAttrs0(data_units=data_units,
                                      parity_units=parity_units,
                                      spare_units=0)
@@ -2145,7 +2145,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     if conf[root_id].mdpool is None:  # no Metadata pool defined in the CDF
         ConfPool.build(conf, root_id, {'type': 'md'})
 
-    conf[root_id].mdredundancy = len(cluster_svcs(conf, SvcT.M0_CST_IOS))
+    conf[root_id].mdredundancy = len(cluster_encls(conf, SvcT.M0_CST_IOS))
 
     for prof in cluster_desc['profiles']:
         prof['pools'] += [aux_pool['name']

--- a/cfgen/dhall/render/Root.dhall
+++ b/cfgen/dhall/render/Root.dhall
@@ -35,7 +35,7 @@ in
       , named.Oid "mdpool" x.mdpool
       , named.TextUnquoted "imeta_pver"
             (Optional/fold types.Oid x.imeta_pver Text renderOid "(0,0)")
-      , named.Natural "mdredundancy" (List/length types.Oid x.nodes)
+      , named.Natural "mdredundancy" x.mdredundancy
       , "params=[]"
       , named.Oids "nodes" x.nodes
       , named.Oids "sites" x.sites

--- a/cfgen/dhall/types/Root.dhall
+++ b/cfgen/dhall/types/Root.dhall
@@ -25,6 +25,7 @@ in
 { id : Oid
 , mdpool : Oid
 , imeta_pver : Optional Oid
+, mdredundancy : Natural
 , nodes : List Oid
 , sites : List Oid
 , pools : List Oid

--- a/cfgen/tests/sample-confd.dhall
+++ b/cfgen/tests/sample-confd.dhall
@@ -115,6 +115,7 @@ let root = types.Obj.Root
   { id = ids.root
   , mdpool = ids.pool_1
   , imeta_pver = Some ids.pver_2
+  , mdredundancy = 1
   , nodes = [ids.node]
   , sites = [ids.site]
   , pools = [ids.pool_69, ids.pool_48, ids.pool_1]


### PR DESCRIPTION
We must take into account the services configured at the enclosures, when we use them to calculate the `parity_units` parameter for the pools: CAS-services for the dix-pool and IOS services for md-pool. Otherwise, we can get the wrong values when the services are not present on the nodes. (Like, for example, in case of the pure client-nodes present in the cluster configuration.)

The same principle must be applied in case of calculating the `tolerance` vector for the pools, as well as the `mdredundancy` parameter.