### PR TITLE
EOS-25926 [2.0.0-421-RC4.2] [v0.0.14] Deployment stuck for 9 N (12+6+0)

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -448,6 +448,9 @@ class ConsulUtil:
     def get_session_node(self, session_id: str) -> str:
         try:
             session = self.cns.session.info(session_id)[1]
+            if session is None or session.get('Node') is None:
+                raise HAConsistencyException('Failed to get session'
+                                             ' node')
             return str(session['Node'])  # principal RM
         except (ConsulException, HTTPError, RequestException) as e:
             raise HAConsistencyException('Failed to communicate to'


### PR DESCRIPTION
Problem: It is possible that consul may not be ready and RC leader may
not have been elected yet, in such a case hax is hitting an exception
during startup which is causing hax to stop.

Solution: Wait until principle RM is not ready

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>