### PR TITLE
Problem: EOS-25507 [Containerization] Support bundle interface should work for hare

### DIFF
--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -19,30 +19,66 @@
 
 set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
-# set -x
+set -x
 
 # :help: gather Hare forensic data
 
 PROG=${0##*/}
 DEFAULT_DEST_DIR=/tmp
+DEFAULT_LOG_DIR=/var/lib/hare
+DEFAULT_CONF_DIR=/var/log/seagate/hare
 
 usage() {
     cat <<EOF
-Usage: $PROG [-h | --help] [<bundle-id> <dest-dir>]
+Usage: $PROG -b <bundleid> -t <path> -c <confstore_url> --systemd_disabled
 
 Create '<dest-dir>/hare/hare_<bundle-id>.tar.gz' archive with Hare
 forensic data --- logs and configuration files, which can be used for
 reporting and researching Hare bugs.
 
 Positional arguments:
-  bundle-id   Support bundle ID; defaults to the local host name
-              (${HOSTNAME%%.*}).
-  dest-dir    Target directory; defaults to '$DEFAULT_DEST_DIR'.
+  -b                    Unique bundle-id used to identify support bundles.
+  -t                    Location at which support bundle needs to be copied.
+  -c                    Configuration directory where Hare
+                        config files are present.
+  -l                    The directory where the Hare related log files
+                        are present.
+  --no-systemd          When set, systemd facilities will not be used to
+                        generate the logs
 
 Options:
   -h, --help   Show this help and exit.
 EOF
 }
+
+bundle_id=$HOSTNAME
+dest_dir=$DEFAULT_DEST_DIR
+log_dir=$DEFAULT_LOG_DIR
+conf_dir=$DEFAULT_CONF_DIR
+use_systemd=true
+
+TEMP=$(getopt --options hm:b:t:c:l: \
+              --longoptions help,systemd-disabled \
+              --name "$PROG" -- "$@" || true)
+
+eval set -- "$TEMP"
+while true; do
+    case "$1" in
+        -h|--help)            usage; exit ;;
+        -b)                   bundle_id=$2; shift 2 ;;
+        -t)                   dest_dir=$2; shift 2 ;;
+        -c)                   conf_dir=$2; shift 2 ;;
+        -l)                   log_dir=$2; shift 2 ;;
+        --no-systemd)         use_systemd=false; shift ;;
+        --)                   shift; break ;;
+        *)                    echo 'getopt: internal error...'; exit 1 ;;
+    esac
+done
+
+echo "Bundle_id: $bundle_id"
+echo "dest_dir: $dest_dir"
+echo "conf_dir: $conf_dir"
+echo "log_dir: $log_dir"
 
 die() {
     echo "$PROG: $*" >&2
@@ -60,6 +96,10 @@ systemd_journal() {
     done
 }
 
+running_process_list() {
+    ps aux > processes.txt || true
+}
+
 case "${1:-}" in
     -h|--help) usage; exit;;
 esac
@@ -67,9 +107,6 @@ esac
 if (($? != 0 && $? != 2)); then
     die "Wrong number of arguments. Type '$PROG --help' for usage."
 fi
-
-bundle_id=${1:-${HOSTNAME%%.*}}
-dest_dir=${2:-$DEFAULT_DEST_DIR}
 
 if [[ -z $bundle_id || -z $dest_dir ]]; then
     die "Invalid argument. Type '$PROG --help' for usage."
@@ -87,13 +124,17 @@ cd "$dest_dir/hare/$HOSTNAME"
 exec 5>&2
 exec 2> >(tee _reportbug.stderr >&2)
 
-systemd_journal
+if $use_systemd; then
+    systemd_journal
 
-sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
-     > syslog-pacemaker.json || true
+    sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
+         > syslog-pacemaker.json || true
 
-sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
-     > systemctl-status.txt || true
+    sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
+         > systemctl-status.txt || true
+else
+    running_process_list
+fi
 
 # cluster status
 sudo timeout --kill-after 30 15 hctl status \
@@ -113,9 +154,9 @@ for f in ${extra_files[@]}; do
     fi
 done
 
-cp --parents /var/lib/hare/* . 2>/dev/null || true
-cp -r --parents /var/lib/hare/consul-{env,server,client}-* . 2>/dev/null || true
-cp -r --parents /var/log/seagate/hare/ . 2>/dev/null || true
+cp --parents $conf_dir/* . 2>/dev/null || true
+cp -r --parents $conf_dir/consul-{env,server,client}-* . 2>/dev/null || true
+cp -r --parents $log_dir/ . 2>/dev/null || true
 cp -r --parents /var/log/cluster/ . 2>/dev/null || true
 
 cd ..


### PR DESCRIPTION
Solution: Added new options required to for support bundle generation

**Test:**
[root@storage-node1 /]# **/opt/seagate/cortx/hare/bin/hare_setup support_bundle -c yaml:///etc/cortx/cluster.conf -b tempb -t tempdest  -s all**

[root@storage-node1 /]# **tar -xvzf tempdest/hare/hare_tempb.tar.gz**
storage-node1/
storage-node1/var/
storage-node1/var/log/
storage-node1/etc/
storage-node1/etc/sysconfig/
storage-node1/etc/sysconfig/motr
storage-node1/etc/cortx/
storage-node1/etc/cortx/hare/
storage-node1/etc/cortx/hare/config/
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-client-conf/
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-client-conf/consul-client-conf.json
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-server-conf/
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/confd.dhall
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/m0trace.28
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/m0trace.30
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/cluster.yaml
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-kv.json
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-env
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/m0trace.570
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/node-name
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/m0trace.5064
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/confd.xc
storage-node1/etc/cortx/hare/config/aaa120a9e051d103c164f605615c32a4/consul-agents.json
storage-node1/_reportbug.stderr
storage-node1/share/
storage-node1/share/var/
storage-node1/share/var/log/
storage-node1/share/var/log/cortx/
storage-node1/share/var/log/cortx/hare/
storage-node1/share/var/log/cortx/hare/log/
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/consul-elect-rc-leader.log
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/consul-proto-rc.log
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/hare-consul.log
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/consul-watch-handler.log
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/hare_deployment/
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/hare_deployment/setup.log
storage-node1/share/var/log/cortx/hare/log/aaa120a9e051d103c164f605615c32a4/hare-hax.log
storage-node1/opt/
storage-node1/opt/seagate/
storage-node1/opt/seagate/cortx/
storage-node1/opt/seagate/cortx/s3/
storage-node1/opt/seagate/cortx/s3/conf/
storage-node1/opt/seagate/cortx/s3/conf/s3config.yaml
storage-node1/processes.txt
storage-node1/hctl-status.txt

[root@storage-node1 /]# **cat storage-node1/hctl-status.txt**
Data pool:
    # fid name
    0x6f00000000000001:0x8a 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xd5 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    storage-node1  (RC)
    [started]  hax        0x7200000000000001:0x7   inet:tcp:storage-node1@2001
    [started]  ioservice  0x7200000000000001:0xa   inet:tcp:storage-node1@3001
    [started]  ioservice  0x7200000000000001:0x17  inet:tcp:storage-node1@3002
    [started]  confd      0x7200000000000001:0x24  inet:tcp:storage-node1@3003
    [started]  s3server   0x7200000000000001:0x27  inet:tcp:storage-node1@4001
    [started]  s3server   0x7200000000000001:0x2a  inet:tcp:storage-node1@4002
    [unknown]  m0_client  0x7200000000000001:0x2d  inet:tcp:storage-node1@5001
    storage-node2
    [started]  hax        0x7200000000000001:0x34  inet:tcp:storage-node2@2001
    [started]  ioservice  0x7200000000000001:0x37  inet:tcp:storage-node2@3001
    [started]  ioservice  0x7200000000000001:0x44  inet:tcp:storage-node2@3002
    [started]  confd      0x7200000000000001:0x51  inet:tcp:storage-node2@3003
    [started]  s3server   0x7200000000000001:0x54  inet:tcp:storage-node2@4001
    [started]  s3server   0x7200000000000001:0x57  inet:tcp:storage-node2@4002
    [unknown]  m0_client  0x7200000000000001:0x5a  inet:tcp:storage-node2@5001
    storage-node3
    [started]  hax        0x7200000000000001:0x61  inet:tcp:storage-node3@2001
    [started]  ioservice  0x7200000000000001:0x64  inet:tcp:storage-node3@3001
    [started]  ioservice  0x7200000000000001:0x71  inet:tcp:storage-node3@3002
    [started]  confd      0x7200000000000001:0x7e  inet:tcp:storage-node3@3003
    [started]  s3server   0x7200000000000001:0x81  inet:tcp:storage-node3@4001
    [started]  s3server   0x7200000000000001:0x84  inet:tcp:storage-node3@4002
    [unknown]  m0_client  0x7200000000000001:0x87  inet:tcp:storage-node3@5001

[root@storage-node1 /]# **cat storage-node1/processes.txt**
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          1  0.0  0.0  11692  1384 ?        Ss   12:54   0:00 /bin/sh -c set -x; /opt/seagate/cortx/hare/bin/hare_setup start --config yaml:///etc/cortx/cluster.conf; sleep infinity;
root          8  0.0  0.3 956176 55212 ?        Sl   12:54   0:02 /usr/bin/python3.6 /opt/seagate/cortx/hare/bin/hare_setup start --config yaml:///etc/cortx/cluster.conf
root         26  5.0  0.3 787440 55928 ?        Sl   12:54   2:46 consul agent -bind=0.0.0.0 -client=0.0.0.0 -datacenter=dc1 -data-dir=/etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4/consul/data -enable-script-checks -config-dir=/etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4/consul/config -domain=consul -serf-lan-port=8301 -retry-join=consul-server.default.svc.cluster.local:8301
root         28 58.1  1.6 6863900 266304 ?      Sl   12:54  32:00 /usr/bin/python3.6 /opt/seagate/cortx/hare/bin/hax
root        354  0.0  0.0  11688   616 ?        S    12:55   0:00 bash /opt/seagate/cortx/hare/libexec/elect-rc-leader --conf-dir /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4
root        356  0.0  0.0  11988  1020 ?        S    12:55   0:00 gawk { print strftime("%Y-%m-%d %H:%M:%S"), $0 }
root        930  0.0  0.0  11688   668 ?        S    12:55   0:00 bash /opt/seagate/cortx/hare/libexec/elect-rc-leader --conf-dir /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4
root        931  0.0  0.1 785136 26996 ?        Sl   12:55   0:02 consul watch -type=keyprefix -prefix eq/ /opt/seagate/cortx/hare/libexec/proto-rc
root      39125  0.1  0.0  15264  2020 pts/0    Ss   13:48   0:00 /bin/bash
root      43117 59.0  0.3 816900 55108 pts/0    S+   13:49   0:01 /usr/bin/python3.6 /opt/seagate/cortx/hare/bin/hare_setup support_bundle -c yaml:///etc/cortx/cluster.conf -b tempb -t tempdest -s all
root      43324  0.0  0.0  15136  1652 pts/0    S+   13:50   0:00 bash /opt/seagate/cortx/hare/bin/../libexec/hare-reportbug -b tempb -t tempdest -l /share/var/log/cortx//hare/log/aaa120a9e051d103c164f605615c32a4 -c /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4 --systemd-disabled
root      43331  0.0  0.0  11688  1568 ?        S    13:50   0:00 bash /opt/seagate/cortx/hare/libexec/check-service --fid 0x7200000000000001:0x17 --port 3002 --conf-dir /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4
root      43334  0.0  0.0  11688  1412 ?        S    13:50   0:00 bash /opt/seagate/cortx/hare/libexec/check-service --svc s3server@0x7200000000000001:0x2a --port 4002 --conf-dir /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4
root      43338  0.0  0.0  15136   676 pts/0    S+   13:50   0:00 bash /opt/seagate/cortx/hare/bin/../libexec/hare-reportbug -b tempb -t tempdest -l /share/var/log/cortx//hare/log/aaa120a9e051d103c164f605615c32a4 -c /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4 --systemd-disabled
root      43339  0.0  0.0  55172  1852 pts/0    R+   13:50   0:00 ps aux
root      43340  0.0  0.0   7776   672 pts/0    S+   13:50   0:00 tee _reportbug.stderr
root      43341  0.0  0.0  11688   232 ?        R    13:50   0:00 bash /opt/seagate/cortx/hare/libexec/check-service --svc s3server@0x7200000000000001:0x2a --port 4002 --conf-dir /etc/cortx/hare/config//aaa120a9e051d103c164f605615c32a4

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>