### PR TITLE
EOS-25123: Start consul client agent in prepare and config stage

### DIFF
--- a/provisioning/miniprov/hare_mp/hax_starter.py
+++ b/provisioning/miniprov/hare_mp/hax_starter.py
@@ -63,14 +63,14 @@ class HaxStarter(StoppableThread):
             path += os.pathsep + '/opt/seagate/cortx/hare/libexec'
             python_path = os.pathsep.join(sys.path)
             cmd = ['hax']
-            self.process = \
-                execute_no_communicate(cmd,
-                                       env={'PYTHONPATH': python_path,
-                                            'PATH': path,
-                                            'LC_ALL': "en_US.utf-8",
-                                            'LANG': "en_US.utf-8"},
-                                       working_dir=self.home_dir,
-                                       out_file=LogWriter(LOG, fh))
+            self.process = execute_no_communicate(cmd,
+                                                  env={'PYTHONPATH':
+                                                       python_path,
+                                                       'PATH': path,
+                                                       'LC_ALL': "en_US.utf-8",
+                                                       'LANG': "en_US.utf-8"},
+                                                  working_dir=self.home_dir,
+                                                  out_file=LogWriter(LOG, fh))
             if self.process:
                 self.process.communicate()
         except Exception:


### PR DESCRIPTION
Hare need to upload configuration to consul in mini-provisioner prepare and
config stages respectively. Oblivious to consul cluster location a consul
client agent needs to be started locally to upload the relevant configuration
to Consul.

Solution:
Start and stop a Consul client agent in prepare and config stages to upload
the respective configuration to Consul.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>