### PR TITLE
Fix facter version check on CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and health-checking mechanisms.
   ```sh
   facter -v
   ```
-  Supported version is **facter >= 3.14.2**, If the facter version is **< 3.14.2** then follow the steps below: 
+  Supported version is **facter >= 3.14**, If the facter version is **< 3.14** then follow the steps below:
   ```sh
   yum erase -y $(rpm -q --whatprovides $(readlink -f /usr/bin/facter)) || rm -fv /usr/bin/facter
   ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and health-checking mechanisms.
   ```sh
   facter -v
   ```
-  Supported version is **facter >= 3.14.8**, If the facter version is **< 3.14.8** then follow the steps below: 
+  Supported version is **facter >= 3.14.2**, If the facter version is **< 3.14.2** then follow the steps below: 
   ```sh
   yum erase -y $(rpm -q --whatprovides $(readlink -f /usr/bin/facter)) || rm -fv /usr/bin/facter
   ```

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -584,11 +584,11 @@ def validate_facter(hostname: str) -> None:
     # 3.14.8 (commit 4339472f441868ecdae694ffc71e7c8ed0fc24e3)
     ver_str = ver_str.split(' ')[0]
 
-    if version(ver_str) >= version('3.14.8'):
+    if version(ver_str) >= version('3.14.2'):
         return
     raise RuntimeError(
         f'Unsupported facter version found at node {hostname}: {ver_str}. '
-        'Please use 3.14.8 or higher.')
+        'Please use 3.14.2 or higher.')
 
 
 def get_facts(hostname: str, mock_p: bool, *args: str) -> Dict[str, Any]:

--- a/hare.spec
+++ b/hare.spec
@@ -47,7 +47,11 @@ BuildRequires: python36-pip
 BuildRequires: python36-setuptools
 
 Requires: consul >= 1.7.0, consul < 1.10.0
+%if %{rhel} < 8
 Requires: puppet-agent >= 6.13.0
+%else
+Requires: facter >= 3.14.2
+%endif
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}
 Requires: cortx-py-utils
@@ -91,11 +95,13 @@ groupadd --force hare
 chgrp hare /var/lib/hare
 chmod --changes g+w /var/lib/hare
 
+%if %{rhel} < 8
 # puppet-agent provides a newer version of facter, but sometimes it might not be
 # available in /usr/bin/, so we need to fix this
 if [[ ! -e /usr/bin/facter && -e /opt/puppetlabs/bin/facter ]] ; then
     ln -vsf /opt/puppetlabs/bin/facter /usr/bin/facter
 fi
+%endif
 
 %postun
 systemctl daemon-reload


### PR DESCRIPTION
On CentOS 8 the standard facter rpm version is 3.14,
which fits our needs. So the puppet-agent rpm (which
provided the needed version of facter-3.14 to us on
CentOS 7) is no longer required on CentOS 8.

-----
[View rendered README.md](https://github.com/andriytk/cortx-hare/blob/fix-facter-check-centos8/README.md)