### PR TITLE
Problem: get_conf_obj_status is convulated

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1970,6 +1970,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('eq-epoch', 1),
         ('leader', ''),
         ('last_fidk', _fidk_gen),
+        ('failvec', ''),
         *[('m0conf/pools/' + oid_to_fidstr(pool_id), m0conf[pool_id]._name)
           for pool_id in sns_pools()],
         *[('m0conf/profiles/' + oid_to_fidstr(prof_id),

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -383,8 +383,8 @@ class Motr:
                   len(event.nvec))
         notes: List[HaNoteStruct] = []
         for n in event.nvec:
-            n.note.no_state = self.consul_util.get_conf_obj_status(
-                ObjT[n.obj_t], n.note.no_id.f_key, kv_cache=kv_cache)
+            n.note.no_state = self.consul_util.get_conf_obj_status_failvec(
+                Fid.from_struct(n.note.no_id), kv_cache=kv_cache)
             notes.append(n.note)
 
         LOG.debug('Replying ha nvec of length ' + str(len(event.nvec)))

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -580,6 +580,25 @@ class ConsulUtil:
 
     @repeat_if_fails()
     @uses_consul_cache
+    def get_conf_obj_status_failvec(self,
+                                    obj_fid: Fid,
+                                    kv_cache=None) -> int:
+        to_ha_state_map = {
+            'unknown': HaNoteStruct.M0_NC_UNKNOWN,
+            'online': HaNoteStruct.M0_NC_ONLINE,
+            'offline': HaNoteStruct.M0_NC_TRANSIENT,
+            'failed': HaNoteStruct.M0_NC_FAILED}
+
+        failvec_data = self.kv.kv_get('failvec', kv_cache=kv_cache)
+        failvec = failvec_data['Value']
+        if failvec:
+            obj_state = failvec.get(f'{obj_fid}')
+            if obj_state:
+                return to_ha_state_map[str(obj_state).lower()]
+        return HaNoteStruct.M0_NC_ONLINE
+
+    @repeat_if_fails()
+    @uses_consul_cache
     def get_conf_obj_status(self,
                             obj_t: ObjT,
                             fidk: int,


### PR DESCRIPTION
Presently in-order to respond to nvec requests, every motr object's
state is fetched from either consul or kv cache iteratively via
get_conf_obj_status(). The function has become too complex with multiple
redudant kv fetch calls. This overall affects the performance.

Solution:
Idea is that Hare needs to report the correct state of the object which is
either FAILED or ONLINE. This can be easily done by maintaining a failure
vector in consul kv. Every failed object reported by HA or consul will be
updated into the failure vector. While responding to a nvec request from a
motr process, hax just needs to fetch this failure vector (single kv fetch
request), this will return a dictionary of failed objects with their
fids as keys and state as the value. Hax then will hash a given object fid
into this failure vector dictionary to get the state. Mainly, if an
object exists in failure vector that means the object is failed else it can
be reported ONLINE. This will significantly reduce the consul fetch requests
and will be easier to maintain.
It is important that failure vector must be updated by Hare RC node only
to maintain consistency.
Note: Updation of failure vector is not part of this PR.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>