### PR TITLE
EOS-25537: Improvement in aux pool enable/disable implementation for kubernetes

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1445,9 +1445,49 @@ def cluster_svcs(m0conf: Dict[Oid, Any], svc_t) -> List[Oid]:
             if m0conf[svc_id].type is svc_t]
 
 
+# node-to-drives mapping
+def pool_drives_with_nodes(m0conf: Dict[Oid, Any]) -> List[Tuple[Oid, Oid]]:
+    all_drives: List[Tuple[Oid, Oid]] = [
+        (drive_id, m0conf[encl_id].node)
+        for encl_id in m0conf if encl_id.type is ObjT.enclosure
+        for ctrl_id in m0conf[encl_id].ctrls
+        for drive_id in m0conf[ctrl_id].drives
+    ]
+    assert all_drives
+    assert all(drive_id.type is ObjT.drive and node_id.type is ObjT.node
+               for drive_id, node_id in all_drives)
+
+    return all_drives
+
+
+def pool_drives_from_references(
+                m0conf: Dict[Oid, Any],
+                pool_desc: Dict[str, Any]) -> List[Tuple[Oid, Oid]]:
+    disk_refs = pool_desc.get('disk_refs')
+    drives = []
+    all_drives: List[Tuple[Oid, Oid]] = pool_drives_with_nodes(m0conf)
+
+    unique_list_of_tuples = list(set(all_drives))
+
+    if disk_refs:
+        for ref in disk_refs:
+            targets = [(drive_id, node_id)
+                       for drive_id, node_id in unique_list_of_tuples
+                       if ref['path'] == m0conf[m0conf[drive_id].sdev].filename
+                       and ref.get('node') in (None, m0conf[node_id].name)]
+            # XXX Improve validate_pools_desc() to catch this error.
+            assert len(targets) == 1, 'Check {} config line'.format(ref)
+            drives.extend(targets)
+        assert all_unique(drives), \
+            'Pool {!r}: some of disk_refs refer to the same disk'.format(
+                pool_desc['name'])
+
+    return drives
+
+
+# The job of this function is to return list of drives.
 def pool_drives(m0conf: Dict[Oid, Any],
-                pool_desc: Dict[str, Any],
-                cluster_desc: Dict[str, Any]) -> List[Oid]:
+                pool_desc: Dict[str, Any]) -> List[Oid]:
     ptype = pool_type(pool_desc)
 
     if ptype is PoolT.dix:
@@ -1466,39 +1506,32 @@ def pool_drives(m0conf: Dict[Oid, Any],
                 for ctrl_id in m0conf if ctrl_id.type is ObjT.controller]
 
     assert ptype is PoolT.sns
-    all_drives: List[Tuple[Oid, Oid]] = [
-        (drive_id, m0conf[encl_id].node)
-        for encl_id in m0conf if encl_id.type is ObjT.enclosure
-        for ctrl_id in m0conf[encl_id].ctrls
-        for drive_id in m0conf[ctrl_id].drives
-    ]
-    assert all_drives
-    assert all(drive_id.type is ObjT.drive and node_id.type is ObjT.node
-               for drive_id, node_id in all_drives)
+    drives = pool_drives_from_references(m0conf, pool_desc)
+    if not drives:
+        drives = pool_drives_with_nodes(m0conf)
 
-    disk_refs = pool_desc.get('disk_refs')
-    if disk_refs is None:
-        drives = all_drives
-    else:
-        assert disk_refs
-        drives = []
-        for ref in disk_refs:
-            targets = [(drive_id, node_id)
-                       for drive_id, node_id in all_drives
-                       if ref['path'] == m0conf[m0conf[drive_id].sdev].filename
-                       and ref.get('node') in (None, m0conf[node_id].name)]
-            # XXX Improve validate_pools_desc() to catch this error.
-            assert len(targets) == 1, 'Check {} config line'.format(ref)
-            drives.extend(targets)
-        assert all_unique(drives), \
-            'Pool {!r}: some of disk_refs refer to the same disk'.format(
-                pool_desc['name'])
+    return [drive_id for drive_id, _ in drives]
+
+
+# we don't allow overlapping pools, i.e. pools sharing physical devices
+# between them. So, this function validate list of drives for a give pools
+# and It disables disk repeation in base pools.
+def check_drive_multiple_references(
+                m0conf: Dict[Oid, Any],
+                cluster_desc: Dict[str, Any]) -> List[Tuple[Oid, Oid]]:
+
+    drives = []
+    for pool in cluster_desc['pools']:
+        drives.extend(pool_drives_from_references(m0conf, pool))
 
     over_referenced: Dict[Oid, List[Oid]] = {}  # node-to-drives mapping
-    for drive_id, node_id in drives:
-        if m0conf[drive_id].pvers:  # already assigned to some pool
-            over_referenced.setdefault(node_id, []).append(drive_id)
 
+    for drive_ref in drives:
+        if drives.count(drive_ref) > 1:
+            over_referenced.setdefault(drive_ref[1], []).append(drive_ref[0])
+
+    # This optional variable added in CDF file to enable/disable aux pool
+    # generation. It defaults to false(i.e. do not generate any aux pools)
     create_aux_val = cluster_desc.get('create_aux')
     if not create_aux_val:
         if over_referenced:
@@ -1510,8 +1543,7 @@ def pool_drives(m0conf: Dict[Oid, Any],
                 for drive_id in sorted(over_referenced[node_id]):
                     err += '\n   \\_ ' + m0conf[m0conf[drive_id].sdev].filename
             raise AssertionError(err)
-
-    return [drive_id for drive_id, _ in drives]
+    return drives
 
 
 def cluster_encls(m0conf: Dict[Oid, Any], svc_t) -> List[Oid]:
@@ -1597,8 +1629,7 @@ class ConfPool(ToDhall):
 
     @classmethod
     def gen_sns_tolerance(cls, m0conf: Dict[Oid, Any],
-                          pool_desc: Dict[str, Any],
-                          cluster_desc: Dict[str, Any]) -> Failures:
+                          pool_desc: Dict[str, Any]) -> Failures:
 
         encls_nr = len(cluster_encls(m0conf, SvcT.M0_CST_IOS))
         ctrls_per_encl = floor(len(cluster_ctrls(m0conf)) / encls_nr)
@@ -1608,7 +1639,7 @@ class ConfPool(ToDhall):
         total_units = data_units + parity_units + spare_units
         fault_tol_info = drives_per_node_and_ctrl(m0conf)
         min_pool_width = fault_tol_info.min_drives_per_node * encls_nr
-        actual_pool_width = len(pool_drives(m0conf, pool_desc, cluster_desc))
+        actual_pool_width = len(pool_drives(m0conf, pool_desc))
         if ((min_pool_width < actual_pool_width) and
                 (min_pool_width / total_units) > 0):
             # Pool is asymmetric, all the nodes don't have same number of
@@ -1655,7 +1686,7 @@ class ConfPool(ToDhall):
         if spare_units is None:
             spare_units = pool_desc.get('parity_units')
 
-        drives = pool_drives(m0conf, pool_desc, cluster_desc)
+        drives = pool_drives(m0conf, pool_desc)
         t = pool_type(pool_desc)
         assert ('data_units' in pool_desc) == ('parity_units' in pool_desc)
         if 'data_units' in pool_desc:
@@ -1687,8 +1718,7 @@ class ConfPool(ToDhall):
                 if t == PoolT.dix:
                     tolerance = ConfPool.gen_md_tolerance(m0conf, pool_desc)
                 else:
-                    tolerance = ConfPool.gen_sns_tolerance(m0conf, pool_desc,
-                                                           cluster_desc)
+                    tolerance = ConfPool.gen_sns_tolerance(m0conf, pool_desc)
         else:
             tolerance = ConfPool.gen_md_tolerance(m0conf, pool_desc)
 
@@ -2327,8 +2357,7 @@ def get_pool_diskrefs(pool_desc: Dict[str, Any]):
 
 def aux_pool_list(pool_desc: Dict[str, Any],
                   disks: List[DiskRef],
-                  m0conf: Dict[Oid, Any],
-                  cluster_desc: Dict[str, Any]) -> None:
+                  m0conf: Dict[Oid, Any]) -> None:
     pool = pool_desc
 
     # Example of encl_ref_combination :
@@ -2377,7 +2406,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
         tolerance = Failures(d['site'], d['rack'], d['encl'],
                              d['ctrl'], d['disk'])
     else:
-        tolerance = ConfPool.gen_sns_tolerance(m0conf, pool, cluster_desc)
+        tolerance = ConfPool.gen_sns_tolerance(m0conf, pool)
     # Generate the node combinations considering node failures as
     # allowed by node tolerance values
     temp_pool_nodes = []
@@ -2479,6 +2508,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                         other_clients[node['hostname']] = []
                     other_clients[node['hostname']].append((node_id, proc_id))
 
+    check_drive_multiple_references(conf, cluster_desc)
+
     create_aux_val = cluster_desc.get('create_aux')
     if not create_aux_val:
         for pool in cluster_desc['pools']:
@@ -2502,7 +2533,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                                 disks.append(DiskRef(path=d,
                                                      node=node['hostname']))
 
-                aux_pool_list(pool, disks, conf, cluster_desc)
+                aux_pool_list(pool, disks, conf)
             else:
                 ConfPool.build(conf, root_id, pool, cluster_desc)
 

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -414,6 +414,7 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
                     del m0d['io_disks']['meta_data']
             m0d['_io_disks'] = get_disks_from_cdf(node['hostname'], mock_p,
                                                   m0d['io_disks']['data'])
+
             if not m0d['_io_disks']:
                 m0d['_io_disks'] = get_disks_ssh(node['hostname'], mock_p,
                                                  m0d['io_disks']['data'])
@@ -1124,6 +1125,21 @@ class ConfProcess(ToDhall):
                     assert ctrl is not None
                     ConfDrive.build(m0conf, ctrl,
                                     ConfSdev.build(m0conf, svc_id, disk))
+
+            if stype is SvcT.M0_CST_CAS:
+                assert proc_desc is not None
+                if meta_data is None:
+                    disk = '/dev/null'
+                if meta_data:
+                    disk = proc_desc['io_disks'].get('meta_data')
+                    assert ctrl is not None
+                    ConfDrive.build(m0conf, ctrl,
+                                    ConfSdev.build(
+                                        m0conf, svc_id,
+                                        Disk(
+                                            path=disk,
+                                            size=1024,
+                                            blksize=1)))
         return proc_id
 
 
@@ -1168,11 +1184,11 @@ def service_types(proc_t: ProcT,
         if proc_desc.get('runs_confd'):
             ts.append(SvcT.M0_CST_CONFD)
         if proc_desc['_io_disks']:
-            ts.extend([SvcT.M0_CST_IOS,
+            ts.extend([SvcT.M0_CST_CAS,
+                       SvcT.M0_CST_IOS,
                        SvcT.M0_CST_SNS_REP,
                        SvcT.M0_CST_SNS_REB,
                        SvcT.M0_CST_ADDB2,
-                       SvcT.M0_CST_CAS,
                        SvcT.M0_CST_ISCS,
                        SvcT.M0_CST_FDMI])
     return ts
@@ -1463,13 +1479,13 @@ def pool_drives_with_nodes(m0conf: Dict[Oid, Any]) -> List[Tuple[Oid, Oid]]:
 def pool_drives_from_references(
                 m0conf: Dict[Oid, Any],
                 pool_desc: Dict[str, Any]) -> List[Tuple[Oid, Oid]]:
-    disk_refs = pool_desc.get('disk_refs')
     drives = []
     all_drives: List[Tuple[Oid, Oid]] = pool_drives_with_nodes(m0conf)
+    disk_refs = get_pool_diskrefs(pool_desc)
 
     unique_list_of_tuples = list(set(all_drives))
 
-    if disk_refs:
+    if disk_refs is not None:
         for ref in disk_refs:
             targets = [(drive_id, node_id)
                        for drive_id, node_id in unique_list_of_tuples
@@ -1481,7 +1497,6 @@ def pool_drives_from_references(
         assert all_unique(drives), \
             'Pool {!r}: some of disk_refs refer to the same disk'.format(
                 pool_desc['name'])
-
     return drives
 
 
@@ -1491,15 +1506,8 @@ def pool_drives(m0conf: Dict[Oid, Any],
     ptype = pool_type(pool_desc)
 
     if ptype is PoolT.dix:
-        cas = [(svc_id, m0conf[svc_id].ctrl_id)
-               for svc_id in cluster_svcs(m0conf, SvcT.M0_CST_CAS)]
-
-        return [ConfDrive.build(m0conf, ctrl_id,
-                                ConfSdev.build(m0conf, svc_id,
-                                               Disk(path='/dev/null',
-                                                    size=1024,
-                                                    blksize=1)))
-                for (svc_id, ctrl_id) in cas]
+        return [m0conf[ctrl_id].drives[0]
+                for ctrl_id in m0conf if ctrl_id.type is ObjT.controller]
 
     if ptype is PoolT.md:
         return [m0conf[ctrl_id].drives[0]
@@ -1519,19 +1527,15 @@ def pool_drives(m0conf: Dict[Oid, Any],
 def check_drive_multiple_references(
                 m0conf: Dict[Oid, Any],
                 cluster_desc: Dict[str, Any]) -> List[Tuple[Oid, Oid]]:
-
     drives = []
     for pool in cluster_desc['pools']:
         drives.extend(pool_drives_from_references(m0conf, pool))
-
     over_referenced: Dict[Oid, List[Oid]] = {}  # node-to-drives mapping
 
     for drive_ref in drives:
         if drives.count(drive_ref) > 1:
             over_referenced.setdefault(drive_ref[1], []).append(drive_ref[0])
 
-    # This optional variable added in CDF file to enable/disable aux pool
-    # generation. It defaults to false(i.e. do not generate any aux pools)
     create_aux_val = cluster_desc.get('create_aux')
     if not create_aux_val:
         if over_referenced:
@@ -1629,7 +1633,8 @@ class ConfPool(ToDhall):
 
     @classmethod
     def gen_sns_tolerance(cls, m0conf: Dict[Oid, Any],
-                          pool_desc: Dict[str, Any]) -> Failures:
+                          pool_desc: Dict[str, Any],
+                          cluster_desc: Dict[str, Any]) -> Failures:
 
         encls_nr = len(cluster_encls(m0conf, SvcT.M0_CST_IOS))
         ctrls_per_encl = floor(len(cluster_ctrls(m0conf)) / encls_nr)
@@ -1718,7 +1723,8 @@ class ConfPool(ToDhall):
                 if t == PoolT.dix:
                     tolerance = ConfPool.gen_md_tolerance(m0conf, pool_desc)
                 else:
-                    tolerance = ConfPool.gen_sns_tolerance(m0conf, pool_desc)
+                    tolerance = ConfPool.gen_sns_tolerance(m0conf, pool_desc,
+                                                           cluster_desc)
         else:
             tolerance = ConfPool.gen_md_tolerance(m0conf, pool_desc)
 
@@ -2357,7 +2363,8 @@ def get_pool_diskrefs(pool_desc: Dict[str, Any]):
 
 def aux_pool_list(pool_desc: Dict[str, Any],
                   disks: List[DiskRef],
-                  m0conf: Dict[Oid, Any]) -> None:
+                  m0conf: Dict[Oid, Any],
+                  cluster_desc: Dict[str, Any]) -> None:
     pool = pool_desc
 
     # Example of encl_ref_combination :
@@ -2406,7 +2413,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
         tolerance = Failures(d['site'], d['rack'], d['encl'],
                              d['ctrl'], d['disk'])
     else:
-        tolerance = ConfPool.gen_sns_tolerance(m0conf, pool)
+        tolerance = ConfPool.gen_sns_tolerance(m0conf, pool, cluster_desc)
     # Generate the node combinations considering node failures as
     # allowed by node tolerance values
     temp_pool_nodes = []
@@ -2533,7 +2540,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                                 disks.append(DiskRef(path=d,
                                                      node=node['hostname']))
 
-                aux_pool_list(pool, disks, conf)
+                aux_pool_list(pool, disks, conf, cluster_desc)
             else:
                 ConfPool.build(conf, root_id, pool, cluster_desc)
 

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -1,7 +1,6 @@
 # Cluster Description File (CDF).
 # See `cfgen --help-schema` for the format description.
 
-create_aux: false # optional; supported values: "false" (default), "true"
 nodes:
   - hostname: localhost     # [user@]hostname
     data_iface: eth1        # name of data network interface

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -27,6 +27,7 @@ nodes:
     m0_clients:
       s3: 0         # number of S3 servers to start
       other: 2      # max quantity of other Motr clients this host may have
+create_aux: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool
     type: sns  # optional; supported values: "sns" (default), "dix", "md"

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -321,13 +321,15 @@ class CdfGenerator:
                 f'storage>cvg[{cvg}]>devices>data')], 'List Text')
         return data_devices
 
-    # TBD motr
+    # conf-store returns a list of devices, thus, the function
+    # must return a single metadata device path instead of a string of
+    # list.
     def _get_metadata_device(self,
                              machine_id: str,
                              cvg: int) -> Text:
         store = self.provider
         metadata_device = Text(store.get(
-            f'node>{machine_id}>storage>cvg[{cvg}]>devices>metadata'))
+            f'node>{machine_id}>storage>cvg[{cvg}]>devices>metadata')[0])
         return metadata_device
 
     # This function is kept as place holder with length returning 1,


### PR DESCRIPTION
Presently there's an option to disable aux pool creation in the Hare configuration generator and there is disk repetition found in base pools. Logically, disk repetition is not allowed for base pools but only aux pools can have disks repeated. So, we don't allow overlapping pools, i.e. pools sharing physical devices between them.

Solution:
Depending on the provided configuration we should be able to generate correct combinations of pools. For this, We need to check specifically for the pool instead of pool versions. and if disks are repeated in base pools then it should be thrown AssertionError for that.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>