### PR TITLE
EOS-25703: hctl status takes too much time in containers

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -24,6 +24,7 @@ import argparse
 import inject
 import io
 import logging
+import re
 import simplejson
 import sys
 from subprocess import PIPE, Popen
@@ -124,26 +125,6 @@ def get_fs_stats(cns: Consul) -> Any:
     return {'stats': {}} if stats is None else json.loads(stats)
 
 
-def proc_id2name(cns: Consul, node: str, proc_id: int) -> str:
-    names = {
-        'confd': 'confd',
-        'ha': 'hax',
-        'ios': 'ioservice',
-        'm0_client_s3': 's3server'
-    }
-    services = kv_item(cns,
-                       f'm0conf/nodes/{node}/processes/{proc_id}/services/',
-                       recurse=True)
-    assert services
-    for svc in services:
-        # key looks like
-        # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
-        svc_type = svc['Key'].split('/')[-1]
-        if svc_type in names:
-            return names[svc_type]
-    return 'm0_client'
-
-
 def fid_key(fid: str) -> int:
     key = fid.split(':')[1]
     return int(key, 16)
@@ -167,31 +148,91 @@ def processes(cns: Consul, consul_util: ConsulUtil,
         parts = x['Key'].split('/', 5)
         if len(parts) == 5:
             proc_fidks.append(fid_key(parts[-1]))
+    node_health = consul_util.get_node_health_status(node_name)
+    process_states = get_node_process_states(cns, node_name)
+    process_list = get_node_processes(cns, node_name)
     return [
         Process(
-            name=proc_id2name(cns, node_name, k),
+            name=proc_id2name(process_list, k),
             fid=Fid(0x7200000000000001, k),
-            ep=(
-                kv_value_as_str(
-                    cns,
-                    f'm0conf/nodes/{node_name}/processes/{k}/endpoint'
-                ) or '**ERROR**'),
-            status=process_status(consul_util, node_name,
+            ep=(proc_id2endpoint(process_list, k) or '**ERROR**'),
+            status=process_status(node_health, process_states,
                                   Fid(0x7200000000000001, k)))
         for k in sorted(proc_fidks)
     ]
 
 
-def process_status(consul_util: ConsulUtil, node_name, fid: Fid) -> str:
-    if (consul_util.get_node_health_status(node_name) != 'passing'):
+def process_status(node_health: str, proc_states: Dict[str, str],
+                   fid: Fid) -> str:
+    if node_health != 'passing':
         return 'offline'
-    status = consul_util.get_process_status(fid, node_name)
-    if status.proc_status == 'M0_CONF_HA_PROCESS_STARTED':
-        return 'started'
-    elif status.proc_status in ('Unknown', 'UNKNOWN'):
-        return 'unknown'
+    if str(fid) in proc_states:
+        return proc_states[str(fid)]
     else:
-        return 'offline'
+        return 'unknown'
+
+
+def get_node_process_states(cns: Consul, node_name: str) -> Dict[str, str]:
+    key = f'{node_name}/processes/'
+    proc_list = kv_item(cns, key, recurse=True)
+    process_states: Dict[str, str] = {}
+    for proc in proc_list:
+        key_split = proc['Key'].split('/')
+        if len(key_split) != 3:
+            continue
+        fid = key_split[-1]
+        val = json.loads(proc['Value'])
+        if val['state'] == 'M0_CONF_HA_PROCESS_STARTED':
+            state = 'started'
+        elif val['state'] in ('Unknown', 'UNKNOWN'):
+            state = 'unknown'
+        else:
+            state = 'offline'
+        process_states[fid] = state
+    return process_states
+
+
+def proc_id2endpoint(process_list: List[Dict[str, Any]],
+                     proc_id: int) -> Optional[str]:
+    regex = re.compile(
+        f'^m0conf\\/.*\\/processes\\/{proc_id}\\/endpoint$')
+    for proc_item in process_list:
+        match_result = re.match(regex, proc_item['Key'])
+        if not match_result:
+            continue
+        process_ep: bytes = proc_item['Value']
+        return process_ep.decode('utf-8')
+    return None
+
+
+def proc_id2name(processes: List[Dict[str, Any]], proc_id: int) -> str:
+    names = {
+        'confd': 'confd',
+        'ha': 'hax',
+        'ios': 'ioservice',
+        'm0_client_s3': 's3server'
+    }
+    regex = re.compile(
+        f'^m0conf\\/.*\\/processes\\/{proc_id}\\/services\\/(.+)$')
+    process_found = False
+    for proc in processes:
+        match_result = re.match(regex, proc['Key'])
+        if not match_result:
+            continue
+        process_found = True
+        svc_type = match_result.group(1)
+        if svc_type in names:
+            return names[svc_type]
+    assert process_found
+    return 'm0_client'
+
+
+def get_node_processes(cns: Consul, node_name: str) -> Any:
+    processes = kv_item(cns,
+                        f'm0conf/nodes/{node_name}/processes/',
+                        recurse=True)
+    assert processes
+    return processes
 
 
 def cluster_online() -> bool:


### PR DESCRIPTION
### Description:
In the containers environment, consul kv calls take a longer time for execution in comparison to the LR environment.
An experiment was done which should a significant difference of 17 mins between the two environments. 

### Solution:
Reduced number of consul kv calls.
Initially, for every process, multiple separate kv calls were made. Now, we are fetching kv for all the processes under a node at once and parsing it further.

### Testing:
- Time taken with the final change ( fetching endpoint for every process function) is yet to be tested on 15 node.
- on 5node could see 33% reduction.
#### time taken in 15 node setup 
- with code changes in 2 functions -  _process_status()_ and _proc_fid2name()_ fetching at node level is:
```
real 1m5.397s
user 0m9.109s
sys 0m0.164s
```
- original hct status script took
```
real 4m5.153s
user 0m22.156s
sys 0m0.235s
```
Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>