### PR TITLE
EOS-25502:Problem: hax still sends FAILED for motr mkfs process

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -30,7 +30,7 @@ from hax.motr import Motr
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.planner import WorkPlanner
 from hax.queue.publish import EQPublisher
-from hax.types import (ConfHaProcess, HAState, MessageId, HaLinkMessagePromise,
+from hax.types import (ConfHaProcess, HAState, MessageId,
                        ObjT, ServiceHealth, StoppableThread, m0HaProcessEvent,
                        m0HaProcessType)
 from hax.util import ConsulUtil, dump_json, repeat_if_fails
@@ -76,7 +76,7 @@ class ConsumerThread(StoppableThread):
                     ServiceHealth.OK),
             (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
                 m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
-                    ServiceHealth.STOPPED),
+                    ServiceHealth.OFFLINE),
             (m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
                 m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
                     ServiceHealth.OK),
@@ -167,17 +167,6 @@ class ConsumerThread(StoppableThread):
 
                     LOG.debug('Got %s message from planner', item)
                     if isinstance(item, FirstEntrypointRequest):
-                        LOG.debug('first entrypoint request, broadcast FAILED')
-                        ids: List[MessageId] = motr.broadcast_ha_states(
-                            [
-                                HAState(fid=item.process_fid,
-                                        status=ServiceHealth.FAILED)
-                            ],
-                            notify_devices=False)
-                        LOG.debug('waiting for broadcast of %s for ep: %s',
-                                  ids, item.remote_rpc_endpoint)
-                        # Wait for failure delivery.
-                        self.herald.wait_for_all(HaLinkMessagePromise(ids))
                         motr.send_entrypoint_request_reply(
                             EntrypointRequest(
                                 reply_context=item.reply_context,

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -133,7 +133,11 @@ def main():
     signal.signal(signal.SIGINT, handle_signal)
 
     util: ConsulUtil = ConsulUtil()
-    _remove_stale_session(util)
+    # Avoid removing session on hax start as this will happen
+    # on every node, thus leader election will keep re-triggering
+    # until the final hax node starts, this will delay further
+    # bootstrapping operations.
+    # _remove_stale_session(util)
     cfg: HL_Fids = _get_motr_fids(util)
 
     LOG.info('Welcome to HaX')

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -598,7 +598,8 @@ class ConsulUtil:
             node_name: str = json.loads(data)['name']
             if (self.get_node_health_status(node_name, kv_cache=kv_cache) !=
                     'passing'):
-                obj_state = HaNoteStruct.M0_NC_FAILED
+                obj_state = self._check_process_status_node_failure(
+                           fidk, kv_cache=kv_cache).to_ha_note_status()
 
         device_obj_types = self.object_state_getters
         if obj_t.name in (ObjT.PROCESS.name, ObjT.SERVICE.name):
@@ -1314,12 +1315,9 @@ class ConsulUtil:
         pfid = create_process_fid(proc_id)
         cns_status = self.get_process_status(pfid,
                                              kv_cache=kv_cache)
-        if (cns_status.proc_status in ('M0_CONF_HA_PROCESS_STOPPED',
-                                       'M0_CONF_HA_PROCESS_STOPPING',
-                                       'unknown') and (
-            cns_status.proc_type in
+        if (cns_status.proc_type in
                 (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name,
-                 'unknown'))):
+                 'Unknown')):
             return ServiceHealth.OFFLINE
         return ServiceHealth.FAILED
 
@@ -1430,8 +1428,9 @@ class ConsulUtil:
                     else:
                         status = svc_health.motr_proc_status_remote
                     if (status != ServiceHealth.OK and
-                            cns_status.proc_type == (
-                            m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name)):
+                            cns_status.proc_type in (
+                            m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name,
+                            'Unknown')):
                         status = ServiceHealth.OFFLINE
 
                     # This situation is not expected but we handle


### PR DESCRIPTION
When a motr-mkfs process reports STOPPED to hax, hax broadcasts FAILED
to all the other peer Motr processes and self in-order to disconnect the
ha links. In case of multiple ioservices per node, other ioservice, on
receiving this FAILED event for its fellow ioservice panics as during
its mkfs process as the corresponding configuration objects in the FAILED
mkfs process's heirarchy are marked FAILED and no clean pool version
can be found. In such a situation ioservice with mkfs in-progress fails
with a `!pv-dirty` assertion.
Also, sending a Failed event on entrypoint request also causes problem
if all the processes start in parallel.

Solution:
- Send OFFLINE event for mkfs STOPPED event
- Don't broadcast FAILED on receiving entrypoint request, this causes
inconsistencies when processes start in parallel.
- check consul kv status if node failure is reported, it could be mkfs
process completing.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>