### PR TITLE
Problem: systemd check in hare_setup start may not work

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -316,51 +316,12 @@ def init_with_bootstrap(args):
         raise RuntimeError(f'Error while initializing cluster :key={error}')
 
 
-def __is_systemd_enabled() -> bool:
-    try:
-        cmd = ['systemctl']
-        execute(cmd)
-    except Exception:
-        return False
-    return True
-
-
 def start_hax_with_systemd():
     cmd = ['systemctl', 'start', 'hare-hax']
     execute(cmd)
 
 
-# def start_hax_without_systemd():
-#     try:
-#         path = os.getenv('PATH', '')
-#         path += os.pathsep + '/opt/seagate/cortx/hare/bin'
-#         path += os.pathsep + '/opt/seagate/cortx/hare/libexec'
-#         python_path = os.pathsep.join(sys.path)
-#         hare_log_file = '/var/log/seagate/hare/cortx-hare.log'
-#         var_hax_path = '/var/motr/hax'
-#         if not os.path.exists(var_hax_path):
-#             os.makedirs(var_hax_path)
-#         logger = logging.getLogger('hax-log')
-#         fhandler = logging.handlers.RotatingFileHandler(hare_log_file,
-#                                                         maxBytes=LOG_FILE_SIZE,
-#                                                         mode='a',
-#                                                         backupCount=5,
-#                                                         encoding=None,
-#                                                         delay=False)
-#         logger.addHandler(fhandler)
-#         cmd = ['hax']
-#         execute_no_communicate(cmd, env={'PYTHONPATH': python_path,
-#                                          'PATH': path,
-#                                          'LC_ALL': "en_US.utf-8",
-#                                          'LANG': "en_US.utf-8"},
-#                                working_dir=var_hax_path,
-#                                out_file=LogWriter(logger, fhandler))
-#     except Exception as error:
-#         raise RuntimeError(f'Error while initializing cluster :key={error}')
-
-
-def start_hax_and_consul_without_systemd(utils: Utils,
-                                         url: str):
+def start_hax_and_consul_without_systemd(url: str, utils: Utils):
     conf_dir = get_config_dir(url)
     # Event on which hare receives a notification in case consul agent or hax
     # terminates.
@@ -376,13 +337,13 @@ def start_hax_and_consul_without_systemd(utils: Utils,
 def start(args):
     url = args.config[0]
     utils = Utils(ConfStoreProvider(url))
-    if __is_systemd_enabled():
+    if args.systemd:
         start_hax_with_systemd()
     else:
         # This is a blocking call and will block until either consul
         # or hax process terminates.
         # TODO: Check if the respective processes need to be restarted.
-        start_hax_and_consul_without_systemd(utils, url)
+        start_hax_and_consul_without_systemd(url, utils)
 
 
 def start_mkfs(hostname: str, hare_config_dir: str):
@@ -873,6 +834,16 @@ def add_service_argument(parser):
     return parser
 
 
+def add_systemd_argument(parser):
+    parser.add_argument('--systemd',
+                        help="""Start Hare servies using systemd interface,
+                        by default start command assumes systemd interface
+                        is not enebaled""",
+                        required=False,
+                        action='store_true')
+    return parser
+
+
 def main():
     inject.configure(di_configuration)
     p = argparse.ArgumentParser(description='Configure hare settings')
@@ -905,12 +876,13 @@ def main():
                            help_str='Initializes Hare',
                            handler_fn=init)))
 
-    add_service_argument(
-        add_file_argument(
-            add_subcommand(subparser,
-                           'start',
-                           help_str='Starts Hare services',
-                           handler_fn=start)))
+    add_systemd_argument(
+        add_service_argument(
+            add_file_argument(
+                add_subcommand(subparser,
+                               'start',
+                               help_str='Starts Hare services',
+                               handler_fn=start))))
 
     add_service_argument(
         add_param_argument(


### PR DESCRIPTION
hare_setup start command checks if systemd is enabled and accordigly
decides to start hax and consul without or with systemd. But,
hare_setup does not start consul in case systemd is enabled in the
containers.

Solution:
Instead of checking systemd internally in hare_setup start command,
take an explicit option to specifiy if hare_setp start is being executed
in environment with or without systemd.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>