### PR TITLE
EOS-25053: Provision for enable-disable aux pools for kubernetes

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -153,6 +153,7 @@ class ShowSchema(argparse.Action):
         print("""\
 # Cluster Description is a YAML file with the following schema:
 ---  # start of the document (optional)
+create_aux: <bool> # optional, defaults to false if not present in CDF
 nodes:
   - hostname: <str>    # [user@]hostname; e.g., localhost, pod-c1
     data_iface: <str>  # name of network interface; e.g., eth1, eth1:c1
@@ -1271,7 +1272,8 @@ def pool_type(pool_desc: Dict[str, Any]) -> PoolT:
 
 
 def pool_drives(m0conf: Dict[Oid, Any],
-                pool_desc: Dict[str, Any]) -> List[Oid]:
+                pool_desc: Dict[str, Any],
+                cluster_desc: Dict[str, Any]) -> List[Oid]:
     ptype = pool_type(pool_desc)
 
     if ptype is PoolT.dix:
@@ -1328,6 +1330,18 @@ def pool_drives(m0conf: Dict[Oid, Any],
     for drive_id, node_id in drives:
         if m0conf[drive_id].pvers:  # already assigned to some pool
             over_referenced.setdefault(node_id, []).append(drive_id)
+
+    create_aux_val = cluster_desc.get('create_aux')
+    if not create_aux_val:
+        if over_referenced:
+            err = '{} referred to by several pools:'.format(
+                'This disk is' if len(over_referenced) == 1 else
+                'These disks are')
+            for node_id in sorted(over_referenced):
+                err += '\n  ' + m0conf[node_id].name
+                for drive_id in sorted(over_referenced[node_id]):
+                    err += '\n   \\_ ' + m0conf[m0conf[drive_id].sdev].filename
+            raise AssertionError(err)
 
     return [drive_id for drive_id, _ in drives]
 
@@ -1418,7 +1432,8 @@ class ConfPool(ToDhall):
 
     @classmethod
     def gen_sns_tolerance(cls, m0conf: Dict[Oid, Any],
-                          pool_desc: Dict[str, Any]) -> Failures:
+                          pool_desc: Dict[str, Any],
+                          cluster_desc: Dict[str, Any]) -> Failures:
         encls_nr = len(cluster_encls(m0conf))
         ctrls_per_encl = floor(len(cluster_ctrls(m0conf)) / encls_nr)
         data_units = pool_desc['data_units']
@@ -1427,7 +1442,7 @@ class ConfPool(ToDhall):
         total_units = data_units + parity_units + spare_units
         fault_tol_info = drives_per_node_and_ctrl(m0conf)
         min_pool_width = fault_tol_info.min_drives_per_node * encls_nr
-        actual_pool_width = len(pool_drives(m0conf, pool_desc))
+        actual_pool_width = len(pool_drives(m0conf, pool_desc, cluster_desc))
         if ((min_pool_width < actual_pool_width) and
                 (min_pool_width / total_units) > 0):
             # Pool is asymmetric, all the nodes don't have same number of
@@ -1458,7 +1473,8 @@ class ConfPool(ToDhall):
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
-              pool_desc: Dict[str, Any]) -> Oid:
+              pool_desc: Dict[str, Any],
+              cluster_desc: Dict[str, Any]) -> Oid:
         assert parent.type is ObjT.root
 
         pool_id = new_oid(ObjT.pool)
@@ -1473,7 +1489,7 @@ class ConfPool(ToDhall):
         if spare_units is None:
             spare_units = pool_desc.get('parity_units')
 
-        drives = pool_drives(m0conf, pool_desc)
+        drives = pool_drives(m0conf, pool_desc, cluster_desc)
         t = pool_type(pool_desc)
         assert ('data_units' in pool_desc) == ('parity_units' in pool_desc)
         if 'data_units' in pool_desc:
@@ -1505,7 +1521,8 @@ class ConfPool(ToDhall):
                 if t == PoolT.dix:
                     tolerance = ConfPool.gen_md_tolerance(m0conf, pool_desc)
                 else:
-                    tolerance = ConfPool.gen_sns_tolerance(m0conf, pool_desc)
+                    tolerance = ConfPool.gen_sns_tolerance(m0conf, pool_desc,
+                                                           cluster_desc)
         else:
             tolerance = ConfPool.gen_md_tolerance(m0conf, pool_desc)
 
@@ -2050,7 +2067,8 @@ def get_pool_diskrefs(pool_desc: Dict[str, Any]):
 
 def aux_pool_list(pool_desc: Dict[str, Any],
                   disks: List[DiskRef],
-                  m0conf: Dict[Oid, Any]) -> None:
+                  m0conf: Dict[Oid, Any],
+                  cluster_desc: Dict[str, Any]) -> None:
     pool = pool_desc
 
     # Example of encl_ref_combination :
@@ -2097,7 +2115,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
         tolerance = Failures(d['site'], d['rack'], d['encl'],
                              d['ctrl'], d['disk'])
     else:
-        tolerance = ConfPool.gen_sns_tolerance(m0conf, pool)
+        tolerance = ConfPool.gen_sns_tolerance(m0conf, pool, cluster_desc)
     # Generate the node combinations considering node failures as
     # allowed by node tolerance values
     temp_pool_nodes = []
@@ -2189,43 +2207,51 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                 proc_id = ConfProcess.build(conf, node_id, node, proc_t)
                 cluster.m0_clients[proc_id] = new_oid(ObjT.service)
 
-    for pool in cluster_desc['pools']:
-        pool_t = pool_type(pool)
-        if pool_t == PoolT.sns:
-            # For SNS pools create the aux pool list
-            disks: List[DiskRef] = []
-            # We need to generate disk_refs only if it is not present
-            # in pool description
-            if not get_pool_diskrefs(pool):
-                for node in cluster_desc['nodes']:
-                    for m0d in node['m0_servers']:
-                        if m0d['runs_confd']:
-                            continue
-                        for d in m0d['io_disks']['data']:
-                            disks.append(DiskRef(path=d,
-                                                 node=node['hostname']))
+    create_aux_val = cluster_desc.get('create_aux')
+    if not create_aux_val:
+        for pool in cluster_desc['pools']:
+            ConfPool.build(conf, root_id, pool, cluster_desc)
+    else:
+        for pool in cluster_desc['pools']:
+            pool_t = pool_type(pool)
+            if pool_t == PoolT.sns:
+                # For SNS pools create the aux pool list
+                disks: List[DiskRef] = []
+                # We need to generate disk_refs only if it is not present
+                # in pool description
+                if not get_pool_diskrefs(pool):
+                    for node in cluster_desc['nodes']:
+                        for m0d in node['m0_servers']:
+                            if m0d['runs_confd']:
+                                continue
+                            for d in m0d['io_disks']['data']:
+                                disks.append(DiskRef(path=d,
+                                                     node=node['hostname']))
 
-            aux_pool_list(pool, disks, conf)
-        else:
-            ConfPool.build(conf, root_id, pool)
+                aux_pool_list(pool, disks, conf, cluster_desc)
+            else:
+                ConfPool.build(conf, root_id, pool, cluster_desc)
 
-    for pool in itertools.chain(cluster_desc['pools'],
-                                *aux_pools.values()):
-        pool_t = pool_type(pool)
-        if pool_t == PoolT.sns:
-            ConfPool.build(conf, root_id, pool)
+        for pool in itertools.chain(cluster_desc['pools'],
+                                    *aux_pools.values()):
+            pool_t = pool_type(pool)
+            if pool_t == PoolT.sns:
+                ConfPool.build(conf, root_id, pool, cluster_desc)
 
     if conf[root_id].imeta_pver is None:  # no DIX pool defined in the CDF
-        ConfPool.build(conf, root_id, {'type': 'dix'})
+        ConfPool.build(conf, root_id, {'type': 'dix'}, cluster_desc)
 
     if conf[root_id].mdpool is None:  # no Metadata pool defined in the CDF
-        ConfPool.build(conf, root_id, {'type': 'md'})
+        ConfPool.build(conf, root_id, {'type': 'md'}, cluster_desc)
 
     for prof in cluster_desc['profiles']:
-        prof['pools'] += [aux_pool['name']
-                          for pool_name in prof['pools']
-                          for aux_pool in aux_pools.get(pool_name, [])]
-        ConfProfile.build(conf, root_id, prof)
+        if not create_aux_val:
+            ConfProfile.build(conf, root_id, prof)
+        else:
+            prof['pools'] += [aux_pool['name']
+                              for pool_name in prof['pools']
+                              for aux_pool in aux_pools.get(pool_name, [])]
+            ConfProfile.build(conf, root_id, prof)
 
     validate_m0conf(conf)
     assert cluster.consul_servers

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -25,7 +25,8 @@ let Node = ./NodeDesc.dhall
 let Pool = ./PoolDesc.dhall
 
 in
-{ nodes : List Node
+{ create_aux : Optional Bool
+, nodes : List Node
 , pools : List Pool
 , profiles : Optional (List ./PoolsRef.dhall)
 }

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -1,6 +1,7 @@
 # Cluster Description File (CDF).
 # See `cfgen --help-schema` for the format description.
 
+create_aux: false # optional; supported values: "false" (default), "true"
 nodes:
   - hostname: localhost     # [user@]hostname
     data_iface: eth1        # name of data network interface

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -22,7 +22,8 @@ let Prelude = ../dhall/Prelude.dhall
 let types = ../dhall/types.dhall
 
 in
-{ nodes =
+{ create_aux = Some False
+, nodes =
     [ { hostname = "localhost"
       , data_iface = "eth1"
       , data_iface_type = None types.Protocol

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -237,12 +237,18 @@ class CdfGenerator:
 
     def _get_cdf_dhall(self) -> str:
         dhall_path = self._get_dhall_path()
+        conf = self.provider
         nodes = self._create_node_descriptions()
         pools = self._create_pool_descriptions()
         profiles = self._create_profile_descriptions(pools)
+        create_aux = conf.get('cluster>create_aux',
+                              allow_null=True)
+        if create_aux is None:
+            create_aux = False
 
         params_text = str(
-            ClusterDesc(node_info=DList(nodes, 'List NodeInfo'),
+            ClusterDesc(create_aux=Maybe(create_aux, 'Bool'),
+                        node_info=DList(nodes, 'List NodeInfo'),
                         pool_info=DList(pools, 'List PoolInfo'),
                         profile_info=DList(profiles, 'List ProfileInfo')))
         gencdf = Template(self._gencdf()).substitute(path=dhall_path,

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -57,7 +57,8 @@ let ProfileInfo =
       }
 
 let ClusterInfo =
-      { node_info: List NodeInfo
+      { create_aux : Optional Bool
+      , node_info: List NodeInfo
       , pool_info: List PoolInfo
       , profile_info: List ProfileInfo
       }
@@ -90,7 +91,8 @@ let toPoolDesc
 let genCdf
     : ClusterInfo -> T.ClusterDesc
     =     \(cluster_info : ClusterInfo)
-      ->  { nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
+      ->  { create_aux = cluster_info.create_aux
+          , nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
           , pools = Prelude.List.map PoolInfo T.PoolDesc toPoolDesc cluster_info.pool_info
           , profiles = Some cluster_info.profile_info
           }

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -156,6 +156,7 @@ class ProfileDesc(DhallTuple):
 
 @dataclass(repr=False)
 class ClusterDesc(DhallTuple):
+    create_aux: Maybe[bool]
     node_info: DList[NodeDesc]
     pool_info: DList[PoolDesc]
     profile_info: DList[ProfileDesc]


### PR DESCRIPTION
We are facing Motr crash and failure during iopath deployment and In deployment, if three aux pools are generated and one node is down then we won't be able to support 2 nodes (enclosure) failure. So we need to provide enable/disable aux pools functionality.
In this, we should be able to generate aux pools depending on provided configuration using the new variable in CDF.
We need to add an optional variable in the CDF file. If the variable is not mentioned in the CDF, then the default value
should be = 0 (don't generate aux pools)

Solution:
Added new variable in CDF: "create_aux" and depending on provided configuration we should be able to generate correct
combinations of aux pools.

Signed-off-by: Supriya Chavan <supriya.s.chavan@seagate.com>