### PR TITLE
EOS-25916: hax uses halink while its disconnecting

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -302,7 +302,8 @@ class Motr:
             # node (enclosure) and CVGs if all Io services are failed.
             if (st.fid.container == ObjT.PROCESS.value
                     and st.status in (ServiceHealth.FAILED, ServiceHealth.OK)
-                    and (not self.consul_util.is_proc_client(st.fid))):
+                    and (not self.consul_util.is_proc_client(st.fid))
+                    and (not self._is_mkfs(st.fid))):
                 # Check if we need to mark node as failed,
                 # otherwise just mark controller as failed/OK
                 # If we receive process failure then we will check if all IO

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -38,6 +38,7 @@
 #include "motr/iem.h"
 #include "ha/msg.h"
 #include "ha/link.h"
+#include "ha/ha.h"
 #include "cm/repreb/cm.h" /* CM_OP_REPAIR etc. */
 #include "conf/ha.h"
 #include "hax.h"
@@ -119,17 +120,6 @@ static void entrypoint_request_cb(struct m0_halon_interface *hi,
 				  bool first_request)
 {
 	struct hax_entrypoint_request *ep;
-	struct hax_link               *hxl;
-
-	M0_ALLOC_PTR(hxl);
-	M0_ASSERT(hxl != NULL);
-	hxl->hxl_req_id = *req_id;
-	hxl->hxl_ep_addr[0] = '\0';
-	strncat(hxl->hxl_ep_addr, remote_rpc_endpoint, EP_ADDR_BUF_SIZE - 1);
-
-	hax_lock(hc0);
-	hx_links_tlink_init_at_tail(hxl, &hc0->hc_links);
-	hax_unlock(hc0);
 
 	/*
 	 * XXX This is obligatory since we want to work with Python object
@@ -577,14 +567,17 @@ static void link_connected_cb(struct m0_halon_interface *hi,
 			      const struct m0_uint128 *req_id,
 			      struct m0_ha_link *link)
 {
+
 	struct hax_link *hxl;
 
 	hax_lock(hc0);
-	hxl = m0_tl_find(hx_links, l, &hc0->hc_links,
-			 m0_uint128_eq(&l->hxl_req_id, req_id));
+	M0_ALLOC_PTR(hxl);
 	M0_ASSERT(hxl != NULL);
+	m0_ha_link_rpc_endpoint(link, hxl->hxl_ep_addr, EP_ADDR_BUF_SIZE);
+	hxl->hxl_req_id = *req_id;
 	hxl->hxl_link = link;
 	hxl->hxl_is_active = true;
+	hx_links_tlink_init_at_tail(hxl, &hc0->hc_links);
 	hax_unlock(hc0);
 }
 
@@ -610,9 +603,8 @@ static void link_is_disconnecting_cb(struct m0_halon_interface *hi,
 	hxl = m0_tl_find(hx_links, l, &hc0->hc_links, l->hxl_link == link);
 	M0_ASSERT(hxl != NULL);
 	M0_LOG(M0_DEBUG, "link=%p addr=%s", hxl, (const char*)hxl->hxl_ep_addr);
-	hax_unlock(hc0);
-
 	m0_halon_interface_disconnect(hi, link);
+	hax_unlock(hc0);
 }
 
 static void link_disconnected_cb(struct m0_halon_interface *hi,


### PR DESCRIPTION
Hax crashed with the following panic,
```
2021-11-11 13:18:35,327 [DEBUG] {rconfc-starter} KVGET key=cortx-data-headless-svc-ssc-vm-g2-rhev4-1634/processes/0x7200000000000001:0x105, kwargs={}
motr[00637]:  9090   WARN  [ha/halon/interface.c:1119:m0_halon_interface_send]  hl=0x7f10540041a0 ep=inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-1963@2001 epoch=0 tag=7 type=2
motr[00637]:  8ed0  FATAL  [lib/assert.c:50:m0_panic]  panic: (m0_ha_lq_invariant(lq)) at m0_ha_lq_enqueue() (ha/lq.c:199)  [git: 2.0.0-527-34-g2fefe244] /etc/cortx/hare/config/c09a91306c824883a5586bc52e3b73c8/m0trace.637
Motr panic: (m0_ha_lq_invariant(lq)) at m0_ha_lq_enqueue() ha/lq.c:199 (errno: 11) (last failed: none) [git: 2.0.0-527-34-g2fefe244] pid: 637  /etc/cortx/hare/config/c09a91306c824883a5586bc52e3b73c8/m0trace.637
/lib64/libmotr.so.2(m0_arch_backtrace+0x2f)[0x7f10a8a3479f]
```

Trying to broadcast to 2001 and 3001 service, where the tag for 3001
looks invalid as highlighted below,
```
174812  448993.082.853486  dff9090  CALL    ha/halon/interface.c:1122:m0_halon_interface_send   < hi=0x27a0950 ha=0x2be9318 hl=0x7f10540041a0 ep=inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-1963@2001 msg=0x7f0ffc04d8a0 epoch=0 tag=7
174813  448993.082.902236  dff9090  CALL    ha/halon/interface.c:1113:m0_halon_interface_send   > hi=0x27a0950 ha=0x2be9318 hl=0x7f0ff0053230 ep=inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-1963@3001 msg=0x7f0ffc04d8a0 epoch=0 *tag=0x7f100dff9288*
```

This could be because the halink was probably getting disconnected,
```
79895  448831.829.719820  f7fd960  CALL    ha/link.c:1362:ha_link_outgoing_fom_tick            > hl=0x7f0ff0053230 phase=HA_LINK_OUTGOING_STATE_IDLE
79896  448831.829.721426  f7fd8f0  CALL    ha/link.c:1310:ha_link_cb_disconnecting_reused      > hl=0x7f0ff0053230
79897  448831.829.722768  f7fd8f0  CALL    ha/link.c:1330:ha_link_cb_disconnecting_reused      < hl=0x7f0ff0053230 cb_disconnecting=0 cb_reused=0
79898  448831.829.727554  f7fd960  CALL    ha/link.c:1590:ha_link_outgoing_fom_tick            < rc=1
```

Thus there seems to be 2 issues,
1. use of invalid halink
   hax maintains an account of halinks, a halink is created when an entrypoint
   request is received, it is possible that it may get used before it is ready,
   e.g. m0_ha_notify may get invoked which may try to use a not ready halink.
2. broadcast of configuration tree hierarchy for mkfs processeses

Solution:
- Don't allocate and add reference to halink in hax context in entrypoint_request_cb(),
instead do it in halink connected call back in a lock, where it more reliable to be used.
- Do not broadcast for entire hierarchy of configuration objects for a mkfs process.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>