### PR TITLE
EOS-25863: ProcessEvents processed with a delay

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from queue import Queue
 from typing import Any, List, Optional
 
-from hax.types import Fid, HaNote, HAState, StobId, Uint128
+from hax.types import ConfHaProcess, Fid, HaNote, HAState, StobId, Uint128
 
 
 @dataclass(unsafe_hash=True)
@@ -53,7 +53,7 @@ class FirstEntrypointRequest(AnyEntrypointRequest):
 
 @dataclass
 class ProcessEvent(BaseMessage):
-    evt: Any
+    evt: ConfHaProcess
 
 
 @dataclass

--- a/hax/test/test_work_planner.py
+++ b/hax/test/test_work_planner.py
@@ -126,6 +126,7 @@ class TestMessageOrder(unittest.TestCase):
         def my_state():
             return State(next_group_id=99999,
                          active_commands=LinkedList(),
+                         active_meta={},
                          current_group_id=99999,
                          next_group_commands=set(),
                          is_shutdown=False)
@@ -458,6 +459,7 @@ class TestWorkPlanner(unittest.TestCase):
         def my_state():
             return State(next_group_id=99999,
                          active_commands=LinkedList(),
+                         active_meta={},
                          current_group_id=99999,
                          next_group_commands=set(),
                          is_shutdown=False)
@@ -467,7 +469,7 @@ class TestWorkPlanner(unittest.TestCase):
         tracker = GroupTracker()
         thread_count = 1
         for i in range(10):
-            planner.add_command(process_event())
+            planner.add_command(broadcast())
 
         for j in range(thread_count):
             planner.add_command(Die())
@@ -512,3 +514,4 @@ class TestWorkPlanner(unittest.TestCase):
         groups_processed = tracker.get_tracks()
         self.assertEqual([99999, 10**5, 0, 1, 2, 3, 4,
                           5, 6, 7], groups_processed)
+


### PR DESCRIPTION
## Problem
In fact, the delay is caused by the fact that when a large cluster is bootstrapping, there is a solid flow of BroadcastHAStates events.  According to the current design every broadcast will create a new partition in WorkPlanner which means that when the number of such commands is large, the execution of the commands becomes purely sequential.

## Solution
1. introduce the notion of 'asap commands queue'. Such commands are executed regardless of the current group number in WorkPlanner.  ProcessEvent command becomes an 'ASAP' command (together with AnyEntrypointRequest and NvecGet).
2. Add ordering between ProcessEvent messages. ProcessEvent messages conflict if they contain the same fid. If a ProcessEvent message is being executed already, another conflicting ProcessEvent will not start processing (this effectively pauses ASAP commands queue execution).

