### PR TITLE
spec: fix make rpm on CentOS 8

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -41,10 +41,17 @@ BuildRequires: cortx-motr
 BuildRequires: cortx-motr-devel
 BuildRequires: cortx-py-utils
 BuildRequires: git
+%if %{rhel} < 8
 BuildRequires: python36
 BuildRequires: python36-devel
 BuildRequires: python36-pip
 BuildRequires: python36-setuptools
+%else
+BuildRequires: python3
+BuildRequires: python3-devel
+BuildRequires: python3-pip
+BuildRequires: python3-setuptools
+%endif
 
 Requires: consul >= 1.7.0, consul < 1.10.0
 Requires: puppet-agent >= 6.13.0

--- a/hare.spec
+++ b/hare.spec
@@ -18,12 +18,12 @@
 # build number
 %define h_build_num  %(test -n "$build_number" && echo "$build_number" || echo 1)
 
-# motr git revision
-#   assume that Motr package release has format 'buildnum_gitid_kernelver'
-%define h_motr_gitrev %(rpm -q --whatprovides cortx-motr | xargs rpm -q --queryformat '%{RELEASE}' | cut -f2 -d_)
-
 # motr version
+%if %{rhel} < 8
 %define h_motr_version %(rpm -q --whatprovides cortx-motr | xargs rpm -q --queryformat '%{VERSION}-%{RELEASE}')
+%else
+%define h_motr_version %(rpm -q --whatprovides cortx-motr | xargs rpm -q --queryformat '%%{VERSION}-%%{RELEASE}')
+%endif
 
 # parallel build jobs
 %define h_build_jobs_opt  %(test -n "$build_jobs" && echo "-j$build_jobs" || echo '')

--- a/hare.spec
+++ b/hare.spec
@@ -58,7 +58,11 @@ Requires: puppet-agent >= 6.13.0
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}
 Requires: cortx-py-utils
+%if %{rhel} < 8
 Requires: python36
+%else
+Requires: python3
+%endif
 
 Conflicts: halon
 


### PR DESCRIPTION
`make rpm` is failing on CentOS 8, solution:
1) `python36-*` packages are called `python3-*` in CentOS 8 - update in requirements.
2) Fix `h_motr_version` for motr requirement: it is taking the VERSION and RELEASE values from Hare instead of Motr. Fix by adding one more escape `%` symbol before VERSION and RELEASE.