### PR TITLE
EOS-25289: nvec request processing takes too much time

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -109,8 +109,8 @@ class ConsumerThread(StoppableThread):
                     if (self.consul.get_process_local_status(
                             state.fid) == 'M0_CONF_HA_PROCESS_STARTED'):
                         continue
-                if current_status in (ServiceHealth.FAILED,
-                                      ServiceHealth.STOPPED):
+                elif current_status in (ServiceHealth.FAILED,
+                                        ServiceHealth.STOPPED):
                     if (self.consul.get_process_local_status(
                             state.fid) == 'M0_CONF_HA_PROCESS_STOPPED'):
                         # Consul may report failure of a process multiple
@@ -118,7 +118,7 @@ class ConsumerThread(StoppableThread):
                         # notifications, it may cause delay in cleanup
                         # activities.
                         continue
-                if current_status == ServiceHealth.UNKNOWN:
+                elif current_status == ServiceHealth.UNKNOWN:
                     # We got service status as UNKNOWN, that means hax was
                     # notified about process failure but hax couldn't
                     # confirm if the process is in failed state or have

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -172,7 +172,6 @@ class Motr:
             git_rev=git_rev,
             pid=pid,
             is_first_request=is_first_request)
-
         # If rconfc from motr land sends an entrypoint request when
         # the hax consumer thread is already stopping, there's no
         # point in en-queueing the request as there's no one to process
@@ -371,7 +370,7 @@ class Motr:
                   len(event.nvec))
         notes: List[HaNoteStruct] = []
         for n in event.nvec:
-            n.note.no_state = self.consul_util.get_conf_obj_status(
+            n.note.no_state = self.consul_util.get_conf_obj_status_online(
                 ObjT[n.obj_t], n.note.no_id.f_key)
             notes.append(n.note)
 

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -546,6 +546,28 @@ class ConsulUtil:
                 return True
         return False
 
+    # Presently nvec processing is taking significant time causing motr
+    # and s3 processes to timeout and fail. This nvec processing time
+    # needs to be re-visited. Meanwhile, this is a purely happy path
+    # function where instead of fetching the real object status from
+    # Consul, Hax will return online for all the configuration objects
+    # for which the status for requested. This function is invoked
+    # only during process startup and not in a runtime path. Thus
+    # Runtime state changes are not affected by this. But this affects
+    # dgread post node failure as a motr client starting with an existing
+    # node failure will not be able to start and it will receive an online
+    # status for a failed node and will keep trying to connect to the
+    # node.
+    # We are not checking node status here because node status depends
+    # on Consul agent being started and running on that node, thus in
+    # case of containers, hax container may start after motr processes
+    # which may result in node status reported as not passing, this
+    # may report invalid conf object status. Thus nvec processing must
+    # be optimized for such scenarios.
+    @repeat_if_fails()
+    def get_conf_obj_status_online(self, obj_t: ObjT, fidk: int) -> int:
+        return HaNoteStruct.M0_NC_ONLINE
+
     @repeat_if_fails()
     def get_conf_obj_status(self, obj_t: ObjT, fidk: int) -> int:
 


### PR DESCRIPTION
Motr and s3server processes on startup requests cluster state from hare
via ha nvec requests. Hare saves an augmented state of the cluster objects
in Consul KV store. Number of cluster objects can easily go in hundreds,
Hare in-order to fetch the latest state of these objects sends multiple
requests to Consul, multilply the number of requests by the number of
motr and s3server processes running on the node. All this adds to the
delay of nvec processing. Nvec processing needs to be optimized to
prevent processes from timing out during initialization.
This interim fix that avoids nvec processing by returning always
online dummy state proves the problem in the nvec processing as the
cluster with multiple processes bootstraps successfully.

Solution:
As an interim solution, reply always online state of the requested
cluster configuration object.
Note that nvec requests are presently sent only during process startup
and runtime state of the cluster is not affected.
Also note that with this patch, dgread from a motr client that starts
post node failure will fail.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>