### PR TITLE
EOS-25688: Reduce mkfs time for multiple io services

### DIFF
--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -29,6 +29,7 @@ from distutils.dir_util import copy_tree
 import shutil
 
 from hax.util import repeat_if_fails, KVAdapter
+from helper.exec import Program, Executor
 
 from hare_mp.store import ValueProvider
 from hare_mp.types import Disk, DList, Maybe, Text
@@ -176,18 +177,8 @@ class LogWriter:
 
 
 def execute(cmd: List[str], env=None) -> str:
-    process = subprocess.Popen(cmd,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE,
-                               encoding='utf8',
-                               env=env)
-    out, err = process.communicate()
-    if process.returncode:
-        raise Exception(
-            f'Command {cmd} exited with error code {process.returncode}. '
-            f'Command output: {err}')
-
+    p = Program(cmd)
+    out = Executor().run(p, env=env)
     return out
 
 


### PR DESCRIPTION
Problem:
On a given node for all the motr processes (confds and ioservices),
presently, mkfs is executed serially via Hare mini-provisioner. It is
executed in parallel across the nodes but not on a node. So ioservices
mkfs does not complete before confd's mkfs completes. Now we don't
require confds to be running for ioservices mkfs (this is done by
passing confd.xc to motr-mkfs). Thus, all can be executed in parallel
on a given node.
For sequential execution of mkfs, it takes significant amount of time
if the number of mkfs requests are more (typically when we have
multinode clusters). With this parallel execution of mkfs we need
to reduce this time.

Solution:
The idea here is to make the mkfs commands to run in parallel.
This PR addresses this using concurrent process execution
mechanism.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>