### PR TITLE
hax: fix SIGSEGV panic on CentOS 8

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -18,12 +18,12 @@
 # build number
 %define h_build_num  %(test -n "$build_number" && echo "$build_number" || echo 1)
 
-# motr git revision
-#   assume that Motr package release has format 'buildnum_gitid_kernelver'
-%define h_motr_gitrev %(rpm -q --whatprovides cortx-motr | xargs rpm -q --queryformat '%{RELEASE}' | cut -f2 -d_)
-
 # motr version
+%if %{rhel} < 8
 %define h_motr_version %(rpm -q --whatprovides cortx-motr | xargs rpm -q --queryformat '%{VERSION}-%{RELEASE}')
+%else
+%define h_motr_version %(rpm -q --whatprovides cortx-motr | xargs rpm -q --queryformat '%%{VERSION}-%%{RELEASE}')
+%endif
 
 # parallel build jobs
 %define h_build_jobs_opt  %(test -n "$build_jobs" && echo "-j$build_jobs" || echo '')
@@ -41,10 +41,17 @@ BuildRequires: cortx-motr
 BuildRequires: cortx-motr-devel
 BuildRequires: cortx-py-utils
 BuildRequires: git
+%if %{rhel} < 8
 BuildRequires: python36
 BuildRequires: python36-devel
 BuildRequires: python36-pip
 BuildRequires: python36-setuptools
+%else
+BuildRequires: python3
+BuildRequires: python3-devel
+BuildRequires: python3-pip
+BuildRequires: python3-setuptools
+%endif
 
 Requires: consul >= 1.7.0, consul < 1.10.0
 %if %{rhel} < 8
@@ -55,7 +62,11 @@ Requires: facter >= 3.14.2
 Requires: jq
 Requires: cortx-motr = %{h_motr_version}
 Requires: cortx-py-utils
+%if %{rhel} < 8
 Requires: python36
+%else
+Requires: python3
+%endif
 
 Conflicts: halon
 

--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -47,7 +47,6 @@ class FsStatsUpdater(StoppableThread):
     def _execute(self, motr: Motr):
         try:
             LOG.info('filesystem stats updater thread has started')
-            motr.adopt_motr_thread()
             while not self.stopped:
                 if not self._am_i_rc():
                     wait_for_event(self.event, self.interval_sec)
@@ -80,8 +79,6 @@ class FsStatsUpdater(StoppableThread):
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:
-            LOG.debug('Releasing motr-related resources for this thread')
-            motr.shun_motr_thread()
             LOG.debug('filesystem stats updater thread exited')
 
     def _am_i_rc(self):

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -167,7 +167,6 @@ class ConsumerThread(StoppableThread):
 
     def _do_work(self, planner: WorkPlanner, motr: Motr):
         LOG.info('Handler thread has started')
-        motr.adopt_motr_thread()
 
         try:
             while True:
@@ -279,6 +278,5 @@ class ConsumerThread(StoppableThread):
             LOG.info('Consumer Stopped')
             if self.idx == 0:
                 motr.stop()
-            motr.shun_motr_thread()
         finally:
             LOG.info('Handler thread has exited')

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -551,14 +551,6 @@ class Motr:
                                  make_c_str(hax_endpoint))
         self.herald.wait_for_all(HaLinkMessagePromise(ids))
 
-    def adopt_motr_thread(self):
-        LOG.debug('Adopting Motr thread')
-        self._ffi.adopt_motr_thread(self._ha_ctx)
-
-    def shun_motr_thread(self):
-        LOG.debug('Shunning Motr thread')
-        self._ffi.shun_motr_thread()
-
     def get_filesystem_stats(self) -> FsStats:
         stats: FsStats = self._ffi.filesystem_stats_fetch(self._ha_ctx)
         if stats is None:

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -118,11 +118,6 @@ class HaxFFI:
         ]
         self.hax_link_stopped = lib.m0_hax_link_stopped
 
-        lib.adopt_motr_thread.argtypes = []
-        lib.adopt_motr_thread.restype = c.c_int
-        self.adopt_motr_thread = lib.adopt_motr_thread
-        self.shun_motr_thread = lib.shun_motr_thread
-
         lib.m0_ha_filesystem_stats_fetch.argtypes = [c.c_void_p]
         lib.m0_ha_filesystem_stats_fetch.restype = c.py_object
         self.filesystem_stats_fetch = lib.m0_ha_filesystem_stats_fetch

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -47,7 +47,6 @@
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_HA
 #include "lib/trace.h"    /* M0_LOG, M0_DEBUG */
 
-static __thread struct m0_thread m0thread;
 static struct hax_context *hc0;
 
 static void __ha_failvec_reply_send(const struct hax_msg *hm,
@@ -898,21 +897,6 @@ static struct m0_ha_msg *_ha_nvec_msg_alloc(const struct m0_ha_nvec *nvec,
 	memcpy(msg->hm_data.u.hed_nvec.hmnv_arr.hmna_arr, nvec->nv_note,
 	       nvec->nv_nr * sizeof(nvec->nv_note[0]));
 	return msg;
-}
-
-void adopt_motr_thread(unsigned long long ctx)
-{
-	struct hax_context *hc = (struct hax_context *)ctx;
-	int                 rc;
-
-	rc = m0_halon_interface_thread_adopt(hc->hc_hi, &m0thread);
-	if (rc != 0)
-		M0_LOG(M0_ERROR, "Motr thread adoption failed: %d\n", rc);
-}
-
-void shun_motr_thread()
-{
-	m0_halon_interface_thread_shun();
 }
 
 /* ---------------------------- SNS operations ---------------------------- */

--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -104,8 +104,6 @@ PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx);
 PyObject *m0_hax_stop(unsigned long long ctx, const struct m0_fid *process_fid,
 		      const char *hax_endpoint);
 void m0_hax_link_stopped(unsigned long long ctx, const char *proc_ep);
-void adopt_motr_thread(unsigned long long ctx);
-void shun_motr_thread(void);
 
 void motr_api_stop(unsigned long long ctx);
 void motr_api_fini(unsigned long long ctx);

--- a/hax/hax/motr/rconfc.py
+++ b/hax/hax/motr/rconfc.py
@@ -36,7 +36,6 @@ class RconfcStarter(StoppableThread):
         try:
             LOG.debug('rconfc starter thread has started')
             self.consul.ensure_motr_all_started(self.event)
-            motr.adopt_motr_thread()
             while (not self.stopped) and (not motr.spiel_ready):
                 started = self.consul.ensure_ioservices_running()
                 if not all(started):
@@ -53,6 +52,4 @@ class RconfcStarter(StoppableThread):
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:
-            motr.shun_motr_thread()
-            LOG.debug('Stopping rconfc')
             LOG.debug('rconfc starter thread exited')

--- a/hax/test/integration/testutils.py
+++ b/hax/test/integration/testutils.py
@@ -239,14 +239,6 @@ class FakeFFI(HaxFFI):
         ...
 
     @trace_call
-    def adopt_motr_thread(self, ha_ctx):
-        ...
-
-    @trace_call
-    def shun_motr_thread(self):
-        ...
-
-    @trace_call
     def ha_broadcast(self, _ha_ctx, ha_notes, notes_len):
         return [MessageId(101, 1), MessageId(101, 2)]
 


### PR DESCRIPTION
The following panic is observed on CentOS 8 on startup:

    hare-hax[270375]: 2021-11-08 16:04:42,950 [DEBUG] {MainThread} Loading library from path: /opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/motr/../../libhax.cpython-36m-x86_64-linux-gnu.so
    hare-hax[270375]: 2021-11-08 16:04:43,061 [INFO] {qconsumer-0} Handler thread has started
    hare-hax[270375]: 2021-11-08 16:04:43,061 [DEBUG] {qconsumer-0} Adopting Motr thread
    hare-hax[270375]: motr[270375]:  c700  FATAL  [lib/assert.c:50:m0_panic]  panic: fatal signal delivered at unknown() (unknown:0)  [git: 2.0.0-307-21-g05f1efe0] /var/motr/hax/m0trace.270375
    hare-hax[270375]: Motr panic: fatal signal delivered at unknown() unknown:0 (errno: 0) (last failed: none) [git: 2.0.0-307-21-g05f1efe0] pid: 270375  /var/motr/hax/m0trace.270375
    hare-hax[270375]: Motr panic reason: signo: 11
    ...
    Stack trace of thread 270397:
    #0  0x00007fce6d6ce7ff raise (libc.so.6)
    #1  0x00007fce6d6b8c35 abort (libc.so.6)
    #2  0x00007fce6554f453 m0_arch_panic (libmotr.so.2)
    #3  0x00007fce6553ec3d m0_panic (libmotr.so.2)
    #4  0x00007fce6554f49c sigsegv (libmotr.so.2)
    #5  0x00007fce6e1f6b20 __restore_rt (libpthread.so.0)
    #6  0x00007fce65bb540b adopt_motr_thread (libhax.cpython-36m-x86_64-linux-gnu.so)
    #7  0x00007fce6b87b09e ffi_call_unix64 (libffi.so.6)
    #8  0x00007fce6b87aa4f ffi_call (libffi.so.6)
    #9  0x00007fce6ba8d947 _ctypes_callproc.cold.53 (_ctypes.cpython-36m-x86_64-linux-gnu.so)
    #10 0x00007fce6ba91fd9 PyCFuncPtr_call (_ctypes.cpython-36m-x86_64-linux-gnu.so)
    #11 0x00007fce6e5a0d2b _PyObject_FastCallKeywords (libpython3.6m.so.1.0)
    #12 0x00007fce6e5a16f6 call_function (libpython3.6m.so.1.0)
    #13 0x00007fce6e5a21f8 _PyEval_EvalFrameDefault (libpython3.6m.so.1.0)
    #14 0x00007fce6e57e098 fast_function (libpython3.6m.so.1.0)
    #15 0x00007fce6e5a15b7 call_function (libpython3.6m.so.1.0)
    #16 0x00007fce6e5a21f8 _PyEval_EvalFrameDefault (libpython3.6m.so.1.0)
    #17 0x00007fce6e4ff112 _PyFunction_FastCallDict (libpython3.6m.so.1.0)
    #18 0x00007fce6e4ffeee _PyObject_FastCallDict (libpython3.6m.so.1.0)
    #19 0x00007fce6e511d80 method_call (libpython3.6m.so.1.0)
    #20 0x00007fce6e506bbb PyObject_Call (libpython3.6m.so.1.0)
    #21 0x00007fce6e5a406a _PyEval_EvalFrameDefault (libpython3.6m.so.1.0)
    #22 0x00007fce6e57e098 fast_function (libpython3.6m.so.1.0)
    #23 0x00007fce6e5a15b7 call_function (libpython3.6m.so.1.0)
    #24 0x00007fce6e5a21f8 _PyEval_EvalFrameDefault (libpython3.6m.so.1.0)
    #25 0x00007fce6e57e098 fast_function (libpython3.6m.so.1.0)
    #26 0x00007fce6e5a15b7 call_function (libpython3.6m.so.1.0)
    #27 0x00007fce6e5a21f8 _PyEval_EvalFrameDefault (libpython3.6m.so.1.0)
    #28 0x00007fce6e4ff112 _PyFunction_FastCallDict (libpython3.6m.so.1.0)
    #29 0x00007fce6e4ffeee _PyObject_FastCallDict (libpython3.6m.so.1.0)
    #30 0x00007fce6e511d80 method_call (libpython3.6m.so.1.0)
    #31 0x00007fce6e506bbb PyObject_Call (libpython3.6m.so.1.0)
    #32 0x00007fce6e612142 t_bootstrap (libpython3.6m.so.1.0)
    #33 0x00007fce6e5b8664 pythread_wrapper (libpython3.6m.so.1.0)
    #34 0x00007fce6e1ec14a start_thread (libpthread.so.0)
    #35 0x00007fce6d793f23 __clone (libc.so.6)

Solution: don't call adopt_motr_thread() - it's not needed
anymore in Motr since the Nikita's patch from 8 Sep 2020:
"implement __thread-based TLS" (commit 2900637d).