### PR TITLE
EOS-26619: Support 'upgrade' command for Hare mini-provisioning

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -1044,6 +1044,13 @@ def main():
                        help_str='Performs the Hare rpm post-upgrade tasks',
                        handler_fn=noop))
 
+    add_service_argument(
+        add_subcommand(subparser,
+                       'upgrade',
+                       help_str='Performs the Hare rpm upgrade tasks',
+                       handler_fn=noop,
+                       config_required=False))
+
     parsed = p.parse_args(sys.argv[1:])
 
     setup_logging(parsed.config[0])


### PR DESCRIPTION
Solution: Added new command 'upgrade' which will be no-op currently
**Test:**
Tested 3 node LR bootstrap and 3 node LC deployment using custom branch.

```
[root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# /opt/seagate/cortx/hare/bin/hare_setup upgrade --config yaml:///etc/cortx/cluster.conf --services all
[root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# echo $?
0
```

[root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x81 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xcc 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-data-headless-svc-ssc-vm-g3-rhev4-2653
    [started]  hax        0x7200000000000001:0x31  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2653@2001
    [started]  ioservice  0x7200000000000001:0x34  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2653@3001
    [started]  ioservice  0x7200000000000001:0x41  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2653@3002
    [started]  confd      0x7200000000000001:0x4e  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2653@3003
    [started]  s3server   0x7200000000000001:0x51  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2653@4001
    [started]  s3server   0x7200000000000001:0x54  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2653@4002
    cortx-data-headless-svc-ssc-vm-g3-rhev4-2655
    [started]  hax        0x7200000000000001:0x7   inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2655@2001
    [started]  ioservice  0x7200000000000001:0xa   inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2655@3001
    [started]  ioservice  0x7200000000000001:0x17  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2655@3002
    [started]  confd      0x7200000000000001:0x24  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2655@3003
    [started]  s3server   0x7200000000000001:0x27  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2655@4001
    [started]  s3server   0x7200000000000001:0x2a  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2655@4002
    cortx-data-headless-svc-ssc-vm-g3-rhev4-2654  (RC)
    [started]  hax        0x7200000000000001:0x5b  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2654@2001
    [started]  ioservice  0x7200000000000001:0x5e  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2654@3001
    [started]  ioservice  0x7200000000000001:0x6b  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2654@3002
    [started]  confd      0x7200000000000001:0x78  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2654@3003
    [started]  s3server   0x7200000000000001:0x7b  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2654@4001
    [started]  s3server   0x7200000000000001:0x7e  inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2654@4002
