### PR TITLE
Privisioner exiting incase of warning or error message

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -150,7 +150,7 @@ def repeat_if_fails(wait_seconds=5, max_retries=-1):
                             'Function %s: Too many errors happened in a row '
                             '(max_retries = %d)', f.__name__, max_retries)
                         raise e
-                    LOG.warning(
+                    LOG.debug(
                         f'Got HAConsistencyException: {e.message} while '
                         f'invoking function {f.__name__} '
                         f'(attempt {attempt_count}). The attempt will be '

--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -79,6 +79,6 @@ class ConsulStarter(StoppableThread):
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:
-            LOG.exception('Stopping Consul')
+            LOG.debug('Stopping Consul')
             self.stop_event.set()
             self.utils.stop_hare()

--- a/provisioning/miniprov/hare_mp/hax_starter.py
+++ b/provisioning/miniprov/hare_mp/hax_starter.py
@@ -76,6 +76,6 @@ class HaxStarter(StoppableThread):
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:
-            LOG.exception('Stopping Hax')
+            LOG.debug('Stopping Hax')
             self.stop_event.set()
             self.utils.stop_hare()

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -223,7 +223,7 @@ def _start_consul(utils: Utils,
         sess = util.get_leader_session_no_wait()
         util.destroy_session(sess)
     except Exception:
-        logging.info('No leader is elected yet')
+        logging.debug('No leader is elected yet')
 
     return consul_starter
 


### PR DESCRIPTION
Following changes in provisoner code causing provisioner to terminate in case
hare prints error or warning message.
Seagate/cortx-prvsnr#6209

So changing them to debug

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>