### PR TITLE
EOS-26888: init and data containers are not ordered across the pods

### DIFF
--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -48,6 +48,10 @@ class ValueProvider:
     def get_storage_set_nodes(self) -> List[str]:
         raise NotImplementedError()
 
+    def search_val(self, parent_key: str, search_key: str,
+                   search_val: str) -> List[str]:
+        raise NotImplementedError()
+
 
 class ConfStoreProvider(ValueProvider):
     def __init__(self, url: str, index='hare'):
@@ -108,6 +112,13 @@ class ConfStoreProvider(ValueProvider):
                 storage_nodes.remove(node)
 
         return storage_nodes
+
+    def search_val(self, parent_key: str, search_key: str,
+                   search_val: str) -> List[str]:
+        """
+        Searches a given key value under the given parent key.
+        """
+        return self.conf.search(self.index, parent_key, search_key, search_val)
 
 
 def get_machine_id() -> str:

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -24,10 +24,11 @@ import json
 import io
 import os
 import logging
-from typing import List
+from typing import List, Dict, Any
 from distutils.dir_util import copy_tree
 import shutil
 
+from cortx.utils.cortx import Const
 from hax.util import repeat_if_fails, KVAdapter
 from helper.exec import Program, Executor
 
@@ -159,6 +160,23 @@ class Utils:
 
     def is_hare_stopping(self) -> bool:
         return self.hare_stop
+
+    def get_io_nodes(self) -> List[str]:
+        nodes: List[str] = []
+        conf = self.provider
+        machines: Dict[str, Any] = conf.get('node')
+        # Query results into a list of keys where, Const.SERVICE_MOTR_IO
+        # is found as one of the services under `services`.
+        # e.g.
+        # node>0b9cf99f07574422a45f9b61d2f5b746>components[1]>services[0]
+        # node>0b9cf99f07574422a45f9b61d2f5b746>components[3]>services[0]
+        services = conf.search_val('node', 'services',
+                                   Const.SERVICE_MOTR_IO.value)
+        for machine_id in machines.keys():
+            result = list(filter(lambda svc: machine_id in svc, services))
+            if result:
+                nodes.append(conf.get(f'node>{machine_id}>hostname'))
+        return nodes
 
 
 class LogWriter:


### PR DESCRIPTION
In containers environment init containers in data pods perform mkfs afer which
the data containers start. Ordering with a given pod happens implicitly but not
across the pods. It is possible that while init container on a pod is in-progress
while another data pod has already started. Motr services from the started data
pod may try to connect to the motr mkfs processes running in the init container as
both motr mkfs and motr ioservices use the same motr identifiers. Furthermore,
once the init container completes, motr ioservices connection would break, resulting
in failures. It is possible that motr may experience failures in this case.
It is epected that not even intermittent failures must be observed.

Solution:
To handle this situation, Hare sets a Consul KV per node on completion of mkfs in
init stage. This kv is checked by all the nodes for all the nodes before completing
their init stages respectively. This will delay starting of data containers until
init containers are done.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>