### PR TITLE
Problem: hare cfgen considers pure m0clients in enclosures

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2080,9 +2080,10 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
-        encl_id = ConfEnclosure.build(conf, rack_id, node_id)
         ctrl_ids: List[Tuple[Optional[Oid], Any]] = []
         m0ds = node.get('m0_servers', [])
+        if m0ds:
+            encl_id = ConfEnclosure.build(conf, rack_id, node_id)
         for m0d in m0ds:
             if m0d['_io_disks']:
                 ctrl_ids.append((ConfController.build(conf, encl_id), m0d))
@@ -2139,6 +2140,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     if conf[root_id].imeta_pver is None:  # no DIX pool defined in the CDF
         ConfPool.build(conf, root_id, {'type': 'dix'})
+
+    conf[root_id].mdredundancy = len(cluster_encls(conf)) - 1
 
     if conf[root_id].mdpool is None:  # no Metadata pool defined in the CDF
         ConfPool.build(conf, root_id, {'type': 'md'})

--- a/cfgen/dhall/render/Root.dhall
+++ b/cfgen/dhall/render/Root.dhall
@@ -35,7 +35,7 @@ in
       , named.Oid "mdpool" x.mdpool
       , named.TextUnquoted "imeta_pver"
             (Optional/fold types.Oid x.imeta_pver Text renderOid "(0,0)")
-      , named.Natural "mdredundancy" (List/length types.Oid x.nodes)
+      , named.Natural "mdredundancy" x.mdredundancy
       , "params=[]"
       , named.Oids "nodes" x.nodes
       , named.Oids "sites" x.sites

--- a/cfgen/dhall/types/Root.dhall
+++ b/cfgen/dhall/types/Root.dhall
@@ -25,6 +25,7 @@ in
 { id : Oid
 , mdpool : Oid
 , imeta_pver : Optional Oid
+, mdredundancy: Natural
 , nodes : List Oid
 , sites : List Oid
 , pools : List Oid


### PR DESCRIPTION
Hare configuration generator calculates number of enclosures to identify
number of parity units for meta data pools (i.e. DIX and md). Number of
enclosures are also used to calculated mdredundancy value.
But a node may comprise of pure m0_clients as well (i.e. no m0_servers
but only motr client processes). Presently Hare cfgen considers m0_client
only nodes as well to calculate number of enclosures which results in
invalid value of redundancy factor.

Solution:
- Create Enclosure object only for m0_servers and not m0_clients.
- Set mdredundancy value explicitly

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>