### PR TITLE
EOS-25014 Add support for getting fid of services by index

### DIFF
--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -178,6 +178,21 @@ def parse_opts(argv):
                    'Default: Returns the fids for all the services.',
                    type=str,
                    action='store')
+    p.add_argument('--index',
+                   '-i',
+                   help='service index. - Returns fid for given service'
+                   ' at given index.'
+                   ' Default: Returns the fids for all the services.'
+                   ' "--service" option is required for this option.'
+                   ' Also note that while returning result simplistic indexing'
+                   ' method is used where the index value is used as a'
+                   ' subscript into the list of identifiers for a given'
+                   ' service type. Hare does not guarantee that a mapping'
+                   ' between a given index and service identifier will always'
+                   ' be preserved',
+                   type=int,
+                   default=-1,
+                   action='store')
     p.add_argument(
         '--node',
         '-n',
@@ -207,7 +222,14 @@ def main(argv=None):
 
         svcs = get_service_for_node(nodes, opts.node, opts.service)
         if svcs:
-            print(simplejson.dumps(svcs, indent=2, for_json=True))
+            if opts.index >= 0:
+                if opts.index >= len(svcs):
+                    raise RuntimeError(f'There are only "{len(svcs)}"'
+                                       'instances of the provided service')
+                print(simplejson.dumps(svcs[opts.index],
+                                       indent=2, for_json=True))
+            else:
+                print(simplejson.dumps(svcs, indent=2, for_json=True))
 
     except (RuntimeError, FileNotFoundError) as e:
         print(e, file=sys.stderr)


### PR DESCRIPTION
Currently hare fetch-fid do not support returning index based service fid.
Lets say there are 2 s3server present in node and component wants to know fid for service present at 0th index then following command can be used
"hctl fetch-fids --service=ioservice --index=0"

**[root@ssc-vm-5246 ~]# hctl fetch-fids --service=ioservice**
[
  {
    "name": "ioservice",
    "fid": "0x7200000000000001:0xa"
  },
  {
    "name": "ioservice",
    "fid": "0x7200000000000001:0x15"
  }
]

**[root@ssc-vm-5246 ~]# hctl fetch-fids --service=ioservice --index=1**
{
  "name": "ioservice",
  "fid": "0x7200000000000001:0x15"
}

**[root@ssc-vm-5246 ~]# hctl fetch-fids --service=ioservice --index=0**
{
  "name": "ioservice",
  "fid": "0x7200000000000001:0xa"
}

**[root@ssc-vm-5246 ~]# hctl fetch-fids --service=s3server --index=0**
{
  "name": "s3server",
  "fid": "0x7200000000000001:0x23"
}
