### PR TITLE
EOS-25106: cdf creation fails for multiple cvgs per container

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -308,11 +308,10 @@ class CdfGenerator:
         # We will create 1 IO service entry in CDF per cvg.
         # An IO service entry will use data devices from corresponding cvg.
         # meta data device is taken from motr-hare shared store.
-        data_drives_info = self.utils.get_drives_info()
         servers = DList([
             M0ServerDesc(
                 io_disks=DisksDesc(
-                    data=data_drives_info,
+                    data=self.utils.get_drives_info_for(cvg),
                     meta_data=Maybe(
                         self._get_metadata_device(name, cvg, m0d), 'Text')),
                 runs_confd=Maybe(False, 'Bool'))

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -97,11 +97,9 @@ class Utils:
                      size=Maybe(drive_info['size'], 'Natural'),
                      blksize=Maybe(drive_info['blksize'], 'Natural')))
 
-    def get_drives_info(self) -> DList[Disk]:
+    def get_drives_info_for(self, cvg: int) -> DList[Disk]:
         machine_id = self.provider.get_machine_id()
-        cvgs_key: str = f'server_node>{machine_id}>storage>cvg'
-        for cvg in range(len(self.provider.get(cvgs_key))):
-            data_devs = self.get_data_devices(machine_id, cvg)
+        data_devs = self.get_data_devices(machine_id, cvg)
         return DList([self.get_drive_info_from_consul(dev_path)
                       for dev_path in data_devs.value], 'List Disk')
 


### PR DESCRIPTION
Hare mini provisioner generates cluster description file for a given
provisioner provided cluster description. A Motr container can have
multiple cvgs and thus start multiple ioservices per container. In
such a scenarios CDF generation is failing due to a bug where data
devices from more than 1 cvgs are not accounted.

Solution:
Account data devices from all the cvgs for a given motr ioservice.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>