### PR TITLE
EOS-26740 : Remove logging from miniprovisioners init mkfs stage

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -390,11 +390,11 @@ class ProcessStartInfo:
 
 def start_mkfs(proc_to_start: ProcessStartInfo) -> int:
     try:
-        logging.info('Starting mkfs process [fid=%s] at hostname=%s',
-                     proc_to_start.fid, proc_to_start.hostname)
+        logging.debug('Starting mkfs process [fid=%s] at hostname=%s',
+                      proc_to_start.fid, proc_to_start.hostname)
         command = proc_to_start.cmd
         execute(command)
-        logging.info('Started mkfs process [fid=%s]', proc_to_start.fid)
+        logging.debug('Started mkfs process [fid=%s]', proc_to_start.fid)
         rc = 0
     except Exception as error:
         logging.error('Error launching mkfs [fid=%s] at hostname=%s: %s',
@@ -437,8 +437,8 @@ def start_mkfs_parallel(hostname: str, hare_config_dir: str):
         raise RuntimeError('One or more mkfs processes failed to start. '
                            'Please check the logs above for details.')
     else:
-        logging.info(f'Total time taken for all mkfs on this node = '
-                     f'{perf_result}\n\n')
+        logging.debug(f'Total time taken for all mkfs on this node = '
+                      f'{perf_result}\n\n')
 
 
 def init(args):


### PR DESCRIPTION
Problem :
Hare miniprovisioner init mkfs stage has some "logging.info" logs in
happy path. These logs were added to monitor mkfs process fids and
execution time. These logs do not just go in the log file but also
get printed on the console. Any additional logs on console are
treated as failures/errors by provisioner. Even if those are treated
as errors, but still those are ignored and deployment gets completed
successfully. So currently technically these logs are not harming.
Because of these logs, the error message that is thrown by provisioner
on the console is misleading, which says "init phase of hare, failed".
It is creating confusion when deployment fails in Hare init stage
because of any kind of genuine failure.

Solution :
Remove the log prints in the happy path. Use logging debug option
instead of info, so that the log message is kept intact when required
for actual debugging.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>