### PR TITLE
EOS-24408: Integration of Hare Mini provisioner - support to F-87A 

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -348,10 +348,7 @@ def start(args):
 
 def start_mkfs(hostname: str, hare_config_dir: str):
     # TODO: path needs to be updated according to the new conf-store key
-    motr_config_dir = '/etc/motr'
     sysconfig_dir = '/etc/sysconfig/'
-    os.makedirs(motr_config_dir, exist_ok=True)
-    shutil.copy(f'{hare_config_dir}/confd.xc', motr_config_dir)
     src = f'{hare_config_dir}/sysconfig/motr/{hostname}'
     for file in os.listdir(src):
         shutil.copy(os.path.join(src, file), sysconfig_dir)
@@ -715,13 +712,15 @@ def save(filename: str, contents: str) -> None:
 
 
 def generate_config(url: str, path_to_cdf: str) -> None:
-    utils = Utils(ConfStoreProvider(url))
+    provider = ConfStoreProvider(url)
+    utils = Utils(provider)
     conf_dir = get_config_dir(url)
     path = os.getenv('PATH')
     if path:
         path += os.pathsep + '/opt/seagate/cortx/hare/bin/'
     python_path = os.pathsep.join(sys.path)
-    cmd = ['configure', '-c', conf_dir, path_to_cdf]
+    cmd = ['configure', '-c', conf_dir, path_to_cdf,
+           '--uuid', provider.get_machine_id()]
     execute(cmd, env={'PYTHONPATH': python_path, 'PATH': path,
                       'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
     utils.copy_conf_files(conf_dir)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -144,6 +144,10 @@ class Utils:
         copy_tree(f'{conf_dir_path}/sysconfig/s3/{node_name}', dest_s3)
         copy_tree(f'{conf_dir_path}/sysconfig/motr/{node_name}', dest_motr)
 
+        shutil.copyfile(
+            f'{conf_dir_path}/confd.xc',
+            f'{dest_motr}/confd.xc')
+
     def copy_consul_files(self, conf_dir_path: str):
         shutil.copyfile(
             f'{conf_dir_path}/consul-server-conf/consul-server-conf.json',

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -33,11 +33,13 @@ usage() {
 Usage: . $PROG [-n | --dry-run]
          $PROG [<option>]... --conf-dir <dir>
          $PROG [<option>]... --kv-file <dir>
+         $PROG [<option>]... --uuid <str>
 
 Positional arguments:
   --conf-dir <dir>  Configuration directory path to read configuration
                     from or write to.
   --kv-file <kv>    Hare-Motr configuration key values file path.
+  --uuid <str>      UUID to be used to write in sysconfig file
 
 Create Consul agent configuration file.
 
@@ -48,7 +50,7 @@ EOF
 }
 
 TEMP=$(getopt --options hns: \
-              --longoptions help,dry-run,conf-dir:,kv-file: \
+              --longoptions help,dry-run,conf-dir:,kv-file:,uuid: \
               --longoptions server \
               --name "$PROG" -- "$@" || true)
 
@@ -60,6 +62,7 @@ conf_dir=/var/lib/hare
 kv_file=/var/lib/hare/consul-kv.json
 dry_run=false
 server=false
+uuid=
 
 while true; do
     case "$1" in
@@ -67,6 +70,7 @@ while true; do
         -c|--conf-dir)       conf_dir=$2; shift 2 ;;
         -k|--kv-file)        kv_file=$2; shift 2 ;;
         -s|--server)         server=true; shift ;;
+        --uuid)              uuid=$2; shift 2 ;;
         --dry-run)           dry_run=true; shift ;;
         --)                  shift; break ;;
         *)                   break ;;
@@ -75,6 +79,12 @@ done
 
 if [[ -z $conf_dir ]]; then
     conf_dir=/etc
+fi
+
+if [[ -z $uuid ]]; then
+    UUID=$(uuidgen --time)
+else
+    UUID=$uuid
 fi
 
 [[ -d $conf_dir ]] || die "'--conf-dir' argument is not a directory"
@@ -219,8 +229,6 @@ append_hax_svc() {
         ]
     }"
 }
-
-UUID=$(uuidgen --time)
 
 append_confd_svc() {
     local id=$1


### PR DESCRIPTION
In provioner environment, currently UUID is being generated by
hare code before writing it into sysconfig files.
But according to motr requirement we should use 'machine_id' as UUID

As a solution :
Use machine_id as uuid, if specified as option
if not specified then generate it.

Also added code for copying confd.xc at $local/motr/sysconfig/<machine-id>/
For e.g. /etc/cortx/motr/sysconfig/<machine-id>/confd.xc

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>

**Test**

Tested config method and sysconfig files are getting generated by using machine-id as UUID
Also tested bootstrap and in that case UUID is randomly generated

[root@ssc-vm-6327 hare]# /opt/seagate/cortx/hare/bin/hare_setup config --config yaml:///tmp/e24393/single_node_confstore.yaml
[root@ssc-vm-6327 hare]# cat /etc/machine-id
85fffa84fee1b12b46bcfc7cc491e602
[root@ssc-vm-6327 hare]# cat /etc/cortx/motr/sysconfig/85fffa84fee1b12b46bcfc7cc491e602/m0d-0x7200000000000001\:0x16
MOTR_M0D_EP='inet:tcp:ssc-vm-6327.colo.seagate.com@3002'
MOTR_HA_EP='inet:tcp:ssc-vm-6327.colo.seagate.com@2001'
MOTR_PROCESS_FID='0x7200000000000001:0x16'
MOTR_CONF_XC='/etc/motr/confd.xc'
MOTR_NODE_UUID='85fffa84fee1b12b46bcfc7cc491e602'