### PR TITLE
EOS-26134 : Enable Whitesource scans

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,13 @@
+{
+  "scanSettings": {
+    "configMode": "AUTO",
+    "baseBranches": ["main", "kubernetes"]
+  },
+  "checkRunSettings": {
+    "displayMode": "diff",
+    "vulnerableCheckRunConclusionLevel": "failure"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "NONE"
+  }
+}


### PR DESCRIPTION
Problem:
Whitesource scans are not enabled for cortx-hare repo.

Solution:
Adding .whitesource file to enable scans on cortx-hare repository
Whitesource scans looks for 3rd party libraries in the repositories.
It further identifies if any of the repositories are
vulnerable to known vulnerabilities.
If it finds out such known vulnerabilities in 3rd party libraries,
it reports the vulnerabilities on whitesource dashboard.
It doesn't interfere in any of the existing code.
This file is already tested on other repositories such as
cortx-s3server, cortx-motr etc.
So there is no impact of this change to existing functionality.