### PR TITLE
Problem: hare_setup fails or delays deployment

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -289,7 +289,8 @@ class Motr:
             # For process failure, we report failure for the corresponding
             # node (enclosure) and CVGs if all Io services are failed.
             if (st.fid.container == ObjT.PROCESS.value
-                    and st.status in (ServiceHealth.FAILED, ServiceHealth.OK)):
+                    and st.status in (ServiceHealth.FAILED, ServiceHealth.OK)
+                    and (not self.consul_util.is_proc_client(st.fid))):
                 # Check if we need to mark node as failed,
                 # otherwise just mark controller as failed/OK
                 # If we receive process failure then we will check if all IO

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -218,13 +218,6 @@ def _start_consul(utils: Utils,
                                    config_dir=config_dir, peers=peers)
     consul_starter.start()
 
-    try:
-        util: ConsulUtil = ConsulUtil()
-        sess = util.get_leader_session_no_wait()
-        util.destroy_session(sess)
-    except Exception:
-        logging.debug('No leader is elected yet')
-
     return consul_starter
 
 
@@ -288,6 +281,13 @@ def prepare(args):
     consul_starter = _start_consul(utils, stop_event, conf_dir, url)
     utils.save_node_facts()
     utils.save_drives_info()
+    try:
+        util: ConsulUtil = ConsulUtil()
+        sess = util.get_leader_session_no_wait()
+        util.destroy_session(sess)
+    except Exception:
+        logging.debug('No leader is elected yet')
+
     consul_starter.stop()
 
 


### PR DESCRIPTION
1. Every node executes hare miniprovisioner, in the init stage
of the mini-provisioner, Hare starts a local consul client agent.
As per the configuration, when consul agent starts, leader election
is triggered. In Hare init, as part of consul startup, any existing
leader session is cleaned which triggers a re-election of Hare
RC leader. Thus, when evey container runs Hare mini-provisioner
it clears the existing consul leader session, this re-start leader
election which has a side effect on other containers which have already
started and are in the middle of their work. Other containers are
interrupted due to destruction of the ealier elected leader. As the
number of containers increase this problem aggravates and delays the
overall operation.

2. Hax reports FAILED for a completed mkfs container. When a mkfs
container stops, its corresponding consul agent also stops. This
triggers a Consul warning for that container, other containers get
this notification from Consul and try to check the current status of
the node (container). But as in this case the consul agent is also
terminated, the node is detected as failed and in this case the
corresponding container is detected as failed and also its local
motr services. This affects the other container operations. Due to
the failure reported the correponding nodes objects are marked as
failed which may go above the number of tolerated failures. This hits
an assert in motr land which fails to find a clean pool version during
its metadata setup hitting the `!pver->pv_is_dirty` assertion in motr.

Solution:
- Do not destroy the existing leader session while starting Consul in
Hare mini-provisioner.
- Check process's status in Consul KV in case Consul reported node failure
during mkfs operation.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>