### PR TITLE
fixup! hax: fix rpm build for ARM64 Motr port

### DIFF
--- a/hax/setup.py
+++ b/hax/setup.py
@@ -125,7 +125,7 @@ def get_motr_cflags():
 
     return [
         '-g', '-Werror', '-Wall', '-Wextra', '-Wno-attributes',
-        '-Wno-unused-parameter', '-include\'config.h\''
+        '-Wno-unused-parameter', '-include', 'config.h'
     ]
 
 


### PR DESCRIPTION
Fix the change at commit c8363d2: the `-include config.h`
compiler option was specified wrongly in the python list
of parameters, which resulted in compilation error:

    'config.h': No such file or directory

Solution: make `-include` and `config.h` a separate list
elements.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>