### PR TITLE
EOS-23500: no template for hare container configuration is present

### DIFF
--- a/containers/examples/3node/config-vol-1-pvc.yaml
+++ b/containers/examples/3node/config-vol-1-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cortx-config-vol-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi

--- a/containers/examples/3node/config-vol-1.yaml
+++ b/containers/examples/3node/config-vol-1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cortx-config-vol-1
+spec:
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdf
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-3947.colo.seagate.com

--- a/containers/examples/3node/config-vol-2-pvc.yaml
+++ b/containers/examples/3node/config-vol-2-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cortx-config-vol-2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi

--- a/containers/examples/3node/config-vol-2.yaml
+++ b/containers/examples/3node/config-vol-2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cortx-config-vol-2
+spec:
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdf
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4218.colo.seagate.com

--- a/containers/examples/3node/config-vol-3-pvc.yaml
+++ b/containers/examples/3node/config-vol-3-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cortx-config-vol-3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi

--- a/containers/examples/3node/config-vol-3.yaml
+++ b/containers/examples/3node/config-vol-3.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cortx-config-vol-3
+spec:
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdf
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4161.colo.seagate.com

--- a/containers/examples/3node/cortx-io-pod-1.yaml
+++ b/containers/examples/3node/cortx-io-pod-1.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cortx-io-pod-1
+  labels:
+    app: cortx-io-pod-1
+spec:
+  restartPolicy: Never
+  nodeName: ssc-vm-3947.colo.seagate.com
+  containers:
+  - name: cortx-hare-container
+    image: ghcr.io/seagate/cortx-all:2.0.0-86-custom-ci
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 2001
+      protocol: TCP
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeDevices:
+      - name: io-sdb-1
+        devicePath: /dev/sdb
+      - name: io-sdc-1
+        devicePath: /dev/sdc
+      - name: io-sdd-1
+        devicePath: /dev/sdd
+      - name: io-sde-1
+        devicePath: /dev/sde
+    volumeMounts:
+    - mountPath: /mnt/etc/cortx
+      name: cortx-config-vol-1
+  - name: cortx-io-container
+    image: ghcr.io/seagate/cortx-all:2.0.0-86-custom-ci
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 3002
+      protocol: TCP
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeDevices:
+      - name: io-sdb-1
+        devicePath: /dev/sdb
+      - name: io-sdc-1
+        devicePath: /dev/sdc
+      - name: io-sdd-1
+        devicePath: /dev/sdd
+      - name: io-sde-1
+        devicePath: /dev/sde
+    volumeMounts:
+    - mountPath: /mnt/etc/cortx
+      name: cortx-config-vol-1
+  volumes:
+    - name: io-sdb-1
+      persistentVolumeClaim:
+        claimName: io-sdb-1
+    - name: io-sdc-1
+      persistentVolumeClaim:
+        claimName: io-sdc-1
+    - name: io-sdd-1
+      persistentVolumeClaim:
+        claimName: io-sdd-1
+    - name: io-sde-1
+      persistentVolumeClaim:
+        claimName: io-sde-1
+    - name: cortx-config-vol-1
+      persistentVolumeClaim:
+        claimName: cortx-config-vol-1
+  imagePullSecrets:
+  - name: cortxregcred
+  - name: docregcred

--- a/containers/examples/3node/cortx-io-pod-2.yaml
+++ b/containers/examples/3node/cortx-io-pod-2.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cortx-io-pod-2
+  labels:
+    app: cortx-io-pod-2
+spec:
+  restartPolicy: Never
+  nodeName: ssc-vm-4218.colo.seagate.com
+  containers:
+  - name: cortx-hare-container
+    image: ghcr.io/seagate/cortx-all:2.0.0-86-custom-ci
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 2001
+      protocol: TCP
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeDevices:
+      - name: io-sdb-2
+        devicePath: /dev/sdb
+      - name: io-sdc-2
+        devicePath: /dev/sdc
+      - name: io-sdd-2
+        devicePath: /dev/sdd
+      - name: io-sde-2
+        devicePath: /dev/sde
+    volumeMounts:
+    - mountPath: /mnt/etc/cortx
+      name: cortx-config-vol-2
+  - name: cortx-io-container
+    image: ghcr.io/seagate/cortx-all:2.0.0-86-custom-ci
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 3002
+      protocol: TCP
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeDevices:
+      - name: io-sdb-2
+        devicePath: /dev/sdb
+      - name: io-sdc-2
+        devicePath: /dev/sdc
+      - name: io-sdd-2
+        devicePath: /dev/sdd
+      - name: io-sde-2
+        devicePath: /dev/sde
+    volumeMounts:
+    - mountPath: /mnt/etc/cortx
+      name: cortx-config-vol-2
+  volumes:
+    - name: io-sdb-2
+      persistentVolumeClaim:
+        claimName: io-sdb-2
+    - name: io-sdc-2
+      persistentVolumeClaim:
+        claimName: io-sdc-2
+    - name: io-sdd-2
+      persistentVolumeClaim:
+        claimName: io-sdd-2
+    - name: io-sde-2
+      persistentVolumeClaim:
+        claimName: io-sde-2
+    - name: cortx-config-vol-2
+      persistentVolumeClaim:
+        claimName: cortx-config-vol-2
+  imagePullSecrets:
+  - name: cortxregcred
+  - name: docregcred

--- a/containers/examples/3node/cortx-io-pod-3.yaml
+++ b/containers/examples/3node/cortx-io-pod-3.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cortx-io-pod-3
+  labels:
+    app: cortx-io-pod-3
+spec:
+  restartPolicy: Never
+  nodeName: ssc-vm-4161.colo.seagate.com
+  containers:
+  - name: cortx-hare-container
+    image: ghcr.io/seagate/cortx-all:2.0.0-86-custom-ci
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 2001
+      protocol: TCP
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeDevices:
+      - name: io-sdb-3
+        devicePath: /dev/sdb
+      - name: io-sdc-3
+        devicePath: /dev/sdc
+      - name: io-sdd-3
+        devicePath: /dev/sdd
+      - name: io-sde-3
+        devicePath: /dev/sde
+    volumeMounts:
+    - mountPath: /mnt/etc/cortx
+      name: cortx-config-vol-3
+  - name: cortx-io-container
+    image: ghcr.io/seagate/cortx-all:2.0.0-86-custom-ci
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 3002
+      protocol: TCP
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeDevices:
+      - name: io-sdb-3
+        devicePath: /dev/sdb
+      - name: io-sdc-3
+        devicePath: /dev/sdc
+      - name: io-sdd-3
+        devicePath: /dev/sdd
+      - name: io-sde-3
+        devicePath: /dev/sde
+    volumeMounts:
+    - mountPath: /mnt/etc/cortx
+      name: cortx-config-vol-3
+  volumes:
+    - name: io-sdb-3
+      persistentVolumeClaim:
+        claimName: io-sdb-3
+    - name: io-sdc-3
+      persistentVolumeClaim:
+        claimName: io-sdc-3
+    - name: io-sdd-3
+      persistentVolumeClaim:
+        claimName: io-sdd-3
+    - name: io-sde-3
+      persistentVolumeClaim:
+        claimName: io-sde-3
+    - name: cortx-config-vol-3
+      persistentVolumeClaim:
+        claimName: cortx-config-vol-3
+  imagePullSecrets:
+  - name: cortxregcred
+  - name: docregcred

--- a/containers/examples/3node/cortx-io-pod-svc-1.yaml
+++ b/containers/examples/3node/cortx-io-pod-svc-1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortx-io-pod-svc-1
+  ports:
+  - name: hax
+    port: 2001
+    protocol: TCP
+    targetPort: 2001
+  - name: confd
+    port: 3002
+    protocol: TCP
+    targetPort: 3002
+  publishNotReadyAddresses: true
+  selector:
+    app: cortx-hare-motr-pod

--- a/containers/examples/3node/cortx-io-svc-1.yaml
+++ b/containers/examples/3node/cortx-io-svc-1.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortx-io-pod-1
+spec:
+  ports:
+  - name: hax
+    port: 2001
+    protocol: TCP
+    targetPort: 2001
+  - name: motr1
+    port: 3001
+    protocol: TCP
+    targetPort: 3001
+  - name: motr2
+    port: 3002
+    protocol: TCP
+    targetPort: 3002
+  - name: motr3
+    port: 3003
+    protocol: TCP
+    targetPort: 3003
+  selector:
+    app: cortx-io-pod-1

--- a/containers/examples/3node/cortx-io-svc-2.yaml
+++ b/containers/examples/3node/cortx-io-svc-2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortx-io-pod-2
+spec:
+  ports:
+  - name: hax
+    port: 2001
+    protocol: TCP
+    targetPort: 2001
+  - name: motr1
+    port: 3001
+    protocol: TCP
+    targetPort: 3001
+  - name: motr2
+    port: 3002
+    protocol: TCP
+    targetPort: 3002
+  - name: motr3
+    port: 3003
+    protocol: TCP
+    targetPort: 3003
+  selector:
+    app: cortx-io-pod-2

--- a/containers/examples/3node/cortx-io-svc-3.yaml
+++ b/containers/examples/3node/cortx-io-svc-3.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortx-io-pod-3
+spec:
+  ports:
+  - name: hax
+    port: 2001
+    protocol: TCP
+    targetPort: 2001
+  - name: motr1
+    port: 3001
+    protocol: TCP
+    targetPort: 3001
+  - name: motr2
+    port: 3002
+    protocol: TCP
+    targetPort: 3002
+  - name: motr3
+    port: 3003
+    protocol: TCP
+    targetPort: 3003
+  selector:
+    app: cortx-io-pod-3

--- a/containers/examples/3node/hare.config.conf.3-node
+++ b/containers/examples/3node/hare.config.conf.3-node
@@ -1,0 +1,153 @@
+{
+  "cluster": {    
+    "my-cluster": {
+      "site": {
+        "storage_set_count": "1"
+      },
+      "storage_set": [
+        {
+          "durability": {
+            "sns": {
+              "data": "4",
+              "parity": "2",
+              "spare": "0"
+            }
+          },
+          "name": "storage1",
+          "server_nodes": [
+            "a075603264464340a5a53b987555fe5c",
+            "a6422fd1d8b04510b291c03c537c147a",
+            "33604d428f544d9596fe0791d7d4d4b0"
+          ]
+        }
+      ]
+    }
+  },
+   "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "0"
+        }
+      }
+    }
+  },
+  "server_node": {
+    "a075603264464340a5a53b987555fe5c": {
+      "cluster_id": "my-cluster",
+      "hostname": "cortx-io-pod-1",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "consul_server"
+      ],
+      "name": "srvnode-1",
+      "network": {
+        "data": {
+          "private_fqdn": "cortx-io-pod-1",
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth0"
+          ]
+        }
+      },
+      "s3_instances": "2",
+      "storage_set_id": "storage1",
+      "storage": {
+        "cvg_count": "1",
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde"
+            ],
+            "metadata_devices": [
+              "/dev/sdj"
+            ]
+          }
+        ]
+      }
+    },
+    "a6422fd1d8b04510b291c03c537c147a": {
+      "cluster_id": "my-cluster",
+      "hostname": "cortx-io-pod-2",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "consul_server"
+      ],
+      "name": "srvnode-2",
+      "network": {
+        "data": {
+          "private_fqdn": "cortx-io-pod-2",
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth0"
+          ]
+        }
+      },
+      "s3_instances": "2",
+      "storage_set_id": "storage1",
+      "storage": {
+        "cvg_count": "1",
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde"
+            ],
+            "metadata_devices": [
+              "/dev/sdj"
+            ]
+          }
+        ]
+      }
+    },
+    "33604d428f544d9596fe0791d7d4d4b0": {
+      "cluster_id": "my-cluster",
+      "hostname": "cortx-io-pod-3",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "consul_server"
+      ],
+      "name": "srvnode-3",
+      "network": {
+        "data": {
+          "private_fqdn": "cortx-io-pod-3",
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth0"
+          ]
+        }
+      },
+      "s3_instances": "2",
+      "storage_set_id": "storage1",
+      "storage": {
+        "cvg_count": "1",
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd",
+              "/dev/sde"
+            ],
+            "metadata_devices": [
+              "/dev/sdj"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/containers/examples/3node/hare.config.conf.n.cvgs.3-node
+++ b/containers/examples/3node/hare.config.conf.n.cvgs.3-node
@@ -1,0 +1,174 @@
+{
+  "cluster": {    
+    "my-cluster": {
+      "site": {
+        "storage_set_count": "1"
+      },
+      "storage_set": [
+        {
+          "durability": {
+            "sns": {
+              "data": "4",
+              "parity": "2",
+              "spare": "0"
+            }
+          },
+          "name": "storage1",
+          "server_nodes": [
+            "a075603264464340a5a53b987555fe5c",
+            "a6422fd1d8b04510b291c03c537c147a",
+            "33604d428f544d9596fe0791d7d4d4b0"
+          ]
+        }
+      ]
+    }
+  },
+   "cortx": {
+    "software": {
+      "motr": {
+        "service": {
+          "client_instances": "2"
+        }
+      },
+      "s3": {
+        "service": {
+          "instances": "0"
+        }
+      }
+    }
+  },
+  "server_node": {
+    "a075603264464340a5a53b987555fe5c": {
+      "cluster_id": "my-cluster",
+      "hostname": "cortx-io-pod-1",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "consul_server"
+      ],
+      "name": "srvnode-1",
+      "network": {
+        "data": {
+          "private_fqdn": "cortx-io-pod-1",
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth0"
+          ]
+        }
+      },
+      "s3_instances": "2",
+      "storage_set_id": "storage1",
+      "storage": {
+        "cvg_count": "2",
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sdb",
+              "/dev/sdc"
+            ],
+            "metadata_devices": [
+              "/dev/sdj"
+            ]
+          },
+          {
+            "data_devices": [
+              "/dev/sdd",
+              "/dev/sde"
+            ],
+            "metadata_devices": [
+              "/dev/sdh"
+            ]
+          }
+        ]
+      }
+    },
+    "a6422fd1d8b04510b291c03c537c147a": {
+      "cluster_id": "my-cluster",
+      "hostname": "cortx-io-pod-2",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "consul_server"
+      ],
+      "name": "srvnode-2",
+      "network": {
+        "data": {
+          "private_fqdn": "cortx-io-pod-2",
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth0"
+          ]
+        }
+      },
+      "s3_instances": "2",
+      "storage_set_id": "storage1",
+      "storage": {
+        "cvg_count": "2",
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sdb",
+              "/dev/sdc"
+            ],
+            "metadata_devices": [
+              "/dev/sdj"
+            ]
+          },
+          {
+            "data_devices": [
+              "/dev/sdd",
+              "/dev/sde"
+            ],
+            "metadata_devices": [
+              "/dev/sdh"
+            ]
+          }
+        ]
+      }
+    },
+    "33604d428f544d9596fe0791d7d4d4b0": {
+      "cluster_id": "my-cluster",
+      "hostname": "cortx-io-pod-3",
+      "roles": [
+        "primary",
+        "openldap_server",
+        "consul_server"
+      ],
+      "name": "srvnode-3",
+      "network": {
+        "data": {
+          "private_fqdn": "cortx-io-pod-3",
+          "interface_type": "tcp",
+          "private_interfaces": [
+            "eth0"
+          ]
+        }
+      },
+      "s3_instances": "2",
+      "storage_set_id": "storage1",
+      "storage": {
+        "cvg_count": "2",
+        "cvg": [
+          {
+            "data_devices": [
+              "/dev/sdb",
+              "/dev/sdc"
+            ],
+            "metadata_devices": [
+              "/dev/sdj"
+            ]
+          },
+          {
+            "data_devices": [
+              "/dev/sdd",
+              "/dev/sde"
+            ],
+            "metadata_devices": [
+              "/dev/sdh"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/containers/examples/3node/io-pv-1.yaml
+++ b/containers/examples/3node/io-pv-1.yaml
@@ -1,0 +1,87 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdb-1
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdb
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-3947.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdc-1
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdc
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-3947.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdd-1
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdd
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-3947.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sde-1
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sde
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-3947.colo.seagate.com

--- a/containers/examples/3node/io-pv-2.yaml
+++ b/containers/examples/3node/io-pv-2.yaml
@@ -1,0 +1,87 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdb-2
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdb
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4218.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdc-2
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdc
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4218.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdd-2
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdd
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4218.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sde-2
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sde
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4218.colo.seagate.com

--- a/containers/examples/3node/io-pv-3.yaml
+++ b/containers/examples/3node/io-pv-3.yaml
@@ -1,0 +1,87 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdb-3
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdb
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4161.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdc-3
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdc
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4161.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sdd-3
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sdd
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4161.colo.seagate.com
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: io-sde-3
+spec:
+  volumeMode: Block
+  capacity:
+    storage: 100Gi
+  local:
+    path: /dev/sde
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ssc-vm-4161.colo.seagate.com

--- a/containers/examples/3node/io-pvc-1.yaml
+++ b/containers/examples/3node/io-pvc-1.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdb-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdb-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdc-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdc-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdd-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdd-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sde-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sde-1

--- a/containers/examples/3node/io-pvc-2.yaml
+++ b/containers/examples/3node/io-pvc-2.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdb-2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdb-2
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdc-2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdc-2
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdd-2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdd-2
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sde-2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sde-2

--- a/containers/examples/3node/io-pvc-3.yaml
+++ b/containers/examples/3node/io-pvc-3.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdb-3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdb-3
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdc-3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdc-3
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sdd-3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sdd-3
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: io-sde-3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: io-sde-3

--- a/containers/examples/3node/motr_hare_keys.json
+++ b/containers/examples/3node/motr_hare_keys.json
@@ -1,0 +1,58 @@
+{
+  "server": {
+    "srvnode-1": {
+      "cvg": [
+        {
+          "m0d": [
+            {
+              "md_seg1": "/dev/vg_srvnode-1_md1/lv_raw_md1"
+            }
+          ]
+        },
+        {
+          "m0d": [
+            {
+              "md_seg1": "/dev/vg_srvnode-1_md2/lv_raw_md2"
+            }
+          ]
+        }
+      ]
+    },
+    "srvnode-2": {
+      "cvg": [
+        {
+          "m0d": [
+            {
+              "md_seg1": "/dev/vg_srvnode-1_md1/lv_raw_md1"
+            }
+          ]
+        },
+        {
+          "m0d": [
+            {
+              "md_seg1": "/dev/vg_srvnode-1_md2/lv_raw_md2"
+            }
+          ]
+        }
+      ]
+    },
+    "srvnode-3": {
+      "cvg": [
+        {
+          "m0d": [
+            {
+              "md_seg1": "/dev/vg_srvnode-1_md1/lv_raw_md1"
+            }
+          ]
+        },
+        {
+          "m0d": [
+            {
+              "md_seg1": "/dev/vg_srvnode-1_md2/lv_raw_md2"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Presently there's no template(s) to support provisioning Hare container. This
inhibits testing Hare in containers.

Solution:
Add template/example files for creating persistent volumes, persistent volume claims,
creating multi-container pods, creating configuration pv and pvc, creating services
corresponding to the Hare-motr pods.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>