### PR TITLE
EOS-25441: entrypoint fom hung and hax notifies Failed

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -30,7 +30,7 @@ from hax.motr import Motr
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.planner import WorkPlanner
 from hax.queue.publish import EQPublisher
-from hax.types import (ConfHaProcess, HaLinkMessagePromise, HAState, MessageId,
+from hax.types import (ConfHaProcess, HAState, MessageId, HaLinkMessagePromise,
                        ObjT, ServiceHealth, StoppableThread, m0HaProcessEvent,
                        m0HaProcessType)
 from hax.util import ConsulUtil, dump_json, repeat_if_fails
@@ -136,9 +136,10 @@ class ConsumerThread(StoppableThread):
                     # broadcasting failure.
                     current_status = ServiceHealth.UNKNOWN
                     planner.add_command(
-                        BroadcastHAStates(states=[
-                            HAState(fid=state.fid, status=ServiceHealth.FAILED)
-                        ],
+                         BroadcastHAStates(states=[
+                            HAState(fid=state.fid,
+                                    status=ServiceHealth.FAILED)
+                         ],
                             reply_to=None))
                 if current_status not in (ServiceHealth.UNKNOWN,
                                           ServiceHealth.OFFLINE):

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -151,7 +151,8 @@ def main():
 
     # TODO make the number of threads configurable
     consumer_threads = [
-        _run_qconsumer_thread(planner, motr, herald, util, i) for i in range(4)
+        _run_qconsumer_thread(planner, motr, herald,
+                              util, i) for i in range(32)
     ]
 
     try:

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -164,19 +164,20 @@ class Motr:
             LOG.exception('Failed to notify failure for %s', process_fid)
 
         LOG.debug('enqueue entrypoint request for %s', remote_rpc_endpoint)
-        entrypoint_req: EntrypointRequest = EntrypointRequest(
+        # entrypoint_req: EntrypointRequest = EntrypointRequest(
+        self.planner.add_command(EntrypointRequest(
             reply_context=reply_context,
             req_id=req_id,
             remote_rpc_endpoint=remote_rpc_endpoint,
             process_fid=process_fid,
             git_rev=git_rev,
             pid=pid,
-            is_first_request=is_first_request)
+            is_first_request=is_first_request))
         # If rconfc from motr land sends an entrypoint request when
         # the hax consumer thread is already stopping, there's no
         # point in en-queueing the request as there's no one to process
         # the same. Thus, invoke send_entrypoint_reply directly.
-        self.send_entrypoint_request_reply(entrypoint_req)
+        # self.send_entrypoint_request_reply(entrypoint_req)
 
     def send_entrypoint_request_reply(self, message: EntrypointRequest):
         reply_context = message.reply_context

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1292,8 +1292,8 @@ class ConsulUtil:
             local_remote_health_ret(ServiceHealth.OFFLINE,
                                     ServiceHealth.UNKNOWN),
             cur_consul_status('passing', 'Unknown'):
-            local_remote_health_ret(ServiceHealth.UNKNOWN,
-                                    ServiceHealth.UNKNOWN),
+            local_remote_health_ret(ServiceHealth.OFFLINE,
+                                    ServiceHealth.OFFLINE),
             cur_consul_status('warning', 'M0_CONF_HA_PROCESS_STOPPING'):
             local_remote_health_ret(ServiceHealth.OFFLINE,
                                     ServiceHealth.STOPPED),
@@ -1307,8 +1307,8 @@ class ConsulUtil:
             local_remote_health_ret(ServiceHealth.OFFLINE,
                                     ServiceHealth.OFFLINE),
             cur_consul_status('warning', 'Unknown'):
-            local_remote_health_ret(ServiceHealth.UNKNOWN,
-                                    ServiceHealth.UNKNOWN)}
+            local_remote_health_ret(ServiceHealth.OFFLINE,
+                                    ServiceHealth.OFFLINE)}
         try:
             node_data: List[Dict[str, Any]] = self.cns.health.node(node)[1]
             if not node_data:


### PR DESCRIPTION
Presently on container cluster, a deployment problem is seen where,
entrypoint fom is hung in hax's motr land, suspect the entrypoint
thread hold up is causing the same. Also, presently hax broadcasts
FAILED and posts an internal broadcast request that may keep consumer
threads busy.

Solution:
- Unblock motr entrypoint thread by posting the entrypoint reply to
consumer.
- Report OFFLINE status instead of UNKNOWN in case a process status
cannot be determined so that no recurring broadcast request is posted
implicitly.