### PR TITLE
hax: fix rpm build for ARM64 Motr port

### DIFF
--- a/hax/setup.py
+++ b/hax/setup.py
@@ -125,7 +125,7 @@ def get_motr_cflags():
 
     return [
         '-g', '-Werror', '-Wall', '-Wextra', '-Wno-attributes',
-        '-Wno-unused-parameter', '-include''config.h'''
+        '-Wno-unused-parameter', '-include\'config.h\''
     ]
 
 

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -125,7 +125,7 @@ def get_motr_cflags():
 
     return [
         '-g', '-Werror', '-Wall', '-Wextra', '-Wno-attributes',
-        '-Wno-unused-parameter'
+        '-Wno-unused-parameter', '-include''config.h'''
     ]
 
 


### PR DESCRIPTION
With the ARM64 Motr port, we are starting to check for
CONFIG_platform macro variable in the code, which is set at
Motr's config.h file. So we should explicitly include this file
via `-include'config.h'` gcc parameter from now on.

The change is compatible with the old Motr code.

See also https://github.com/Seagate/cortx-motr/pull/1086.