### PR TITLE
EOS-26660: "services" option in hare_setup command should support 'hax' as argument

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -70,6 +70,7 @@ class Plan(Enum):
 
 class Svc(Enum):
     All = 'all'
+    Hax = 'hax'
 
 
 def create_logger_directory(log_dir):
@@ -935,7 +936,8 @@ def add_factory_argument(parser):
 
 def add_service_argument(parser):
     parser.add_argument('--services', '-s',
-                        help='Services to be setup.',
+                        help='Services to be setup. Supported '
+                        'values: ' + str([s.value for s in Svc]),
                         nargs=1,
                         type=Svc,
                         action='store')


### PR DESCRIPTION
Solution: Added 'hax' as supported value for 'services' option

**Test:**
Tested 3 node LC deployment

> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# /opt/seagate/cortx/hare/bin/hare_setup upgrade --config yaml:///etc/cortx/cluster.conf --services hax
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# echo $?
> 0
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# /opt/seagate/cortx/hare/bin/hare_setup upgrade --config yaml:///etc/cortx/cluster.conf --services all
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# echo $?
> 0
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# /opt/seagate/cortx/hare/bin/hare_setup post_install --config yaml:///etc/cortx/cluster.conf --services all
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# echo $?
> 0
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# /opt/seagate/cortx/hare/bin/hare_setup post_install --config yaml:///etc/cortx/cluster.conf --services hax
> [root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2653 /]# echo $?
> 0