### PR TITLE
EOS-25404: node name in motr_hare_shared_keys.json may not be consistent 

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -307,23 +307,25 @@ class CdfGenerator:
         return data_devices
 
     # TBD motr
-    def _get_metadata_device(self, name: str, cvg: int, m0d: int) -> Text:
+    def _get_metadata_device(self,
+                             machine_id: str,
+                             cvg: int,
+                             m0d: int) -> Text:
         motr_store = self.motr_provider
         metadata_device = Text(motr_store.get(
-            f'server>{name}>cvg[{cvg}]>m0d[{m0d}]>md_seg1'))
+            f'server>{machine_id}>cvg[{cvg}]>m0d[{m0d}]>md_seg1'))
         return metadata_device
 
     # TBD motr
-    def _get_m0d_per_cvg(self, name: str, cvg: int) -> int:
+    def _get_m0d_per_cvg(self, machine_id: str, cvg: int) -> int:
         motr_store = self.motr_provider
-        return len(motr_store.get(f'server>{name}>cvg[{cvg}]>m0d'))
+        return len(motr_store.get(f'server>{machine_id}>cvg[{cvg}]>m0d'))
 
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
 
         hostname = self.utils.get_hostname(machine_id)
         # node>{machine-id}>name
-        name = store.get(f'node>{machine_id}>name')
         iface = self._get_iface(machine_id)
         try:
             # cortx>motr>client_instances
@@ -341,12 +343,13 @@ class CdfGenerator:
                 io_disks=DisksDesc(
                     data=self.utils.get_drives_info_for(cvg),
                     meta_data=Maybe(
-                        self._get_metadata_device(name, cvg, m0d), 'Text')),
+                        self._get_metadata_device(
+                            machine_id, cvg, m0d), 'Text')),
                 runs_confd=Maybe(False, 'Bool'))
             # node>{machine_id}>storage>cvg
             for cvg in range(len(store.get(
                 f'node>{machine_id}>storage>cvg')))
-            for m0d in range(self._get_m0d_per_cvg(name, cvg))
+            for m0d in range(self._get_m0d_per_cvg(machine_id, cvg))
         ], 'List M0ServerDesc')
 
         # Adding a Motr confd entry per server node in CDF.

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -31,6 +31,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
@@ -33,6 +33,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",
@@ -75,6 +76,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_2",
@@ -118,6 +120,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_3",

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -38,6 +38,7 @@
       "cluster_id": "my-cluster",
       "hostname": "ssc-vm-1623.colo.seagate.com",
       "name": "srvnode-1",
+      "type": "storage_node",
       "network": {
         "data": {
           "private_fqdn": "srvnode-1.data.private",
@@ -82,6 +83,7 @@
       "cluster_id": "my-cluster",
       "hostname": "ssc-vm-1624.colo.seagate.com",
       "name": "srvnode-2",
+      "type": "storage_node",
       "network": {
         "data": {
           "private_fqdn": "srvnode-2.data.private",
@@ -126,6 +128,7 @@
       "cluster_id": "my-cluster",
       "hostname": "ssc-vm-1625.colo.seagate.com",
       "name": "srvnode-3",
+      "type": "storage_node",
       "network": {
         "data": {
           "private_fqdn": "srvnode-3.data.private",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
@@ -31,6 +31,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -33,6 +33,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",
@@ -75,6 +76,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_2",
@@ -117,6 +119,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_3",

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
@@ -31,6 +31,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
@@ -33,6 +33,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",
@@ -75,6 +76,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_2",
@@ -117,6 +119,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_3",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
@@ -31,6 +31,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -33,6 +33,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",
@@ -75,6 +76,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_2",
@@ -117,6 +119,7 @@
       "cluster_id": "TMPL_CLUSTER_ID",
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
+      "type": "TMPL_NODE_TYPE",
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_3",

--- a/provisioning/miniprov/test/__init__.py
+++ b/provisioning/miniprov/test/__init__.py
@@ -15,3 +15,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
+import inject
+from hax.common import di_configuration
+
+inject.configure(di_configuration)

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -184,6 +184,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>name': 'myhost',
                 'node>MACH_ID>hostname':
                 'myhost',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>storage>cvg[0]>devices>data':
@@ -255,13 +256,13 @@ class TestCDF(unittest.TestCase):
 
         def ret_motr_mdvalues(value: str) -> Any:
             data = {
-                'server>myhost>cvg[0]>m0d':
+                'server>MACH_ID>cvg[0]>m0d':
                 ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
-                'server>myhost>cvg[0]>m0d[0]>md_seg1':
+                'server>MACH_ID>cvg[0]>m0d[0]>md_seg1':
                 '/dev/vg_srvnode-1_md1/lv_raw_md1',
-                'server>myhost>cvg[1]>m0d':
+                'server>MACH_ID>cvg[1]>m0d':
                 ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
-                'server>myhost>cvg[1]>m0d[0]>md_seg1':
+                'server>MACH_ID>cvg[1]>m0d[0]>md_seg1':
                 '/dev/vg_srvnode-1_md2/lv_raw_md2'
             }
             return data.get(value)
@@ -312,6 +313,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>storage>cvg[1]>devices>metadata': ['/dev/meta1'],
                 'node>MACH_ID>hostname':                'myhost',
                 'node>MACH_ID>name': 'mynodename',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>network>data>private_interfaces':                ['eth1', 'eno2'],
@@ -348,13 +350,13 @@ class TestCDF(unittest.TestCase):
 
         def ret_motr_mdvalues(value: str) -> Any:
             data = {
-                'server>mynodename>cvg[0]>m0d':
+                'server>MACH_ID>cvg[0]>m0d':
                 ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
-                'server>mynodename>cvg[0]>m0d[0]>md_seg1':
+                'server>MACH_ID>cvg[0]>m0d[0]>md_seg1':
                 '/dev/vg_srvnode-1_md1/lv_raw_md1',
-                'server>mynodename>cvg[1]>m0d':
+                'server>MACH_ID>cvg[1]>m0d':
                 ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
-                'server>mynodename>cvg[1]>m0d[0]>md_seg1':
+                'server>MACH_ID>cvg[1]>m0d[0]>md_seg1':
                 '/dev/vg_srvnode-1_md2/lv_raw_md2'
             }
             return data.get(value)
@@ -471,6 +473,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID1>storage>cvg[1]>devices>metadata': ['/dev/meta2'],
                 'node>MACH_ID1>hostname':                'myhost',
                 'node>MACH_ID1>name': 'mynodename',
+                'node>MACH_ID1>type': 'storage_node',
                 'node>MACH_ID1>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID1>network>data>private_interfaces':                ['eth1', 'eno2'],
@@ -483,6 +486,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID2>storage>cvg[1]>devices>metadata': ['/dev/meta2'],
                 'node>MACH_ID2>hostname':                'myhost',
                 'node>MACH_ID2>name': 'mynodename',
+                'node>MACH_ID2>type': 'storage_node',
                 'node>MACH_ID2>network>data>private_fqdn':
                     'srvnode-2.data.private',
                 'node>MACH_ID2>network>data>private_interfaces':                ['eth1', 'eno2'],
@@ -495,6 +499,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID3>storage>cvg[1]>devices>metadata': ['/dev/meta2'],
                 'node>MACH_ID3>hostname':                'myhost',
                 'node>MACH_ID3>name': 'mynodename',
+                'node>MACH_ID3>type': 'storage_node',
                 'node>MACH_ID3>network>data>private_fqdn':
                     'srvnode-3.data.private',
                 'node>MACH_ID3>network>data>private_interfaces':                ['eth1', 'eno2'],
@@ -532,7 +537,7 @@ class TestCDF(unittest.TestCase):
                 'cluster>storage_set_count': 1,
                 'cluster>storage_set>server_node_count': 1,
                 'cluster>storage_set[0]>name': 'StorageSet-1',
-                'cluster>storage_set[0]>nodes': ['srvnode_1'],
+                'cluster>storage_set[0]>nodes': ['MACH_ID'],
                 'cluster>storage_set[0]>durability>sns': {'stub': 1},
                 'cluster>storage_set[0]>durability>sns>data': 1,
                 'cluster>storage_set[0]>durability>sns>parity': 0,
@@ -540,39 +545,40 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>cluster_id':
                 'CLUSTER_ID',
                 'node': {
-                    'srvnode_1': {
+                    'MACH_ID': {
                         'cluster_id': 'CLUSTER_ID'
                     }
                 },
-                'node>srvnode_1>cluster_id':
+                'node>MACH_ID>cluster_id':
                 'CLUSTER_ID',
-                'node>srvnode_1>name':
+                'node>MACH_ID>name':
                 'myhost',
-                'node>srvnode_1>hostname':
+                'node>MACH_ID>hostname':
                 'myhost',
-                'node>srvnode_1>network>data>private_fqdn':
+                'node>MACH_ID>type': 'storage_node',
+                'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
-                'node>srvnode_1>network>data>private_interfaces':
+                'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>srvnode_1>storage>cvg_count':
+                'node>MACH_ID>storage>cvg_count':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
                 'cortx>motr>client_instances':
                 2,
-                'node>srvnode_1>storage>cvg':
+                'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
-                'node>srvnode_1>storage>cvg[0]>devices>data':
+                'node>MACH_ID>storage>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>srvnode_1>storage>cvg[1]>devices>data':
+                'node>MACH_ID>storage>cvg[1]>devices>data':
                 ['/dev/sdc'],
             }
             return data.get(value)
 
         store._raw_get = Mock(side_effect=ret_values)
-        store.get_machine_id = Mock(return_value='srvnode_1')
+        store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_storage_set_nodes = Mock(return_value=['srvnode_1'])
         cdf = CdfGenerator(provider=store, motr_provider=Mock())
         cdf._get_m0d_per_cvg = Mock(return_value=1)
@@ -632,6 +638,7 @@ class TestCDF(unittest.TestCase):
                 'CLUSTER_ID',
                 'node>MACH_ID>hostname':
                 'myhost',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
@@ -687,6 +694,7 @@ class TestCDF(unittest.TestCase):
                 'CLUSTER_ID',
                 'node>MACH_ID>hostname':
                 'myhost',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
@@ -735,6 +743,7 @@ class TestCDF(unittest.TestCase):
                 'CLUSTER_ID',
                 'node>MACH_ID>hostname':
                 'myhost',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>network>data>private_interfaces':
@@ -800,6 +809,7 @@ class TestCDF(unittest.TestCase):
                 'CLUSTER_ID',
                 'node>MACH_ID>hostname':
                 'myhost',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>network>data>private_interfaces':
@@ -863,6 +873,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>hostname':
                 'myhost',
                 'node>MACH_ID>name': 'mynodename',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sdc'], 'metadata': ['/dev/meta2']}}],
@@ -910,13 +921,13 @@ class TestCDF(unittest.TestCase):
 
         def ret_motr_mdvalues(value: str) -> Any:
             data = {
-                'server>mynodename>cvg[0]>m0d':
+                'server>MACH_ID>cvg[0]>m0d':
                 ['/dev/vg_srvnode-1_md1/lv_raw_md1'],
-                'server>mynodename>cvg[0]>m0d[0]>md_seg1':
+                'server>MACH_ID>cvg[0]>m0d[0]>md_seg1':
                 '/dev/vg_srvnode-1_md1/lv_raw_md1',
-                'server>mynodename>cvg[1]>m0d':
+                'server>MACH_ID>cvg[1]>m0d':
                 ['/dev/vg_srvnode-1_md2/lv_raw_md2'],
-                'server>mynodename>cvg[1]>m0d[0]>md_seg1':
+                'server>MACH_ID>cvg[1]>m0d[0]>md_seg1':
                 '/dev/vg_srvnode-1_md2/lv_raw_md2'
             }
             return data.get(value)
@@ -967,6 +978,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>hostname':
                 'myhost',
                 'node>MACH_ID>name': 'mynodename',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>network>data>private_interfaces':
@@ -979,6 +991,7 @@ class TestCDF(unittest.TestCase):
                 ['/dev/meta'],
                 'node>MACH_2_ID>name':                'host-2',
                 'node>MACH_2_ID>hostname':            'host-2',
+                'node>MACH_2_ID>type':                'storage_node',
                 'cortx>motr>interface_type':                'tcp',
                 'node>MACH_2_ID>network>data>private_fqdn':
                     'srvnode-2.data.private',
@@ -1062,6 +1075,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>hostname':
                 'myhost',
+                'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta']}}],
                 'node>MACH_ID>storage>cvg[0]>devices>data':

--- a/provisioning/miniprov/test/test_templates.py
+++ b/provisioning/miniprov/test/test_templates.py
@@ -91,6 +91,7 @@ def placeholders() -> Dict[str, str]:
         'TMPL_DATA_INTERFACE_TYPE': 'tcp',
         'TMPL_DATA_UNITS_COUNT': '1',
         'TMPL_HOSTNAME': 'hostname',
+        'TMPL_NODE_TYPE': 'storage_node',
         'TMPL_MACHINE_ID': 'machine-id',
         'TMPL_MACHINE_ID_1': 'machine-id',
         'TMPL_METADATA_DEVICE': '/dev/meta',


### PR DESCRIPTION
Presently motr uses node hostname and Hare uses node name from cortx
conf-store to access nodes in motr_hare_shared_keys.json. Due to multiple
node naming conventions, there can be a runtime confusion due to a weak
contract. Thus it is better if Motr uses machine-id instead of node
hostname/name which will be more unique, thus, creating a stricter contract
between Hare and Motr.

Solution:
Machine identifier being unique without having semantically similar additional
keys, it is better to use machine-id instead of hostname/node-name for nodes.
Using machine-id also enables to have a stricter contract across Hare, Motr and
Provisioner.


Tested on:
 @shriya-deshmukh setup by combining this patch with motr patch https://github.com/Seagate/cortx-motr/pull/1136/files

cluster bootstrap is working fine.