### PR TITLE
EOS-25377: StobIoqError type not JSON-serializable

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -17,7 +17,7 @@
 #
 
 import queue as q
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from queue import Queue
 from typing import Any, List, Optional
 
@@ -139,6 +139,37 @@ class StobIoqError(BaseMessage):
     offset: int
     size: int
     bshift: int
+
+    def for_json(self):
+        parts = {}
+
+        def as_str(a):
+            return str(a)
+
+        def as_repr(a):
+            return repr(a)
+
+        def as_is(a):
+            return a
+
+        for fld in fields(self):
+            f_type = fld.type
+            f_name = fld.name
+            if f_name == 'group':
+                # group is a thing used by WorkPlanner for task scheduling
+                # logic. We don't need to expose it
+                continue
+            val = getattr(self, f_name)
+            to_str = as_str
+            if f_type is Fid:
+                to_str = as_repr
+            elif f_type is StobId:
+                to_str = as_is
+            elif f_type is int or f_type is None:
+                to_str = as_is
+            parts[fld.name] = to_str(val)
+
+        return parts
 
 
 class Die(BaseMessage):

--- a/hax/test/integration/test_server.py
+++ b/hax/test/integration/test_server.py
@@ -22,11 +22,12 @@ from typing import List
 
 import pytest
 import simplejson
-from hax.message import BroadcastHAStates
+from hax.message import BroadcastHAStates, StobId, StobIoqError
 from hax.motr import WorkPlanner
 from hax.motr.delivery import DeliveryHerald
 from hax.server import ServerRunner
 from hax.types import Fid, HAState, MessageId, ServiceHealth
+from hax.util import dump_json
 
 
 @pytest.fixture
@@ -152,3 +153,56 @@ async def test_bq_stob_message_type_recognized(hax_client, planner, herald,
     planner.add_command.assert_called_once_with(
         ContainsStates(
             [HAState(fid=Fid(0x1, 0x4), status=ServiceHealth.FAILED)]))
+
+
+async def test_bq_stob_message_deserialized(hax_client, planner, herald,
+                                            consul_util, mocker):
+    def fake_get(key):
+        ret = {'bq-delivered/192.168.0.28': ''}
+        return ret[key]
+
+    mocker.patch.object(herald, 'wait_for_any')
+    #
+    # InboxFilter will try to read epoch - let's mock KV operations
+    stob = StobId(Fid(12, 13), Fid(14, 15))
+    msg = StobIoqError(fid=Fid(5, 6),
+                       conf_sdev=Fid(0x103, 0x204),
+                       stob_id=stob,
+                       fd=42,
+                       opcode=4,
+                       rc=2,
+                       offset=0xBF,
+                       size=100,
+                       bshift=4)
+
+    # Here we make sure that rea StobIoqError can be used as the payload
+    # for STOB_IOQ_ERROR bq message.
+    stob_payload = dump_json(msg)
+    parsed_stob = simplejson.loads(stob_payload)
+
+    mocker.patch.object(consul_util.kv, 'kv_put')
+    mocker.patch.object(consul_util.kv, 'kv_get', fake_get)
+    event_payload = {'message_type': 'STOB_IOQ_ERROR', 'payload': parsed_stob}
+    event_str = simplejson.dumps(event_payload)
+    b64: bytes = b64encode(event_str.encode())
+    b64_str = b64.decode()
+
+    payload = [{
+        'Key': 'bq/12',
+        'CreateIndex': 1793,
+        'ModifyIndex': 1793,
+        'LockIndex': 0,
+        'Flags': 0,
+        'Value': b64_str,
+        'Session': ''
+    }]
+    # Test execution
+    resp = await hax_client.post('/watcher/bq', json=payload)
+    # Validate now
+    if resp.status != 200:
+        resp_json = await resp.json()
+        logging.getLogger('hax').debug('Response: %s', resp_json)
+    assert resp.status == 200
+    planner.add_command.assert_called_once_with(
+        ContainsStates(
+            [HAState(fid=Fid(0x103, 0x204), status=ServiceHealth.FAILED)]))


### PR DESCRIPTION
JIRA ticket: [EOS-25377](https://jts.seagate.com/browse/EOS-25377)

## Problem
Dataclass StobIoqError turns out to be not serialized by `simplejson` library. The serializing is done as a normal workflow of STOB_IOQ_ERROR message propagation (so this dataclass gets serialized into JSON and that JSON is sent as a payload to EQ and then retransmitted to BQ from the RC leader node).

## Solution
1. Implement custom serializer function for StobIoqError (for_json())
2. Implement integration tests that verify that the bug is not
reproduced anymore:
   - StobIoqError is serializable by simplejson library
   - Resulting payload is understood by the BQ processor


Closes #1830 