### PR TITLE
Problem: hax or consul start may fail and hax shutdown may hang

### DIFF
--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -71,11 +71,19 @@ class ConsulStarter(StoppableThread):
             for peer in self.peers:
                 cmd.append(f'-retry-join={peer}')
 
-            self.process = execute_no_communicate(cmd,
-                                                  working_dir=self.log_dir,
-                                                  out_file=LogWriter(LOG, fh))
-            if self.process:
-                self.process.communicate()
+            restart = True
+            while restart:
+                try:
+                    if self.process:
+                        self.process.terminate()
+                    self.process = execute_no_communicate(
+                        cmd, working_dir=self.log_dir,
+                        out_file=LogWriter(LOG, fh))
+                    if self.process:
+                        self.process.communicate()
+                        restart = False
+                except Exception:
+                    continue
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:


### PR DESCRIPTION
It is possible that consul or even hax may fail to start at the
first attempt. Also, it is possible that hax shutdown may hang
during dpeloyment in motr cleanup.

Solution:
- Re-try starting hax and consul subprocesses in case of failure.
- Kill hax subprocess instead of terminating to avoid hang.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>