### PR TITLE
Problem: no interface to start hax service without systemd

### DIFF
--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+from typing import List
+from threading import Event
+from hax.types import StoppableThread
+from hare_mp.utils import execute_no_communicate, LogWriter, Utils
+
+LOG = logging.getLogger('consul')
+LOG_FILE_SIZE = 1024 * 1024 * 1024
+
+
+class ConsulStarter(StoppableThread):
+    """
+    Starts consul agent and blocks until terminated.
+    """
+    def __init__(self, utils: Utils, stop_event: Event, log_dir: str,
+                 data_dir: str, config_dir: str, peers: List[str],
+                 bind_addr: str = '0.0.0.0',
+                 client_addr: str = '0.0.0.0'):
+        super().__init__(target=self._execute,
+                         name='consul-starter')
+        self.utils = utils
+        self.stop_event = stop_event
+        self.process = None
+        self.log_dir = log_dir
+        self.data_dir = data_dir
+        self.config_dir = config_dir
+        self.peers = peers
+        self.bind_addr = bind_addr
+        self.client_addr = client_addr
+
+    def stop(self):
+        try:
+            if self.process:
+                self.process.terminate()
+        except Exception:
+            pass
+
+    def _execute(self):
+        try:
+            log_file = f'{self.log_dir}/hare-consul.log'
+            fh = logging.handlers.RotatingFileHandler(log_file,
+                                                      maxBytes=LOG_FILE_SIZE,
+                                                      mode='a',
+                                                      backupCount=5,
+                                                      encoding=None,
+                                                      delay=False)
+            LOG.addHandler(fh)
+            cmd = ['consul', 'agent', f'-bind={self.bind_addr}',
+                   f'-client={self.client_addr}', '-datacenter=dc1',
+                   f'-data-dir={self.data_dir}', '-enable-script-checks',
+                   f'-config-dir={self.config_dir}', '-domain=consul',
+                   '-serf-lan-port=8301']
+            for peer in self.peers:
+                cmd.append(f'-retry-join={peer}:8301')
+
+            self.process = execute_no_communicate(cmd,
+                                                  working_dir=self.log_dir,
+                                                  out_file=LogWriter(LOG, fh))
+            if self.process:
+                self.process.communicate()
+        except Exception:
+            LOG.exception('Aborting due to an error')
+        finally:
+            LOG.exception('Stopping Consul')
+            self.stop_event.set()
+            self.utils.stop_hare()

--- a/provisioning/miniprov/hare_mp/hax_starter.py
+++ b/provisioning/miniprov/hare_mp/hax_starter.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+import sys
+from threading import Event
+import os
+from hax.types import StoppableThread
+from hare_mp.utils import execute_no_communicate, LogWriter, Utils
+
+LOG = logging.getLogger('hax')
+LOG_FILE_SIZE = 1024 * 1024 * 1024
+
+
+class HaxStarter(StoppableThread):
+    """
+    Starts consul agent and blocks until terminated.
+    """
+    def __init__(self, utils: Utils, stop_event: Event, home_dir: str,
+                 log_dir: str):
+        super().__init__(target=self._execute,
+                         name='hax-starter')
+        self.utils = utils
+        self.stop_event = stop_event
+        self.process = None
+        self.home_dir = home_dir
+        self.log_dir = log_dir
+
+    def stop(self):
+        try:
+            if self.process:
+                self.process.terminate()
+        except Exception:
+            pass
+
+    def _execute(self):
+        try:
+            hax_log_file = f'{self.log_dir}/hare-hax.log'
+            fh = logging.handlers.RotatingFileHandler(hax_log_file,
+                                                      maxBytes=LOG_FILE_SIZE,
+                                                      mode='a',
+                                                      backupCount=5,
+                                                      encoding=None,
+                                                      delay=False)
+            LOG.addHandler(fh)
+            path = os.getenv('PATH', '')
+            path += os.pathsep + '/opt/seagate/cortx/hare/bin'
+            path += os.pathsep + '/opt/seagate/cortx/hare/libexec'
+            python_path = os.pathsep.join(sys.path)
+            cmd = ['hax']
+            self.process = execute_no_communicate(cmd, env={'PYTHONPATH': python_path,
+                                                  'PATH': path,
+                                                  'LC_ALL': "en_US.utf-8",
+                                                  'LANG': "en_US.utf-8"},
+                                                  working_dir=self.home_dir,
+                                                  out_file=LogWriter(LOG, fh))
+            if self.process:
+                self.process.communicate()
+        except Exception:
+            LOG.exception('Aborting due to an error')
+        finally:
+            LOG.exception('Stopping Hax')
+            self.stop_event.set()
+            self.utils.stop_hare()


### PR DESCRIPTION
Presently without systemd, there is no other interface to start Hare hax service.
In-order to start hax process the corresponding environment and logging needs to
be configured explicitly in a non-systemd environment.

Solution:
- Add a sub command, start to hare_setup utility.
- Configure required environment, logging and start hax service in background
  as part of hare_setup start command.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>