### PR TITLE
EOS-25863: BroadcastHAStates is slow at large clusters

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -19,7 +19,7 @@
 import ctypes as c
 import logging
 from errno import EAGAIN
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from hax.consul.cache import supports_consul_cache, uses_consul_cache
 from hax.exception import ConfdQuorumException, RepairRebalanceException
@@ -32,7 +32,7 @@ from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
                        MessageId, ObjT, Profile, ReprebStatus, ServiceHealth,
                        m0HaProcessEvent, m0HaProcessType)
-from hax.util import ConsulUtil, repeat_if_fails, FidWithType
+from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
 
 LOG = logging.getLogger('hax')
 
@@ -306,17 +306,23 @@ class Motr:
                 is_node_failed = self.is_node_failed(note, kv_cache=kv_cache)
                 if (st.status == ServiceHealth.FAILED
                         and is_node_failed):
-                    notes += self.notify_node_status_by_process(note)
+                    notes += self.notify_node_status_by_process(
+                        note, kv_cache=kv_cache)
                 elif (st.status == ServiceHealth.OK
                         and not is_node_failed):
-                    notes += self.notify_node_status_by_process(note)
+                    notes += self.notify_node_status_by_process(
+                        note, kv_cache=kv_cache)
                 else:
-                    ctrl_note = self.get_ctrl_status(note)
+                    ctrl_note = self.get_ctrl_status(note, kv_cache=kv_cache)
                     if ctrl_note is not None:
-                        notes.append(ctrl_note)
+                        (a_note, updates) = ctrl_note
+                        notes.append(a_note)
+                        self._write_updates(updates, kv_cache)
 
             if st.fid.container == ObjT.DRIVE.value:
-                self.consul_util.update_drive_state([st.fid], st.status)
+                self.consul_util.update_drive_state([st.fid],
+                                                    st.status,
+                                                    kv_cache=kv_cache)
             elif st.fid.container == ObjT.NODE.value:
                 self.consul_util.set_node_state(st.fid,
                                                 st.status,
@@ -494,11 +500,14 @@ class Motr:
 
         # Update the states of all the controllers as failed, in case of
         # node failure event.
+        #
         if new_state == ServiceHealth.FAILED and ctrl_fids:
+            updates: List[PutKV] = []
             for x in ctrl_fids:
-                self.consul_util.set_ctrl_state(x,
-                                                new_state,
-                                                kv_cache=kv_cache)
+                updates += self.consul_util.get_ctrl_state_updates(
+                    x, new_state, kv_cache=kv_cache)
+
+            self._write_updates(updates, kv_cache)
 
         notes = []
         if encl_fid:
@@ -524,39 +533,53 @@ class Motr:
 
         node = self.consul_util.get_process_node(proc_fid, kv_cache=kv_cache)
 
+        updates: List[PutKV] = []
         if new_state == ServiceHealth.OK:
             # Node can have multiple controllers. Node can be online, with
             # a single controller running online.
             # If we receive process 'OK', only the process state is
             # updated. So, we need to update the corresponding
             # controller state.
-            ctrl_fid = self.consul_util.get_ioservice_ctrl_fid(proc_fid)
+            ctrl_fid = self.consul_util.get_ioservice_ctrl_fid(
+                proc_fid, kv_cache=kv_cache)
             if ctrl_fid:
-                self.consul_util.set_ctrl_state(ctrl_fid, new_state)
+                updates = self.consul_util.get_ctrl_state_updates(
+                    ctrl_fid, new_state, kv_cache=kv_cache)
 
         node_fid = self.consul_util.get_node_fid(node, kv_cache=kv_cache)
+        # FIXME make these two functions to return List[PutKV] so that the
+        # write operations can be delayed to reuse the cache as long as
+        # possible
         notes = self.add_node_state_by_fid(node_fid, new_state)
         notes += self.add_enclosing_devices_by_node(node_fid,
                                                     new_state,
                                                     node=node,
                                                     kv_cache=kv_cache)
+        self._write_updates(updates, kv_cache)
         return notes
 
-    def get_ctrl_status(self,
-                        proc_note: HaNoteStruct) -> Optional[HaNoteStruct]:
+    @supports_consul_cache
+    def get_ctrl_status(
+            self,
+            proc_note: HaNoteStruct,
+            kv_cache=None) -> Optional[Tuple[HaNoteStruct, List[PutKV]]]:
         new_state = proc_note.no_state
         proc_fid = Fid.from_struct(proc_note.no_id)
         assert ObjT.PROCESS.value == proc_fid.container
         LOG.debug('Notifying ctrl status for process_fid=%s state=%s',
                   proc_fid, new_state)
 
-        ctrl_fid = self.consul_util.get_ioservice_ctrl_fid(proc_fid)
+        ctrl_fid = self.consul_util.get_ioservice_ctrl_fid(proc_fid,
+                                                           kv_cache=kv_cache)
 
         if ctrl_fid:
             # Update controller state in consul kv.
-            self.consul_util.set_ctrl_state(
-                ctrl_fid, ServiceHealth.from_ha_note_state(new_state))
-            return HaNoteStruct(no_id=ctrl_fid.to_c(), no_state=new_state)
+            updates = self.consul_util.get_ctrl_state_updates(
+                ctrl_fid,
+                ServiceHealth.from_ha_note_state(new_state),
+                kv_cache=kv_cache)
+            return (HaNoteStruct(no_id=ctrl_fid.to_c(),
+                                 no_state=new_state), updates)
         return None
 
     # Check if all the IO services of node are failed
@@ -681,3 +704,7 @@ class Motr:
                 'Failed to send SPIEL request "sns_rebalance_resume",' +
                 'please check Motr logs for more details.')
         LOG.debug('Rebalancing resumed for pool %s', pool_fid)
+
+    def _write_updates(self, updates: List[PutKV], kv_cache=None) -> None:
+        for op in updates:
+            self.consul_util.kv.kv_put(op.key, op.value, kv_cache=kv_cache)

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -168,6 +168,11 @@ def repeat_if_fails(wait_seconds=5, max_retries=-1):
 TxPutKV = NamedTuple('TxPutKV', [('key', str), ('value', str),
                                  ('cas', Optional[Any])])
 
+PutKV = NamedTuple('PutKV', [
+    ('key', str),
+    ('value', str)
+])
+
 
 def wait_for_event(event: Event, interval_sec) -> None:
     """
@@ -832,14 +837,18 @@ class ConsulUtil:
         return list_fids
 
     @repeat_if_fails()
+    @uses_consul_cache
     def get_io_service_devices(self,
-                               ioservice_fid: Fid) -> Optional[List[str]]:
+                               ioservice_fid: Fid,
+                               kv_cache=None) -> Optional[List[str]]:
         if not ioservice_fid:
             return None
         # Example key m0conf/nodes/0x6e00000000000001:0x3/processes/
         #   0x7200000000000001:0x15/services/0x7300000000000001:0x17/sdevs/
         #   0x6400000000000001:0x18:{"path": "/dev/sdc", "state": "offline"}
-        sdev_items = self.kv.kv_get('m0conf/nodes', recurse=True)
+        sdev_items = self.kv.kv_get('m0conf/nodes',
+                                    recurse=True,
+                                    kv_cache=kv_cache)
         regex = re.compile(
             f'^m0conf\\/.*\\/processes\\/{ioservice_fid}\\/.*\\/sdevs\\/.*$')
         sdev_fids = []
@@ -858,12 +867,13 @@ class ConsulUtil:
         return self.kv.kv_get('m0conf/sites', recurse=True, kv_cache=kv_cache)
 
     @repeat_if_fails()
-    def get_device_controller(self, sdev_fid):
+    @uses_consul_cache
+    def get_device_controller(self, sdev_fid, kv_cache=None):
         # Example key m0conf/sites/0x5300000000000001:0x1/racks/
         #    0x6100000000000001:0x2/encls/0x6500000000000001:0x4/ctrls/
         #    0x6300000000000001:0x5/drives/0x6b00000000000001:0x38:
         #    {"sdev": "0x6400000000000001:0x37", "state": "M0_NC_UNKNOWN"}
-        sites_items = self.get_all_sites()
+        sites_items = self.get_all_sites(kv_cache=kv_cache)
 
         for item in sites_items:
             if 'sdev' not in json.loads(item['Value']).keys():
@@ -876,7 +886,10 @@ class ConsulUtil:
         return None
 
     @repeat_if_fails()
-    def get_ioservice_ctrl_fid(self, ioservice_fid: Fid) -> Optional[Fid]:
+    @uses_consul_cache
+    def get_ioservice_ctrl_fid(self,
+                               ioservice_fid: Fid,
+                               kv_cache=None) -> Optional[Fid]:
         """
         Returns the fid of the controller for the given IOservice.
 
@@ -889,14 +902,15 @@ class ConsulUtil:
         if not ioservice_fid:
             return None
 
-        sdev_fids = self.get_io_service_devices(ioservice_fid)
+        sdev_fids = self.get_io_service_devices(ioservice_fid,
+                                                kv_cache=kv_cache)
 
         if not sdev_fids:
             return None
 
         sdev_fid = sdev_fids[0]
 
-        ctrl_fid = self.get_device_controller(sdev_fid)
+        ctrl_fid = self.get_device_controller(sdev_fid, kv_cache=kv_cache)
 
         if ctrl_fid is None:
             return None
@@ -1038,10 +1052,10 @@ class ConsulUtil:
             self.kv.kv_put(encl['Key'], json.dumps(value), kv_cache=kv_cache)
 
     @repeat_if_fails()
-    def set_ctrl_state(self,
-                       ctrl_fid: Fid,
-                       status: ServiceHealth,
-                       kv_cache=None) -> None:
+    def get_ctrl_state_updates(self,
+                               ctrl_fid: Fid,
+                               status: ServiceHealth,
+                               kv_cache=None) -> List[PutKV]:
         # Example,
         # {
         #    "key": "m0conf/sites/0x5300000000000001:0x1/
@@ -1052,15 +1066,17 @@ class ConsulUtil:
         # }
         ctrl_items = self.get_all_sites(kv_cache=kv_cache)
         regex = re.compile(f'^m0conf\\/.*\\/ctrls/{ctrl_fid}$')
+        result: List[PutKV] = []
         for ctrl in ctrl_items:
             match_result = re.match(regex, ctrl['Key'])
             if not match_result:
                 continue
             value = json.loads(ctrl['Value'])
             value['state'] = self.get_device_ha_state(status)
-            LOG.debug('Setting ctrl=%s in KV with state=%s',
-                      ctrl_fid, value['state'])
-            self.kv.kv_put(ctrl['Key'], json.dumps(value), kv_cache=kv_cache)
+            LOG.debug('Setting ctrl=%s in KV with state=%s', ctrl_fid,
+                      value['state'])
+            result.append(PutKV(key=ctrl['Key'], value=json.dumps(value)))
+        return result
 
     @repeat_if_fails()
     @uses_consul_cache
@@ -1173,29 +1189,43 @@ class ConsulUtil:
         LOG.debug('Setting process status in KV: %s:%s', key, data)
         self.kv.kv_put(key, data)
 
+    @supports_consul_cache
     def update_drive_state(self,
                            drive_fids: List[Fid],
                            status: ServiceHealth,
-                           device_event=True) -> None:
+                           device_event=True,
+                           kv_cache=None) -> None:
         device_state_map = {
             ServiceHealth.OK: 'online',
             ServiceHealth.FAILED: 'failed',
             ServiceHealth.OFFLINE: 'offline',
         }
+        updates: List[PutKV] = []
         for drive in drive_fids:
             sdev_fid = self.drive_to_sdev_fid(drive)
-            self.set_sdev_state(sdev_fid, device_state_map[status],
-                                device_event)
+            # Note that we don't update KV values within this call
+            # but accumulate the changes until we come to the end of the
+            # current function. This helps to reuse the kv_cache as long as
+            # possible (any kv_put operation will invalidate the current cache)
+            updates += self.get_sdev_state_update(sdev_fid,
+                                                  device_state_map[status],
+                                                  device_event)
+        for op in updates:
+            self.kv.kv_put(op.key, op.value, kv_cache=kv_cache)
 
     @repeat_if_fails()
-    def set_sdev_state(self,
-                       sdev_fid: Fid,
-                       state: str,
-                       device_event=True) -> None:
+    @supports_consul_cache
+    def get_sdev_state_update(self,
+                              sdev_fid: Fid,
+                              state: str,
+                              device_event=True,
+                              kv_cache=None) -> List[PutKV]:
         LOG.debug('Setting sdev=%s in KV with state=%s', sdev_fid, state)
-        sdev_items = self.kv.kv_get('m0conf/nodes', recurse=True)
-        regex = re.compile(
-            f'^m0conf\\/.*\\/sdevs\\/{sdev_fid}$')
+        sdev_items = self.kv.kv_get('m0conf/nodes',
+                                    recurse=True,
+                                    kv_cache=kv_cache)
+        regex = re.compile(f'^m0conf\\/.*\\/sdevs\\/{sdev_fid}$')
+        result: List[PutKV] = []
         for sdev in sdev_items:
             match_result = re.match(regex, sdev['Key'])
             if not match_result:
@@ -1204,7 +1234,8 @@ class ConsulUtil:
             if not device_event and value['state'] == 'failed':
                 continue
             value['state'] = state
-            self.kv.kv_put(sdev['Key'], json.dumps(value))
+            result.append(PutKV(key=sdev['Key'], value=json.dumps(value)))
+        return result
 
     @repeat_if_fails()
     @uses_consul_cache


### PR DESCRIPTION
Solution:
1. Make sure that execution path of broadcast_ha_states reuses the same
kv_cache instance (to minimize repeated KV GET requests).
2. Refactor the KV-modifying functions so that actual kv_put()
operations can be postponed when possible (reason: kv_put() invalidates
the current kv_cache instance which may be an overkill if kv_put is
invoked too early).
