### PR TITLE
EOS-25125 Fetch local paths from confstore

### DIFF
--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -69,7 +69,7 @@ class ConsulStarter(StoppableThread):
                    f'-config-dir={self.config_dir}', '-domain=consul',
                    '-serf-lan-port=8301']
             for peer in self.peers:
-                cmd.append(f'-retry-join={peer}:8301')
+                cmd.append(f'-retry-join={peer}')
 
             self.process = execute_no_communicate(cmd,
                                                   working_dir=self.log_dir,

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -26,6 +26,7 @@ import os
 import logging
 from typing import List
 from distutils.dir_util import copy_tree
+import shutil
 
 from hax.util import repeat_if_fails, KVAdapter
 
@@ -142,6 +143,11 @@ class Utils:
 
         copy_tree(f'{conf_dir_path}/sysconfig/s3/{node_name}', dest_s3)
         copy_tree(f'{conf_dir_path}/sysconfig/motr/{node_name}', dest_motr)
+
+    def copy_consul_files(self, conf_dir_path: str):
+        shutil.copyfile(
+            f'{conf_dir_path}/consul-server-conf/consul-server-conf.json',
+            f'{conf_dir_path}/consul/config/consul-server-conf.json')
 
     def stop_hare(self):
         self.hare_stop = True

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -5,7 +5,7 @@
     {
       "type": "key",
       "key": "leader",
-      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader", "--conf-dir", "TMP_CONF_DIR" ]
     },
     {
       "type": "keyprefix",

--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -19,16 +19,36 @@
 
 set -eu -o pipefail
 
-#
-# This is the handler for RC Leader election.
-#
-# It creates the session with confd health check and
-# tries to acquire the leader lock with this session.
-#
-# Use it like this:
-#
-# $ consul watch -type=key -key leader elect-rc-leader
-#
+# set -x
+
+PROG=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: $PROG [<option>]
+Elect new RC leader
+Options:
+  -h, --help            Show this help and exit.
+  -c, --conf-dir        config dir where config files are present
+EOF
+}
+
+TEMP=$(getopt --options h: \
+              --longoptions help,conf-dir: \
+              --name "$PROG" -- "$@" || true)
+
+eval set -- "$TEMP"
+
+conf_dir=/var/lib/hare
+
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        -c|--conf-dir)       conf_dir=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   usage; exit ;;
+    esac
+done
 
 sudo mkdir -p /var/log/seagate/hare
 
@@ -52,7 +72,7 @@ get_node_name() {
     # script.
     # In non-hctl context, the scripts should use absolute path instead
     # when accessing scripts under hare/libexec/.
-    /opt/seagate/cortx/hare/libexec/node-name
+    /opt/seagate/cortx/hare/libexec/node-name --conf-dir $conf_dir
 }
 
 cleanup() {

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -190,6 +190,9 @@ else
     CONF_FILE=$conf_dir/consul-client-conf/consul-client-conf.json
 fi
 
+pwdesc=$(echo $conf_dir | sed 's_/_\\/_g')
+sed -i "s/TMP_CONF_DIR/$pwdesc/" $CONF_FILE
+
 SVCS_CONF=''
 
 append_hax_svc() {


### PR DESCRIPTION
Modified code to to fetch paths for consul and hax from confstore
Also modified code to get consul endpoints from confstore
Destroying leader session after consul start
Copying 'consul-server-conf.json' to '{hare_local_dir}/consul/config'' directory
Updating elect-rc-leader watcher entry in consul-server-conf.json to take config-dir as input

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>