### PR TITLE
EOS-25377: StobIoqError type not JSON-serializable

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -17,7 +17,7 @@
 #
 
 import queue as q
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from queue import Queue
 from typing import Any, List, Optional
 
@@ -139,6 +139,37 @@ class StobIoqError(BaseMessage):
     offset: int
     size: int
     bshift: int
+
+    def for_json(self):
+        parts = {}
+
+        def as_str(a):
+            return str(a)
+
+        def as_repr(a):
+            return repr(a)
+
+        def as_is(a):
+            return a
+
+        for fld in fields(self):
+            f_type = fld.type
+            f_name = fld.name
+            if f_name == 'group':
+                # group is a thing used by WorkPlanner for task scheduling
+                # logic. We don't need to expose it
+                continue
+            val = getattr(self, f_name)
+            to_str = as_str
+            if f_type is Fid:
+                to_str = as_repr
+            elif f_type is StobId:
+                to_str = as_is
+            elif f_type is int or f_type is None:
+                to_str = as_is
+            parts[fld.name] = to_str(val)
+
+        return parts
 
 
 class Die(BaseMessage):

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -26,13 +26,13 @@ import pytest
 from hax.common import HaxGlobalState
 from hax.handler import ConsumerThread
 from hax.message import (BaseMessage, Die, FirstEntrypointRequest,
-                         HaNvecGetEvent)
+                         HaNvecGetEvent, StobId, StobIoqError)
 from hax.motr import Motr, WorkPlanner
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI
-from hax.types import (Fid, FidStruct, HaNoteStruct, HAState, Profile, HaNote,
+from hax.types import (Fid, FidStruct, HaNote, HaNoteStruct, HAState, Profile,
                        ServiceHealth, Uint128)
-from hax.util import create_process_fid, create_profile_fid
+from hax.util import create_process_fid, create_profile_fid, dump_json
 
 from .testutils import (AssertionPlan, FakeFFI, Invocation, TraceMatcher,
                         tr_and, tr_method, tr_not)
@@ -991,3 +991,23 @@ def test_broadcast_io_service_failure(mocker, planner, motr, consumer,
     assert AssertionPlan(tr_and(tr_method('ha_broadcast'),
                                 node_fid_failed())).not_exists(traces), \
         'Node failure should not be broadcast'
+
+
+# flake8: noqa
+
+
+def test_bq_stob_serializeable():
+    stob = StobId(Fid(12, 13), Fid(14, 15))
+    msg = StobIoqError(fid=Fid(5, 6),
+                       conf_sdev=Fid(1, 2),
+                       stob_id=stob,
+                       fd=42,
+                       opcode=4,
+                       rc=2,
+                       offset=0xBF,
+                       size=100,
+                       bshift=4)
+    first = dump_json(stob)
+    assert first == '{"domain_fid": "0xc:0xd", "fid": "0xe:0xf"}'
+    second = dump_json(msg)
+    assert second == '{"fid": "0x5:0x6", "conf_sdev": "0x1:0x2", "stob_id": {"domain_fid": "0xc:0xd", "fid": "0xe:0xf"}, "fd": 42, "opcode": 4, "rc": 2, "offset": 191, "size": 100, "bshift": 4}'


### PR DESCRIPTION
This is a duplicate of #1833 for `kubernetes` branch.


Solution:
1. Implement custom serializer function for StobIoqError (for_json())
2. Implement integration tests that verify that the bug is not
reproduced anymore:
   - StobIoqError is serializable by simplejson library
   - Resulting payload is understood by the BQ processor
