### PR TITLE
hax: fix panic at link_disconnected_cb()

### DIFF
--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -45,9 +45,15 @@ struct hax_context {
 	bool                       hc_rconfc_initialized;
 };
 
+enum {
+	EP_ADDR_BUF_SIZE = 64
+};
+
 struct hax_link {
 	struct m0_ha_link *hxl_link;
 	struct m0_tlink    hxl_tlink;
+	struct m0_uint128  hxl_req_id;
+	char               hxl_ep_addr[EP_ADDR_BUF_SIZE];
 	uint64_t           hxl_magic;
 	bool               hxl_is_active;
 };


### PR DESCRIPTION
Fix use after free panic at link_disconnected_cb() - the
rpc connection might be already freed by the time the callback
is called, so we cannot use it to figure out the endpoint
address. Here is the panic sample:

    motr[29162]:  6700   WARN  [ha/halon/interface.c:537:halon_interface_link_disconnected_cb]  hl=0x7f5dfc55d690 ep=172.18.1.25@o2ib:12345:4:1
    motr[29162]:  60c0  FATAL  [lib/assert.c:50:m0_panic]  panic: fatal signal delivered at unknown() (unknown:0)  [git: 2.0.0-307-11-gcacd425] /var/motr/hax/m0trace.29162
    Motr panic: fatal signal delivered at unknown() unknown:0 (errno: 0) (last failed: none) [git: 2.0.0-307-11-gcacd425] pid: 29162  /var/motr/hax/m0trace.29162
    Motr panic reason: signo: 11
    /lib64/libmotr.so.2(m0_arch_backtrace+0x2f)[0x7f5e1404540f]
    /lib64/libmotr.so.2(m0_arch_panic+0xf3)[0x7f5e140455f3]
    /lib64/libmotr.so.2(+0x353684)[0x7f5e14035684]
    /lib64/libmotr.so.2(+0x363638)[0x7f5e14045638]
    /lib64/libpthread.so.0(+0xf630)[0x7f5e239fb630]
    /lib64/libmotr.so.2(m0_rpc_conn_addr+0xb)[0x7f5e140bb50b]
    /opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/motr/../../libhax.cpython-36m-x86_64-linux-gnu.so(+0x4378)[0x7f5e14685378]
    /lib64/libmotr.so.2(+0x33850f)[0x7f5e1401a50f]
    /lib64/libmotr.so.2(+0x32e4bd)[0x7f5e140104bd]
    /lib64/libmotr.so.2(+0x354b87)[0x7f5e14036b87]
    /lib64/libmotr.so.2(+0x354bda)[0x7f5e14036bda]
    /lib64/libmotr.so.2(+0x3f0c59)[0x7f5e140d2c59]
    /lib64/libmotr.so.2(+0x33278b)[0x7f5e1401478b]
    /lib64/libmotr.so.2(+0x32541b)[0x7f5e1400741b]
    /lib64/libmotr.so.2(m0_thread_trampoline+0x5e)[0x7f5e1403bdfe]

Some more details about the stack:

    (gdb) l *(m0_rpc_conn_addr+0xb)
    0x3d950b is in m0_rpc_conn_addr (rpc/conn.c:1308).
    1303		return 0;
    1304	}
    1305
    1306	M0_INTERNAL const char *m0_rpc_conn_addr(const struct m0_rpc_conn *conn)
    1307	{
    1308		return conn->c_rpcchan->rc_destep->nep_addr;
    1309	}
    1310
    1311	M0_INTERNAL bool m0_rpc_conn_is_known_dead(const struct m0_rpc_conn *conn)
    1312	{

    (gdb) l *(+0x4378)
    0x4378 is in link_disconnected_cb (hax/motr/hax.c:617).
    612		M0_LOG(M0_DEBUG, "disconnected ha link to %s",
    613			m0_rpc_conn_addr(&link->hln_rpc_link.rlk_conn));
    614		hax_lock(hc0);
    615		m0_tl_for(hx_links, &hc0->hc_links, hxl) {
    616			hxl_ep = m0_rpc_conn_addr(&hxl->hxl_link->hln_rpc_link.rlk_conn);
    617	                hl_ep = m0_rpc_conn_addr(&link->hln_rpc_link.rlk_conn);
    618			if (m0_streq(hxl_ep, hl_ep)) {
    619				hxl_out = hxl;
    620				break;
    621			}

    (gdb) l *(+0x33850f)
    0x33850f is in halon_interface_link_disconnected_cb (ha/halon/interface.c:539).
    534		m0_ha_rpc_endpoint(&hii->hii_ha, hl, buf, ARRAY_SIZE(buf));
    535		M0_ENTRY("hii=%p ha=%p hl=%p ep=%s", hii, ha, hl, ep);
    536		if (hii->hii_cfg.hic_log_link)
    537			M0_LOG(M0_WARN, "hl=%p ep=%s", hl, ep);
    538		hii->hii_cfg.hic_link_disconnected_cb(hii->hii_hi, hl);
    539		M0_LEAVE("hii=%p ha=%p hl=%p ep=%s", hii, ha, hl, ep);
    540	}
    541
    542	static const struct m0_ha_ops halon_interface_ha_ops = {
    543		.hao_entrypoint_request    = &halon_interface_entrypoint_request_cb,
    (gdb) l *(+0x32e4bd)
    0x32e4bd is in ha_link_event_cb (ha/ha.c:151).
    146					hao_link_is_disconnecting(ha, &hlx->hlx_link);
    147			}
    148			break;
    149		case M0_HA_LINK_STATE_STOP:
    150			if (hlx != ha->h_link_ctx) {
    151				ha->h_cfg.hcf_ops.hao_link_disconnected(ha,
    152									&hlx->hlx_link);
    153			}
    154			break;
    155		default:
    (gdb) l *(+0x354b87)
    0x354b87 is in clink_signal (lib/chan.c:135).
    130		if (clink->cl_is_oneshot)
    131			m0_clink_del(clink);
    132		if (clink->cl_cb != NULL) {
    133			m0_enter_awkward();
    134			if (ca == NULL)
    135				consumed = clink->cl_cb(clink);
    136			else
    137				M0_ADDB2_HIST(ca->ca_cb, &ca->ca_cb_hist,
    138					      m0_ptr_wrap(clink->cl_cb),
    139					      consumed = clink->cl_cb(clink));
    (gdb) l *(+0x354bda)
    0x354bda is in chan_signal_nr (lib/chan.c:151).
    146	static void chan_signal_nr(struct m0_chan *chan, uint32_t nr)
    147	{
    148		struct m0_clink *clink;
    149
    150		M0_PRE_EX(m0_chan_is_locked(chan) && m0_chan_invariant(chan));
    151		while (nr-- > 0 &&
    152		       (clink = clink_tlist_head(&chan->ch_links)) != NULL) {
    153			clink_tlist_move_tail(&chan->ch_links, clink);
    154			clink_signal(clink);
    155		}
    (gdb) l *(+0x3f0c59)
    0x3f0c59 is in state_set (sm/sm.c:461).
    456			sd = sm_state(mach);
    457			state = sd->sd_in != NULL ? sd->sd_in(mach) : -1;
    458			m0_chan_broadcast(&mach->sm_chan);
    459		} while (state >= 0);
    460
    461		M0_POST(m0_sm_invariant(mach));
    462	}
    463
    464	M0_INTERNAL void m0_sm_fail(struct m0_sm *mach, int fail_state, int32_t rc)
    465	{
    (gdb) l *(+0x33278b)
    0x33278b is in ha_link_outgoing_fom_tick (ha/link.c:1417).
    1412				(void)ha_link_q_in_confirm_all(hl);
    1413				m0_mutex_unlock(&hl->hln_lock);
    1414				ha_link_msg_recv_or_delivery_broadcast(hl);
    1415				m0_sm_group_lock(&hl->hln_sm_group);
    1416				m0_sm_state_set(&hl->hln_sm, M0_HA_LINK_STATE_STOP);
    1417				m0_sm_group_unlock(&hl->hln_sm_group);
    1418				m0_mutex_lock(&hl->hln_lock);
    1419				if (hl->hln_reconnect_cfg_is_set) {
    1420					ha_link_conn_cfg_free(
    1421					                &hl->hln_conn_reconnect_cfg);
    (gdb) l *(+0x32541b)
    0x32541b is in loc_handler_thread (fop/fom.c:793).
    788		do {
    789			M0_ASSERT(m0_fom_invariant(fom));
    790			M0_ASSERT(m0_fom_phase(fom) != M0_FOM_PHASE_FINISH);
    791			rc = fom->fo_ops->fo_tick(fom);
    792			if (FOM_PHASE_DEBUG) {
    793				fom->fo_log[fom->fo_transitions %
    794					    ARRAY_SIZE(fom->fo_log)] =
    795					m0_fom_phase(fom);
    796			}
    797			/*

Here is the snippet from the m0trace log of hax about the rpc
connection which shows that it was already freed by the time
the disconnected callback was called:

    2761670  36913913.185.494104  7f5e03ff6ca0  CALL    rpc/conn.c:533:m0_rpc_rcv_conn_init   > conn: 0x7f5dfc27dfb0, ep_addr: 172.18.1.25@o2ib:12345:4:1, machine: 0x15a9828
    ...
    2764088  36913913.699.522104  7f5d659c1900  CALL    rpc/conn.c:502:__conn_fini   > conn: 0x7f5dfc27dfb0
    2764092  36913913.699.529732  7f5d659c1900  INFO    rpc/conn.c:174:conn_state_set   0x7f5dfc27dfb0[RECEIVER] Terminated -> Finalised
    2764093  36913913.699.531544  7f5d659c1950  INFO    rpc/conn.c:677:m0_rpc_conn_fini_locked   0x7f5dfc27dfb0 FINALISED
    2764095  36913913.699.532984  7f5d659c19a0  DEBUG   lib/memory.c:150:m0_free   0x7f5dfc27dfb0
    ...
    2769729  36913925.182.126942  7f5e03ff6700  WARN    ha/halon/interface.c:537:halon_interface_link_disconnected_cb   hl=0x7f5dfc55d690 ep=172.18.1.25@o2ib:12345:4:1
    2769731  36913925.182.201554  7f5e03ff60c0  FATAL   lib/assert.c:50:m0_panic   panic: fatal signal delivered at unknown() (unknown:0)  [git: 2.0.0-307-11-gcacd425] /var/motr/hax/m0trace.29162

Solution: don't use the address to find the hx_link in the
hx_links - use the ha_link address directly for this. It's
simpler and faster also.

Also, get rid of m0_rpc_conn_addr() usage - it's not safe.
Get the endpoint address on the 1st entrypoint_request_cb()
call, store it at hax_link and use it from there.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>
(cherry picked from commit ad2739e69683a18e6b9ba1af3eed7e80a8c2b043)