### PR TITLE
EOS-26836: wait function in init is not reliable (cherry pick from main)

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -270,6 +270,21 @@ class CatalogAdapter:
     def __init__(self, cns: Optional[Consul] = None):
         self.cns: Consul = cns or Consul()
 
+    def get_node_names(self) -> List[str]:
+        """
+        Return full list of service names currently registered in Consul
+        server.
+        """
+        try:
+            node_names: List[str] = []
+            nodes: List[Dict[str, Any]] = self.cns.catalog.nodes()[1]
+            for node in nodes:
+                node_names.append(str(node['Node']))
+            return node_names
+        except (ConsulException, HTTPError, RequestException) as e:
+            raise HAConsistencyException(
+                'Cannot access Consul catalog') from e
+
     def get_service_names(self) -> List[str]:
         """
         Return full list of service names currently registered in Consul
@@ -838,6 +853,24 @@ class ConsulUtil:
             ctrl_fid: str = match_result.group(1)
             list_fids.append(Fid.parse(ctrl_fid))
         return list_fids
+
+    def get_node_hare_motr_s3_fids(self, node: str) -> List[Fid]:
+        """
+        Parameters:
+            node : hostname of the node
+        response:
+            returns list of fids for hax, ioservices, confd and s3services
+            configured and running on @node.
+        """
+        services = ['hax', 'ios', 'confd', 's3service']
+        node_data: List[Dict[str, Any]] = self.get_node_health_details(node)
+        fids: List[Fid] = []
+        if not node_data:
+            return []
+        for item in node_data:
+            if item['ServiceName'] in services:
+                fids.append(mk_fid(ObjT.PROCESS, int(item['ServiceID'])))
+        return fids
 
     @repeat_if_fails()
     @uses_consul_cache


### PR DESCRIPTION
It is possible that not all the remote and local process statuses
are updated on every node. For more reliability it is better to
check all the processes status per node explicity.

Solution:
Iterate over each node's processes and check the corresponding status
in Consul KV.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>
(cherry picked from commit 3e4c24effaad0b81f7ff732b80793f8f0e5266c7)

Conflicts:
	provisioning/miniprov/hare_mp/main.py