### PR TITLE
EOS-25727: motr process probe in hare check-service script may timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ install: install-dirs install-cfgen install-hax install-miniprov install-systemd
 	@$(call _info,Altering generated executables to make Python imports work)
 	@$(call _fix_hare_imports,hare_setup)
 	@$(call _fix_hare_imports,configure)
+	@$(call _fix_hare_imports,m0ping)
 	@$(call _fix_hare_imports,update-conf)
 
 .PHONY: install-dirs

--- a/hax/helper/ping.py
+++ b/hax/helper/ping.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +16,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import sys
+
 from tcpping import tcpping
 
 
@@ -26,11 +25,7 @@ def main():
         hostname = sys.argv[1]
         port = sys.argv[2]
         if tcpping(host=hostname, port=port, timeout=1):
-            exit(0)
+            sys.exit(0)
     except Exception:
-        exit(1)
-    exit(1)
-
-
-if __name__ == '__main__':
-    main()
+        sys.exit(1)
+    sys.exit(1)

--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -23,6 +23,7 @@ click==8.0.1
 dataclasses==0.8
 python-consul==1.1.0
 simplejson==3.17.2
+tcpping==0.2
 pytest-cov
 coverage
 inject==4.3.1

--- a/hax/setup.py
+++ b/hax/setup.py
@@ -166,6 +166,7 @@ setup(
         'console_scripts': [
             'hax=hax.hax:main', 'q=hax.queue.cli:main',
             'configure=helper.configure:main',
+            'm0ping=helper.ping:main',
             'update-conf=helper.update_conf:main'
         ]
     },

--- a/stubs/tcpping/__init__.pyi
+++ b/stubs/tcpping/__init__.pyi
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+def tcpping(host, port, timeout = 5): ...

--- a/utils/check-service
+++ b/utils/check-service
@@ -117,7 +117,7 @@ if [[ $service =~ m0d ]]; then
     fi
 fi
 
-/opt/seagate/cortx/hare/libexec/m0ping $(get_node_name) $port
+/opt/seagate/cortx/hare/bin/m0ping $(get_node_name) $port
 rc=$?
 # Curl return codes that suggests that the service is active,
 # 0 -> OK, all fine. Proceed as usual.

--- a/utils/check-service
+++ b/utils/check-service
@@ -117,7 +117,7 @@ if [[ $service =~ m0d ]]; then
     fi
 fi
 
-curl $(get_node_name):$port
+/opt/seagate/cortx/hare/libexec/m0ping $(get_node_name) $port
 rc=$?
 # Curl return codes that suggests that the service is active,
 # 0 -> OK, all fine. Proceed as usual.
@@ -131,7 +131,7 @@ rc=$?
 #       is received when curl request is sent to motr processes on
 #       their given ports.
 case $rc in
-    0|52|56)
+    0)
         exit ${status[passing]};;
     *)
         exit ${status[warning]};;

--- a/utils/m0ping
+++ b/utils/m0ping
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import sys
+from tcpping import tcpping
+
+
+def main():
+    try:
+        hostname = sys.argv[1]
+        port = sys.argv[2]
+        if tcpping(host=hostname, port=port, timeout=1):
+            exit(0)
+    except Exception:
+        exit(1)
+    exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In non-container environment with systemd enabled, hare uses systemd
interface to check if motr process is online or not. As systemd is not
enabled in container environment, hare uses a http probe to check if
motr process is online or not. This works but the respective curl command
may take more than 30s to complete in certain circumstances. This may
result in the consul watcher timeout which by default 30s.

```
[root@cortx-data-headless-svc-sm13-r2 /]# time curl cortx-data-headless-svc-sm13-r2:3001
curl: (56) Recv failure: Connection reset by peer

real    0m45.988s
user    0m0.007s
sys     0m0.006s
```
This may lead to timeout when consul watcher tries to check the status of
a motr service which may lead to a false failure notification,

```
{'Node': 'cortx-data-headless-svc-sm13-r2', 'CheckID': 'service:198',
'Name': "Service 'ios' check", 'Status': 'critical', 'Notes': '',
'Output': 'Timed out (30s) running check
```

Due to this a false Motr service failure might be reported. A more reliable
mechanism must be used in container environment in-order to monitor motr processes.

Solution:
- develop a ping utility to ping a given endpoint address and port to check if
the endpoint is active or not.

Tested on a container setup,
```
[root@cortx-data-headless-svc-sm13-r2 ~]# ./m0ping cortx-data-headless-svc-sm13-r2 5001
[root@cortx-data-headless-svc-sm13-r2 ~]# echo $?
1
[root@cortx-data-headless-svc-sm13-r2 ~]# ./m0ping cortx-data-headless-svc-sm13-r2 3001
Connected to cortx-data-headless-svc-sm13-r2[:3001]: seq=1 time=0.41 ms
[root@cortx-data-headless-svc-sm13-r2 ~]# echo $?
0
```

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>