### PR TITLE
EOS-25916: mkfs halink is not disconnected

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -277,13 +277,15 @@ class Motr:
     def broadcast_ha_states(self,
                             ha_states: List[HAState],
                             notify_devices=True,
-                            kv_cache=None) -> List[MessageId]:
+                            kv_cache=None,
+                            broadcast_hax_only=False) -> List[MessageId]:
         LOG.debug('Broadcasting HA states %s over ha_link', ha_states)
 
         def ha_obj_state(st):
             return HaNoteStruct.M0_NC_ONLINE if st.status == ServiceHealth.OK \
                 else HaNoteStruct.M0_NC_FAILED
 
+        hax_fid = self.consul_util.get_hax_fid()
         notes = []
         for st in ha_states:
             if st.status in (ServiceHealth.UNKNOWN, ServiceHealth.OFFLINE):
@@ -291,19 +293,31 @@ class Motr:
             note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st))
             notes.append(note)
 
-            if st.fid.container == ObjT.PROCESS.value:
-                self.consul_util.set_process_state(st.fid, st.status)
-
-            notes += self._generate_sub_services(note,
-                                                 self.consul_util,
-                                                 notify_devices,
-                                                 kv_cache=kv_cache)
             # For process failure, we report failure for the corresponding
             # node (enclosure) and CVGs if all Io services are failed.
+            # We avoid broadcasting for the configuration tree corresponding
+            # to motr client processes, S3servers and hax, as the
+            # failure of them does not affect the motr storage devices.
+            # In some cases the broadcast need not be to Motr processes and
+            # s3servers, e.g. for motr-mkfs processes, but the motr-mkfs
+            # event still needs to be delivered to hax's motr land in-order
+            # to update the hax-motr halink state. hax-motr halink is
+            # established when hax responds to Motr/S3server entrypoint
+            # request and terminated when Motr/S3server process notifies
+            # M0_CONF_HA_PROCESS_STOPPED.
             if (st.fid.container == ObjT.PROCESS.value
                     and st.status in (ServiceHealth.FAILED, ServiceHealth.OK)
                     and (not self.consul_util.is_proc_client(st.fid))
-                    and (not self._is_mkfs(st.fid))):
+                    and (not broadcast_hax_only)
+                    and (st.fid != hax_fid)):
+
+                if st.fid.container == ObjT.PROCESS.value:
+                    self.consul_util.set_process_state(st.fid, st.status)
+
+                notes += self._generate_sub_services(note,
+                                                     self.consul_util,
+                                                     notify_devices,
+                                                     kv_cache=kv_cache)
                 # Check if we need to mark node as failed,
                 # otherwise just mark controller as failed/OK
                 # If we receive process failure then we will check if all IO
@@ -341,8 +355,16 @@ class Motr:
                                                             kv_cache=kv_cache)
         if not notes:
             return []
-        message_ids: List[MessageId] = self._ffi.ha_broadcast(
-            self._ha_ctx, make_array(HaNoteStruct, notes), len(notes))
+        message_ids: List[MessageId] = []
+        LOG.debug('broadcast ha states phase %s', broadcast_hax_only)
+        if broadcast_hax_only:
+            hax_endpoint = self.consul_util.get_hax_endpoint()
+            message_ids = self._ffi.ha_broadcast_hax_only(
+                self._ha_ctx, make_array(HaNoteStruct, notes), len(notes),
+                make_c_str(hax_endpoint))
+        else:
+            message_ids = self._ffi.ha_broadcast(
+                self._ha_ctx, make_array(HaNoteStruct, notes), len(notes))
         LOG.debug(
             'Broadcast HA state complete with the following message_ids = %s',
             message_ids)

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -95,6 +95,15 @@ class HaxFFI:
         lib.m0_ha_notify.restype = c.py_object
         self.ha_broadcast = lib.m0_ha_notify
 
+        lib.m0_ha_notify_hax_only.argtypes = [
+            c.c_void_p,  # unsigned long long ctx
+            c.POINTER(HaNoteStruct),  # struct m0_ha_note *notes
+            c.c_uint32,  # uint32_t nr_notes
+            c.c_char_p  # const char *hax_ep
+        ]
+        lib.m0_ha_notify_hax_only.restype = c.py_object
+        self.ha_broadcast_hax_only = lib.m0_ha_notify_hax_only
+
         lib.m0_ha_nvec_reply_send.argtypes = [
             c.c_void_p,  # unsigned long long  hax_msg
             c.POINTER(HaNoteStruct),  # struct m0_ha_note *notes

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -603,6 +603,7 @@ static void link_is_disconnecting_cb(struct m0_halon_interface *hi,
 	hxl = m0_tl_find(hx_links, l, &hc0->hc_links, l->hxl_link == link);
 	M0_ASSERT(hxl != NULL);
 	M0_LOG(M0_DEBUG, "link=%p addr=%s", hxl, (const char*)hxl->hxl_ep_addr);
+	hxl->hxl_is_active = false;
 	m0_halon_interface_disconnect(hi, link);
 	hax_unlock(hc0);
 }
@@ -799,6 +800,49 @@ PyObject* m0_ha_notify(unsigned long long ctx, struct m0_ha_note *notes,
 							 "MessageId", "(KK)",
 							 hxl->hxl_link, tag);
 		PyList_Append(broadcast_tags, instance);
+	}
+	m0_tl_endfor;
+	Py_DECREF(hax_mod);
+	PyGILState_Release(gstate);
+	hax_unlock(hc);
+
+	return broadcast_tags;
+}
+
+PyObject* m0_ha_notify_hax_only(unsigned long long ctx,
+				struct m0_ha_note *notes,
+				uint32_t nr_notes,
+				const char *hax_endpoint)
+{
+	struct hax_context *hc = (struct hax_context *)ctx;
+	struct m0_ha_nvec nvec = { .nv_nr = nr_notes, .nv_note = notes };
+	struct m0_halon_interface *hi = hc->hc_hi;
+	struct hax_link *hxl;
+	struct m0_ha_msg *msg;
+	uint64_t tag;
+
+	msg = _ha_nvec_msg_alloc(&nvec, 0, M0_HA_NVEC_SET);
+	hax_lock(hc);
+
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
+
+	PyObject* hax_mod = getModule("hax.types");
+	PyObject* broadcast_tags = PyList_New(0);
+	m0_tl_for(hx_links, &hc->hc_links, hxl)
+	{
+		if (!hxl->hxl_is_active)
+			continue;
+		if (m0_streq(hxl->hxl_ep_addr, hax_endpoint)) {
+			Py_BEGIN_ALLOW_THREADS
+			m0_halon_interface_send(hi, hxl->hxl_link,
+						msg, &tag);
+			Py_END_ALLOW_THREADS
+			PyObject *instance = PyObject_CallMethod(hax_mod,
+							"MessageId", "(KK)",
+							hxl->hxl_link, tag);
+			PyList_Append(broadcast_tags, instance);
+		}
 	}
 	m0_tl_endfor;
 	Py_DECREF(hax_mod);

--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -93,6 +93,11 @@ void m0_ha_failvec_reply_send(unsigned long long hm, struct m0_fid *pool_fid,
 			      uint32_t nr_notes);
 void m0_ha_nvec_reply_send(unsigned long long hm, struct m0_ha_note *notes, uint32_t nr_notes);
 PyObject *m0_ha_notify(unsigned long long ctx, struct m0_ha_note *notes, uint32_t nr_notes);
+
+PyObject* m0_ha_notify_hax_only(unsigned long long ctx,
+				struct m0_ha_note *notes,
+				uint32_t nr_notes,
+				const char *hax_endpoint);
 void m0_ha_broadcast_test(unsigned long long ctx);
 
 /*

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -629,6 +629,9 @@ def test_broadcast_node_failure(mocker, motr, consul_util):
     mocker.patch.object(consul_util.kv, 'kv_get', side_effect=my_get)
     mocker.patch.object(consul_util.kv, 'kv_put', return_value=0)
     mocker.patch.object(consul_util,
+                        'get_hax_fid',
+                        return_value=Fid(0x7200000000000001, 0x6))
+    mocker.patch.object(consul_util,
                         'get_node_fid',
                         return_value=Fid(0x6e00000000000001, 0x3))
 
@@ -787,6 +790,7 @@ def create_stub_get(process_type: str) -> Callable[[str, bool], Any]:
     return my_get
 
 
+# @pytest.mark.skip(reason="disabled temporarily")
 def test_mkfs_process_stopped_no_disk_marked_offline(mocker, motr,
                                                      consul_util):
     mocker.patch.object(
@@ -796,11 +800,17 @@ def test_mkfs_process_stopped_no_disk_marked_offline(mocker, motr,
     mocker.patch.object(consul_util.kv, 'kv_put', return_value=0)
     mocker.patch.object(consul_util, 'update_drive_state')
     mocker.patch.object(consul_util,
+                        'get_hax_fid',
+                        return_value=Fid(0x7200000000000001, 0x6))
+    mocker.patch.object(consul_util,
                         'get_node_fid',
                         return_value=Fid(0x6e00000000000001, 0x3))
     mocker.patch.object(consul_util,
                         'get_node_encl_fid',
                         return_value=Fid(0x6500000000000001, 0x4))
+    mocker.patch.object(consul_util,
+                        'get_hax_endpoint',
+                        return_value='endpoint')
 
     motr.broadcast_ha_states([
         HAState(fid=Fid(0x7200000000000001, 0x15), status=ServiceHealth.FAILED)
@@ -822,6 +832,9 @@ def test_nonmkfs_process_stop_causes_drive_offline(mocker, motr, consul_util):
                         side_effect=create_stub_get('M0_CONF_HA_PROCESS_M0D'))
     mocker.patch.object(consul_util.kv, 'kv_put', return_value=0)
     mocker.patch.object(consul_util, 'update_drive_state')
+    mocker.patch.object(consul_util,
+                        'get_hax_fid',
+                        return_value=Fid(0x7200000000000001, 0x6))
     mocker.patch.object(consul_util,
                         'get_node_fid',
                         return_value=Fid(0x6e00000000000001, 0x3))
@@ -973,6 +986,9 @@ def test_broadcast_io_service_failure(mocker, planner, motr, consumer,
     mocker.patch.object(consul_util.kv, 'kv_get', side_effect=my_get)
     # TODO: Handle 'kv_put' by updating kv returned by 'kv_get'
     mocker.patch.object(consul_util.kv, 'kv_put', return_value=0)
+    mocker.patch.object(consul_util,
+                        'get_hax_fid',
+                        return_value=Fid(0x7200000000000001, 0x6))
     mocker.patch.object(consul_util,
                         'get_node_fid',
                         return_value=Fid(0x6e00000000000001, 0x3))

--- a/hax/test/integration/testutils.py
+++ b/hax/test/integration/testutils.py
@@ -251,6 +251,11 @@ class FakeFFI(HaxFFI):
         return [MessageId(101, 1), MessageId(101, 2)]
 
     @trace_call
+    def ha_broadcast_hax_only(self, _ha_ctx, ha_notes, notes_len,
+                              hax_endpoint):
+        return [MessageId(101, 1), MessageId(101, 2)]
+
+    @trace_call
     def entrypoint_reply(self, *args):
         return 1
 


### PR DESCRIPTION
Hax relays self's and motr-mkfs process events to all the peer connected motr-mkfs
and to hax's motr land. Eventhough motr-mkfs processes event broadcasts are
restricted to the process states only and not to the entire motr process's
configuratio tree hierarchy (i.e. process's corresponding node, controller,
enclosure and drives), hax process events broadcasts happen to its corresponding
configuration tree hierarchy. Thus, when hax's motr land starts, the event is a
broadcast to all the connected motr-mkfs processes as well. As process, entrypoint
and nvec motr process events are given higher proirities, it may happen that
hax's process event broadcast may take time. It is observed that in a certain
situation, hax tries to send an event notification to itself and other connected
motr-mkfs processes, it may happen that although hax only starts to use the halink
after hax gets a `link_connected_cb()` call back from motr land (which should assure
that the halink is ready to use), the halink is not ready and hax crashes in Motr
land due to `Motr panic: (m0_ha_lq_invariant(lq)) at m0_ha_lq_enqueue() ha/lq.c:199`
invariant failure.
A related bug identified was that the halink saved in hax was not deactivated in
`link_disconnecting_cb()` received from hax's motr land, although, the invariant
failure was observed even after deactivating the halink.
All the evidence and the problem's intermittent occurance points to a race condition,
the suspect of the same is the halink being either not ready to use or being used
while it is getting disconnected. This needs to be further investigated.

Few other related fixes in hax tend to avoid this halink crash in the motr land.

Other fixes:
- Presently hax sends OFFLINE for mkfs M0_CONF_HA_PROCESS_STOPPED event to
avoid pv-dirty crashes during motr-mkfs to peer motr processes. But, this restricts
the motr-mkfs halink to be disconnected. Thus send FAILED notification for
motr-mkfs STOPPED event.
- Motr mkfs processes execute independent of each other and are short lived, thus,
they do not require a STOPPED/FAILED notification corresponding to a peer motr-mkfs
process, but, hax motr land requires the same in order to disconnect hax - motr-mkfs
halink corresponding to a motr-mkfs process, thus the broadcast of motr-mkfs events
need to be only to hax.
- Hax process events are a broadcast to all the connected motr processes which also
include hax's configuration tree hierarchy (i.e. hax's node, enclosure, controller,
etc.). Hax failure needs to be handled separately and such a broadcast is not
required as hax may share a node with other motr processes. This may lead to
inconsistencies, thus avoid broadcasting hax states to motr processes.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>