### PR TITLE
Provision for enable-disable aux pools for kubernetes

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2277,7 +2277,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                             disks.append(DiskRef(path=d,
                                                  node=node['hostname']))
 
-            aux_pool_list(pool, disks, conf)
+            if cluster_desc.get('create_aux'):
+                aux_pool_list(pool, disks, conf)
         else:
             ConfPool.build(conf, root_id, pool)
 

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -25,7 +25,8 @@ let Node = ./NodeDesc.dhall
 let Pool = ./PoolDesc.dhall
 
 in
-{ nodes : List Node
+{ create_aux : Optional Bool
+, nodes : List Node
 , pools : List Pool
 , profiles : Optional (List ./PoolsRef.dhall)
 , fdmi_filters: Optional (List ./FdmiFilterDesc.dhall)

--- a/cfgen/dhall/types/PoolsRef.dhall
+++ b/cfgen/dhall/types/PoolsRef.dhall
@@ -18,6 +18,7 @@
 
 -}
 
-{ name : Text
+{ create_aux : Optional Bool
+, name : Text
 , pools : List Text
 }

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -1,6 +1,7 @@
 # Cluster Description File (CDF).
 # See `cfgen --help-schema` for the format description.
 
+create_aux: false  # optional; supported values: "false" (default), "true"
 nodes:
   - hostname: localhost     # [user@]hostname
     data_iface: eth1        # name of data network interface

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -22,7 +22,8 @@ let Prelude = ../dhall/Prelude.dhall
 let types = ../dhall/types.dhall
 
 in
-{ nodes =
+{ create_aux = Some False
+, nodes =
     [ { hostname = "localhost"
       , data_iface = "eth1"
       , data_iface_type = None types.Protocol


### PR DESCRIPTION

Solution:
Added new variable in CDF: "create_aux" and depending on provided configuration we should be able to generate correct
combinations of aux pools.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>