### PR TITLE
EOS-25248: [Containerization] Log rotation policy to be implemented

### DIFF
--- a/provisioning/logrotate/hare
+++ b/provisioning/logrotate/hare
@@ -1,4 +1,5 @@
-/var/log/seagate/hare/*.log
+TMP_LOG_PATH/*.log
+TMP_LOG_PATH/hare_deployment/*.log
 {
     rotate 10
     maxsize 50M

--- a/provisioning/logrotate/physical
+++ b/provisioning/logrotate/physical
@@ -1,4 +1,5 @@
-/var/log/seagate/hare/*.log
+TMP_LOG_PATH/*.log
+TMP_LOG_PATH/hare_deployment/*.log
 {
     rotate 10
     maxsize 50M

--- a/provisioning/logrotate/virtual
+++ b/provisioning/logrotate/virtual
@@ -1,4 +1,5 @@
-/var/log/seagate/hare/*.log
+TMP_LOG_PATH/*.log
+TMP_LOG_PATH/hare_deployment/*.log
 {
     rotate 10
     maxsize 50M

--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -4,7 +4,9 @@
     {
       "type": "key",
       "key": "leader",
-      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader", "--conf-dir", "TMP_CONF_DIR" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader",
+                "--conf-dir", "TMP_CONF_DIR",
+                "--log-dir", "TMP_LOG_DIR" ]
     },
     {
       "type": "service",
@@ -29,7 +31,8 @@
     {
       "type": "service",
       "service": "ios",
-      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
     },
     {
       "type": "service",
@@ -44,7 +47,8 @@
     {
       "type": "service",
       "service": "s3service",
-      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
     }
   ],
   "services": []

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -5,7 +5,9 @@
     {
       "type": "key",
       "key": "leader",
-      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader", "--conf-dir", "TMP_CONF_DIR" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader",
+                "--conf-dir", "TMP_CONF_DIR",
+                "--log-dir", "TMP_LOG_DIR" ]
     },
     {
       "type": "keyprefix",
@@ -30,7 +32,8 @@
     {
       "type": "service",
       "service": "confd",
-      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
     },
     {
       "type": "service",
@@ -45,7 +48,8 @@
     {
       "type": "service",
       "service": "ios",
-      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
     },
     {
       "type": "service",
@@ -60,7 +64,8 @@
     {
       "type": "service",
       "service": "s3service",
-      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler" ]
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
     }
   ],
   "enable_local_script_checks": true,

--- a/utils/consul-watch-handler
+++ b/utils/consul-watch-handler
@@ -49,8 +49,36 @@ set -eu -o pipefail
 #
 #   $ consul catalog services
 
+PROG=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: . $PROG [<option>]... --log-dir <dir>
+
+Positional arguments:
+  --log-dir <dir>  Log directory path
+EOF
+}
+
+TEMP=$(getopt --options h: \
+              --longoptions help,log-dir: \
+              --name "$PROG" -- "$@" || true)
+
+eval set -- "$TEMP"
+
+log_dir=/var/log/seagate/hare
+
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        --log-dir)           log_dir=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
+
 # Redirect all printouts to the log file with the timestamp prefix:
-exec &>> /var/log/seagate/hare/${0##*/}.log
+exec &>> ${log_dir}/${0##*/}.log
 exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 
 jq '[.[] | { "Node": .Node.Node,

--- a/utils/elect-rc-leader
+++ b/utils/elect-rc-leader
@@ -30,21 +30,24 @@ Elect new RC leader
 Options:
   -h, --help            Show this help and exit.
   -c, --conf-dir        config dir where config files are present
+  -l --log-dir <dir>       Log directory path
 EOF
 }
 
 TEMP=$(getopt --options h: \
-              --longoptions help,conf-dir: \
+              --longoptions help,conf-dir:,log-dir: \
               --name "$PROG" -- "$@" || true)
 
 eval set -- "$TEMP"
 
 conf_dir=/var/lib/hare
+log_dir=/var/log/seagate/hare
 
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         -c|--conf-dir)       conf_dir=$2; shift 2 ;;
+        -l|--log-dir)        log_dir=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   usage; exit ;;
     esac
@@ -53,7 +56,7 @@ done
 sudo mkdir -p /var/log/seagate/hare
 
 # Redirect all printouts to the log file with the timestamp prefix:
-exec &>> /var/log/seagate/hare/consul-${0##*/}.log
+exec &>> ${log_dir}/consul-${0##*/}.log
 exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 
 export SRC_DIR="$(dirname $(readlink -f $0))"
@@ -141,5 +144,5 @@ export SID
     # XXX: notify Motr about new Principal RM here
 
     # Start EQ watch:
-    consul watch -type=keyprefix -prefix eq/ $SRC_DIR/proto-rc
+    consul watch -type=keyprefix -prefix eq/ $SRC_DIR/proto-rc --log-dir $log_dir
 ) &

--- a/utils/proto-rc
+++ b/utils/proto-rc
@@ -36,8 +36,36 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 #   $ consul watch -type=keyprefix -prefix eq/ proto-rc
 #
 
+PROG=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: . $PROG [<option>]... --log-dir <dir>
+
+Positional arguments:
+  --log-dir <dir>  Log directory path
+EOF
+}
+
+TEMP=$(getopt --options h: \
+              --longoptions help,log-dir: \
+              --name "$PROG" -- "$@" || true)
+
+eval set -- "$TEMP"
+
+log_dir=/var/log/seagate/hare
+
+while true; do
+    case "$1" in
+        -h|--help)           usage; exit ;;
+        --log-dir)           log_dir=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
+
 # Redirect all printouts to the log file with the timestamp prefix:
-LOGFILE="/var/log/seagate/hare/consul-${0##*/}.log"
+LOGFILE="${log_dir}/consul-${0##*/}.log"
 exec &>> ${LOGFILE}
 exec &> >(stdbuf --output=L gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -38,6 +38,7 @@ Usage: . $PROG [-n | --dry-run]
 Positional arguments:
   --conf-dir <dir>  Configuration directory path to read configuration
                     from or write to.
+  --log-dir <dir>   Log directory path
   --kv-file <kv>    Hare-Motr configuration key values file path.
   --uuid <str>      UUID to be used to write in sysconfig file
 
@@ -51,6 +52,7 @@ EOF
 
 TEMP=$(getopt --options hns: \
               --longoptions help,dry-run,conf-dir:,kv-file:,uuid: \
+              --longoptions log-dir: \
               --longoptions server \
               --name "$PROG" -- "$@" || true)
 
@@ -59,6 +61,7 @@ TEMP=$(getopt --options hns: \
 eval set -- "$TEMP"
 
 conf_dir=/var/lib/hare
+log_dir=/var/log/seagate/hare
 kv_file=/var/lib/hare/consul-kv.json
 dry_run=false
 server=false
@@ -68,6 +71,7 @@ while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         -c|--conf-dir)       conf_dir=$2; shift 2 ;;
+        -l|--log-dir)        log_dir=$2; shift 2 ;;
         -k|--kv-file)        kv_file=$2; shift 2 ;;
         -s|--server)         server=true; shift ;;
         --uuid)              uuid=$2; shift 2 ;;
@@ -209,6 +213,7 @@ fi
 
 pwdesc=$(echo $conf_dir | sed 's_/_\\/_g')
 sed -i "s/TMP_CONF_DIR/$pwdesc/" $CONF_FILE
+sed -i "s|TMP_LOG_DIR|$log_dir|" $CONF_FILE
 
 SVCS_CONF=''
 


### PR DESCRIPTION
Fixed log path for elect-rc leader, proto-rc and consul-watch handler scripts.
Log rotation will be configures in post_install for LR and in 'start' for LC
Log path will be template value in code, during log rotation configuration those will be replaced by actual paths
After log rotation configuration, 'crond start' will be executes

Changed log path of 'hare-hax' . New path will be as follows
`/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/hare-hax.log`
Also changes log path for consul agent

**Test done:**
```
[root@storage-node1 /]# cat /etc/logrotate.d/hare
/share/var/log/cortx//hare/log/aaa120a9e051d103c164f605615c32a4/*.log
/share/var/log/cortx//hare/log/aaa120a9e051d103c164f605615c32a4/hare_deployment/*.log
{
    rotate 10
    maxsize 50M
    weekly
    compress
    missingok
    copytruncate
}
```

```
#cat /etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-client-conf/consul-client-conf.json
.
.
.
{
  "enable_local_script_checks": true,
  "watches": [
    {
      "type": "key",
      "key": "leader",
      "args": [
        "/opt/seagate/cortx/hare/libexec/elect-rc-leader",
        "--conf-dir",
        "/etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4",
        "--log-dir",
        "/share/var/log/cortx//hare/log/aaa120a9e051d103c164f605615c32a4"
      ]
    },
    {
      "type": "service",
      "service": "ios",
      "handler_type": "http",
      "http_handler_config": {
        "path": "http://storage-node1:8008",
        "method": "POST",
        "timeout": "10s"
      }
    },
    {
      "type": "keyprefix",
      "prefix": "bq/",
      "handler_type": "http",
      "http_handler_config": {
        "path": "http://storage-node1:8008/watcher/bq",
        "method": "POST",
        "timeout": "10s"
      }
    },
    {
      "type": "service",
      "service": "ios",
      "args": [
        "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
        "--log-dir",
        "/share/var/log/cortx//hare/log/aaa120a9e051d103c164f605615c32a4"
      ]
    },
    {
.
.
.
.
```

```
[root@storage-node1 /]# ls /share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/ -l
total 79912
-rw-r--r-- 1 root root        0 Oct 24 03:17 consul-elect-rc-leader.log
-rw-r--r-- 1 root root      288 Oct 21 09:58 consul-elect-rc-leader.log-20211024.gz
-rw-r--r-- 1 root root        0 Oct 24 03:17 consul-proto-rc.log
-rw-r--r-- 1 root root       20 Oct 21 09:49 consul-proto-rc.log-20211024.gz
-rw-r--r-- 1 root root   186978 Oct 25 12:15 consul-watch-handler.log
-rw-r--r-- 1 root root    20240 Oct 24 02:58 consul-watch-handler.log-20211024.gz
-rw-r--r-- 1 root root   152654 Oct 25 13:06 hare-consul.log
-rw-r--r-- 1 root root    33725 Oct 24 03:16 hare-consul.log-20211024.gz
drwxr-xr-x 2 root root     4096 Oct 24 03:17 hare_deployment
-rw-r--r-- 1 root root 54318729 Oct 25 13:06 hare-hax.log
```