### PR TITLE
Add ARM64/AArch64 support

### DIFF
--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -19,6 +19,7 @@
 import ctypes as c
 import logging
 import os
+import platform
 
 from typing import Optional
 from hax.types import FidStruct, HaNoteStruct, Uint128Struct
@@ -47,7 +48,8 @@ def make_array(ctr, some_list):
 class HaxFFI:
     def __init__(self):
         dirname = os.path.dirname(os.path.abspath(__file__))
-        lib_path = f'{dirname}/../../libhax.cpython-36m-x86_64-linux-gnu.so'
+        arch = platform.machine()
+        lib_path = f'{dirname}/../../libhax.cpython-36m-{arch}-linux-gnu.so'
         LOG.debug('Loading library from path: %s', lib_path)
         lib = c.cdll.LoadLibrary(lib_path)
         lib.init_motr_api.argtypes = [c.py_object, c.c_char_p]


### PR DESCRIPTION
Add ARM64/AArch64 support:
1) `make rpm` works now on Arm64.
2) Fixed `libhax.cpython*.so` name for Arm64 at `HaxFFI::__init__`.

Testing: 1) rpm was built with `make rpm` and then installed successfully on the node; 2) singlenode cluster bootstrapped successfully:

```
$ hctl bootstrap --mkfs singlenode.yaml 
2021-10-30 13:14:43: Generating cluster configuration... OK
2021-10-30 13:15:25: Starting Consul server on this node..................................................................................... OK
2021-10-30 13:18:21: Importing configuration into the KV store... OK
2021-10-30 13:18:24: Starting Consul on other nodes...Consul ready on all nodes
2021-10-30 13:18:26: Updating Consul configuraton from the KV store... OK
2021-10-30 13:18:43: Waiting for the RC Leader to get elected...... OK
2021-10-30 13:19:00: Starting Motr (phase1, mkfs)... OK
2021-10-30 13:19:57: Starting Motr (phase1, m0d)... OK
2021-10-30 13:20:36: Starting Motr (phase2, mkfs)... OK
2021-10-30 13:21:28: Starting Motr (phase2, m0d)... OK
2021-10-30 13:22:24: Checking health of services... OK
```

Note: `sage-2.1` branch was used for testing.