### PR TITLE
Problem: linters not run over helper module

### DIFF
--- a/hax/setup.py
+++ b/hax/setup.py
@@ -41,7 +41,7 @@ class MypyCmd(Command):
         pass
 
     def run(self):
-        report, errors, exit_code = api.run(['hax'])
+        report, errors, exit_code = api.run(['hax', 'helper'])
 
         if report:
             self.announce(report, level=INFO)


### PR DESCRIPTION
This means that even if there is a problem that mypy or flake8 could
have found and highlight during the build, these errors are not seen and
the build green even when there are obvious problems (like missing
positional argument).

Solution: add 'helper' module explicitly to `setup.py hax` CLI call. Fix
existing problems in helper module.
