### PR TITLE
EOS-26350: Wrong allowed failure vector is generated

### DIFF
--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -98,8 +98,16 @@ class ConfStoreProvider(ValueProvider):
     def get_storage_set_nodes(self) -> List[str]:
         storage_set_index = self.get_storage_set_index()
 
-        server_nodes_key = (f'cluster>storage_set[{storage_set_index}]>nodes')
-        return self.get(server_nodes_key)
+        storage_nodes_key = (f'cluster>storage_set[{storage_set_index}]>nodes')
+        storage_nodes = self.get(storage_nodes_key)
+
+        for node in storage_nodes:
+            node_type = self.get(f'node>{node}>type')
+            # Skipping controller node
+            if node_type != 'storage_node':
+                storage_nodes.remove(node)
+
+        return storage_nodes
 
 
 def get_machine_id() -> str:


### PR DESCRIPTION
Problem: Currently we check all the nodes in 'storage_set' key.
But some of the nodes can be of type 'control_node' and we dont need to
include then while calculating allowed failure vector

Solution: Added check for 'storage_node' while getting list of nodes

**Testing:**
Config generated for 15 node setup is as follows
`pools:
- allowed_failures:
disk: 7
ctrl: 6
encl: 3
rack: 0
site: 0
spare_units: 0
name: storage-set-1__sns
data_units: 8
parity_units: 7`

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>