### PR TITLE
EOS-26608: config, cfgen support nodes without motr srvces and devices

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -404,6 +404,9 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
         if 'm0_servers' not in node:
             continue
 
+        m0d = node['m0_servers']
+        if m0d is None:
+            continue
         for m0d in node['m0_servers']:
             m0d.setdefault('runs_confd', False)
             if 'meta_data' in m0d['io_disks']:
@@ -460,6 +463,9 @@ def validate_nodes_desc(nodes_desc: List[Dict[str, Any]]) -> None:
         _assert(node['facts'][ipaddr_key(iface)],
                 f"""{name}: {iface!r} interface has no IP address
 Make sure the value of data_iface in the CDF is correct.""")
+        m0d = node['m0_servers']
+        if m0d is None:
+            continue
 
         if 'm0_servers' not in node:
             _assert((node['m0_clients']['s3']
@@ -2420,21 +2426,26 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         node_id = ConfNode.build(conf, root_id, node)
         encl_id = ConfEnclosure.build(conf, rack_id, node_id)
         ctrl_ids: List[Tuple[Optional[Oid], Any]] = []
-        for m0d in node.get('m0_servers', []):
-            if m0d['_io_disks']:
-                ctrl_ids.append((ConfController.build(conf, encl_id), m0d))
-            else:
-                ctrl_ids.append((None, m0d))
+        m0srv = node['m0_servers']
+        if m0srv is not None:
+            for m0d in node.get('m0_servers', []):
+                if m0d['_io_disks']:
+                    ctrl_ids.append((ConfController.build(conf, encl_id), m0d))
+                else:
+                    ctrl_ids.append((None, m0d))
+
         ConfProcess.build(conf, node_id, node, ProcT.hax)
 
-        confd_p = False
-        for ctrl_id in ctrl_ids:
-            m0d = ctrl_id[1]
-            conf_ctrl_id: Optional[Oid] = ctrl_id[0]
-            ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
-                              conf_ctrl_id)
-            if m0d['runs_confd']:
-                confd_p = True
+        m0srv = node['m0_servers']
+        if m0srv is not None:
+            confd_p = False
+            for ctrl_id in ctrl_ids:
+                m0d = ctrl_id[1]
+                conf_ctrl_id: Optional[Oid] = ctrl_id[0]
+                ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
+                                  conf_ctrl_id)
+                if m0d['runs_confd']:
+                    confd_p = True
 
         ipaddr = node['facts'][ipaddr_key(node['data_iface'])]
         (cluster.consul_servers if confd_p else cluster.consul_clients).\

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -123,7 +123,6 @@ class CdfGenerator:
             # Skipping for controller, ha and server nodes
             if (node_type in ('storage_node', 'data_node')):
                 out.append(node)
-
         return out
 
     def _validate_pool(self, pool: PoolHandle) -> None:
@@ -343,6 +342,7 @@ class CdfGenerator:
         # servers: DList[M0ServerDesc] = None
         servers = None
         no_m0clients = 0
+        nr_s3_instances = int(store.get('cortx>s3>service_instances'))
         if(self.utils.is_motr_component(machine_id)):
             try:
                 # cortx>motr>client_instances
@@ -377,6 +377,7 @@ class CdfGenerator:
                     data=DList([], 'List Disk'),
                     meta_data=Maybe(None, 'Text')),
                 runs_confd=Maybe(True, 'Bool')))
+            nr_s3_instances = 0
 
         node_facts = self.utils.get_node_facts()
         return NodeDesc(
@@ -393,6 +394,5 @@ class CdfGenerator:
             # TODO in the future the value must be taken from a correct
             # ConfStore key (it doesn't exist now).
             # cortx>s3>service_instances
-            s3_instances=int(
-                store.get('cortx>s3>service_instances')),
+            s3_instances=nr_s3_instances,
             client_instances=no_m0clients)

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -105,13 +105,13 @@ class ConfStoreProvider(ValueProvider):
         storage_nodes_key = (f'cluster>storage_set[{storage_set_index}]>nodes')
         storage_nodes = self.get(storage_nodes_key)
 
+        data_nodes: List[Any] = []
         for node in storage_nodes:
             node_type = self.get(f'node>{node}>type')
             # Skipping controller node
-            if node_type != 'storage_node':
-                storage_nodes.remove(node)
-
-        return storage_nodes
+            if (node_type == 'storage_node' or node_type == 'data_node'):
+                data_nodes += [node]
+        return data_nodes
 
     def search_val(self, parent_key: str, search_key: str,
                    search_val: str) -> List[str]:

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -113,12 +113,15 @@ class ConfStoreProvider(ValueProvider):
                 data_nodes += [node]
         return data_nodes
 
+
+'''
     def search_val(self, parent_key: str, search_key: str,
                    search_val: str) -> List[str]:
         """
         Searches a given key value under the given parent key.
         """
         return self.conf.search(self.index, parent_key, search_key, search_val)
+'''
 
 
 def get_machine_id() -> str:

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -98,17 +98,30 @@ class Utils:
         disk_key = path.strip('/')
         self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
 
+    def is_motr_component(self, machine_id: str) -> bool:
+        logging.info(f'1.is_motr_component : machine_id = {machine_id}')
+        comp_names = self.provider.get(f'node>{machine_id}>'
+                                       f'components')
+        for component in comp_names:
+            if(component.get('name') == 'motr'):
+                rc = True
+                break
+            else:
+                rc = False
+        return rc
+
     def save_drives_info(self):
         machine_id = self.provider.get_machine_id()
-        cvgs_key: str = f'node>{machine_id}>storage>cvg'
-        for cvg in range(len(self.provider.get(cvgs_key))):
-            data_devs = self.get_data_devices(machine_id, cvg)
-            for dev_path in data_devs.value:
-                self._save_drive_info(dev_path.s)
+        if(self.is_motr_component(machine_id)):
+            cvgs_key: str = f'node>{machine_id}>storage>cvg'
+            for cvg in range(len(self.provider.get(cvgs_key))):
+                data_devs = self.get_data_devices(machine_id, cvg)
+                for dev_path in data_devs.value:
+                    self._save_drive_info(dev_path.s)
 
     @repeat_if_fails()
-    def get_drive_info_from_consul(self, path: Text) -> Disk:
-        hostname = self.get_local_hostname()
+    def get_drive_info_from_consul(self, path: Text, machine_id: str) -> Disk:
+        hostname = self.get_hostname(machine_id)
         disk_path = json.loads(str(path)).lstrip(os.sep)
         drive_data = self.kv.kv_get(f'{hostname}/{disk_path}')
         drive_info = json.loads(drive_data['Value'])
@@ -116,10 +129,9 @@ class Utils:
                      size=Maybe(drive_info['size'], 'Natural'),
                      blksize=Maybe(drive_info['blksize'], 'Natural')))
 
-    def get_drives_info_for(self, cvg: int) -> DList[Disk]:
-        machine_id = self.provider.get_machine_id()
+    def get_drives_info_for(self, cvg: int, machine_id: str) -> DList[Disk]:
         data_devs = self.get_data_devices(machine_id, cvg)
-        return DList([self.get_drive_info_from_consul(dev_path)
+        return DList([self.get_drive_info_from_consul(dev_path, machine_id)
                       for dev_path in data_devs.value], 'List Disk')
 
     def import_kv(self, conf_dir_path: str):

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -28,7 +28,7 @@ from typing import List, Dict, Any
 from distutils.dir_util import copy_tree
 import shutil
 
-from cortx.utils.cortx import Const
+# from cortx.utils.cortx import Const
 from hax.util import repeat_if_fails, KVAdapter
 from helper.exec import Program, Executor
 
@@ -99,7 +99,6 @@ class Utils:
         self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
 
     def is_motr_component(self, machine_id: str) -> bool:
-        logging.info(f'1.is_motr_component : machine_id = {machine_id}')
         comp_names = self.provider.get(f'node>{machine_id}>'
                                        f'components')
         for component in comp_names:
@@ -182,12 +181,14 @@ class Utils:
         # e.g.
         # node>0b9cf99f07574422a45f9b61d2f5b746>components[1]>services[0]
         # node>0b9cf99f07574422a45f9b61d2f5b746>components[3]>services[0]
-        services = conf.search_val('node', 'services',
-                                   Const.SERVICE_MOTR_IO.value)
+        # services = conf.search_val('node', 'services',
+        #                            Const.SERVICE_MOTR_IO.value)
         for machine_id in machines.keys():
-            result = list(filter(lambda svc: machine_id in svc, services))
-            if result:
-                nodes.append(conf.get(f'node>{machine_id}>hostname'))
+            # result = list(filter(lambda svc: machine_id in svc, services))
+            # if result:
+            #     nodes.append(conf.get(f'node>{machine_id}>hostname'))
+            if(self.is_motr_component(machine_id)):
+                nodes += [self.get_hostname(machine_id)]
         return nodes
 
 


### PR DESCRIPTION
Currently Hare 'config' stage is assuming that each node / pod will
contain motr services and devices mentioned in CDF file.
In any scenarios, config stage of hare should check, if motr services
are there and then only generate motr related fids.
In case motr services are not there, do not start/intiate motr
dependent services. Also currently 'config' is failing in s3server pod,
if 'motr-hare_keys.json' is not present, this needs to be fixed for
s3server pod.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
