### PR TITLE
EOS-25582 entrypoint request is processed with delay

### DIFF
--- a/hax/hax/motr/planner.py
+++ b/hax/hax/motr/planner.py
@@ -340,7 +340,8 @@ class WorkPlanner:
             self.state.next_group_id = self._get_increased_group(
                 self.state.next_group_id)
 
-        if isinstance(cmd, AnyEntrypointRequest):
+        if (isinstance(cmd, AnyEntrypointRequest)
+                or isinstance(cmd, HaNvecGetEvent)):
             # Entrypoint and Die will always be added to the CURRENT group
             # (the one being currently active), so they can be executed at
             # first priority.

--- a/hax/test/test_work_planner.py
+++ b/hax/test/test_work_planner.py
@@ -120,7 +120,7 @@ class TestMessageOrder(unittest.TestCase):
             assign(broadcast()),
             assign(nvec_get())
         ]
-        self.assertEqual([0, 1, 2, 2], [m.group for (m, _) in msgs])
+        self.assertEqual([0, 1, 2, 0], [m.group for (m, _) in msgs])
 
     def test_group_id_cycled(self):
         def my_state():
@@ -166,8 +166,8 @@ class TestMessageOrder(unittest.TestCase):
             assign(entrypoint())
         ]
         self.assertEqual([0, 0, 1, 0], [m.group for (m, _) in msgs_after_bc])
-        self.assertEqual([0, 1, 2, 0], [m.group for (m, _) in msgs_after_ep])
-        self.assertEqual([0, 2, 2, 0], [m.group for (m, _) in msgs_after_nvec])
+        self.assertEqual([0, 0, 2, 0], [m.group for (m, _) in msgs_after_ep])
+        self.assertEqual([0, 0, 0, 0], [m.group for (m, _) in msgs_after_nvec])
 
 
 class TestWorkPlanner(unittest.TestCase):
@@ -243,7 +243,7 @@ class TestWorkPlanner(unittest.TestCase):
         if exc:
             raise exc
         groups_processed = tracker.get_tracks()
-        self.assertEqual([0, 1, 1, 2, 2, 3, 3, 4, 4, 5], groups_processed)
+        self.assertEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], groups_processed)
 
 
     def test_entrypoint_request_processed_asap(self):
@@ -379,7 +379,7 @@ class TestWorkPlanner(unittest.TestCase):
         if exc:
             raise exc
         groups_processed = tracker.get_tracks()
-        self.assertEqual([0, 1, 1, 2, 2, 3, 3, 4, 4, 5], groups_processed)
+        self.assertEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], groups_processed)
 
     def test_no_hang_when_group_id_cycled(self):
         planner = WorkPlanner()


### PR DESCRIPTION
When the cluster bootstraps, the health status picture changes very
frequently (especially given that the m0d processes in the cluster start
out of order). In this case a huge flow of BroadcastHAState events is
observed (reason: Consul notices the change in health statuses at
different nodes).

BroadcastHAState events by definition are processed sequentially, one by
one. If after a sequence of such events an entrypoint request comes, it
will start processing not earlier than the previous broadcasts are
fulfilled (and corresponding 'delivered' notifications are received).

This causes a significant delay of entrypoint request processing (up to
several minutes) and that becomes a reason of m0d processes hang.

## Solution
process entrypoint requests out of order. Entrypoint requests
are processed in the current group, regardless what other messages are
being processed in the moment.