### PR TITLE
EOS-26800: [Redefined PODs] Hare mini provisioning is failing at config phase on data-node

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -68,7 +68,8 @@ class CdfGenerator:
         for machine_id in machines.keys():
             node_type = conf.get(f'node>{machine_id}>type')
             # Skipping for controller node
-            if node_type == 'storage_node':
+            if (node_type in
+                    ('storage_node', 'data_node', 'server_node')):
                 nodes.append(self._create_node(machine_id))
         return nodes
 
@@ -122,7 +123,8 @@ class CdfGenerator:
         for node in nodes:
             node_type = self.provider.get(f'node>{node}>type')
             # Skipping for controller node
-            if node_type == 'storage_node':
+            if (node_type in
+                    ('storage_node', 'data_node', 'server_node')):
                 out.append(node)
 
         return out


### PR DESCRIPTION
Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>

# Problem Statement
- Provisioner recently introduced redefined PODs in which new pod types are introduced and one existing pod type is renamed from 'storage_node' to 'data_node'
Due to above change config stage of Hare is failing as it still checks for 'storage_node'

# Design
-  Added check for both data_node as well as storage_node. Since new new redefined pod also introduced 'server_pod' and Hare also needs to be run on that pod so including 'server_pod' also in the check

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- We are going to commit this change(and all the other changes related to pod separation) in 'K8s_pod_separation' branch
- Currently testing this change in working session between motr/hare/s3

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
