### PR TITLE
EOS-26874: Use constants to filter node type info from conf-store

### DIFF
--- a/hax/helper/configure.py
+++ b/hax/helper/configure.py
@@ -168,7 +168,7 @@ class ConfGenerator:
         cns_file = f'{self.conf_dir}/consul-agents.json'
 
         def get_join_ip() -> str:
-            for node, ip in self._get_server_nodes(cns_file):
+            for node, ip in self._get_data_nodes(cns_file):
                 if node == node_name:
                     return ip
             raise RuntimeError(f'Logic error: node_name={node_name}'
@@ -176,7 +176,7 @@ class ConfGenerator:
 
         join_ip = get_join_ip()
         join_peers_opt: List[str] = []
-        for node, ip in self._get_server_nodes(cns_file):
+        for node, ip in self._get_data_nodes(cns_file):
             if node == node_name:
                 continue
             join_peers_opt += ['--join', ip]
@@ -237,8 +237,8 @@ class ConfGenerator:
 
         return hostname == self._read_file(minion_file).strip()
 
-    def _get_server_nodes(self,
-                          consul_agents_file: str) -> List[Tuple[str, str]]:
+    def _get_data_nodes(self,
+                        consul_agents_file: str) -> List[Tuple[str, str]]:
         return self._get_nodes_ex(consul_agents_file,
                                   '.servers[] | "\\(.node_name) \\(.ipaddr)"')
 

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -110,7 +110,7 @@ class TestCDF(unittest.TestCase):
 
 
             store.get_machine_id = Mock(return_value='1114a50a6bf6f9c93ebd3c49d07d3fd4')
-            store.get_storage_set_nodes = Mock(return_value=['1114a50a6bf6f9c93ebd3c49d07d3fd4'])
+            store.get_data_nodes = Mock(return_value=['1114a50a6bf6f9c93ebd3c49d07d3fd4'])
             utils = Utils(store)
             kv = KVAdapter()
             def my_get(key: str, recurse: bool = False):
@@ -231,7 +231,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -325,7 +325,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -510,7 +510,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID1')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID1', 'MACH_ID2', 'MACH_ID3'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID1', 'MACH_ID2', 'MACH_ID3'])
 
         ret = CdfGenerator(provider=store,
                            motr_provider=Mock())._create_pool_descriptions()
@@ -579,7 +579,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['srvnode_1'])
+        store.get_data_nodes = Mock(return_value=['srvnode_1'])
         cdf = CdfGenerator(provider=store, motr_provider=Mock())
         cdf._get_m0d_per_cvg = Mock(return_value=1)
         utils = Utils(store)
@@ -769,7 +769,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID'])
         ret = CdfGenerator(provider=store,
                            motr_provider=Mock())._create_pool_descriptions()
         self.assertEqual(1, len(ret))
@@ -835,7 +835,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID'])
         ret = CdfGenerator(provider=store,
                            motr_provider=Mock())._create_pool_descriptions()
         self.assertEqual(['sns', 'dix'], [t.type.name for t in ret])
@@ -896,7 +896,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -1011,7 +1011,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
 
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['MACH_ID'])
+        store.get_data_nodes = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -1095,7 +1095,7 @@ class TestCDF(unittest.TestCase):
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
-        store.get_storage_set_nodes = Mock(return_value=['srvnode_1'])
+        store.get_data_nodes = Mock(return_value=['srvnode_1'])
         cdf = CdfGenerator(provider=store, motr_provider=Mock())
         utils = Utils(store)
         kv = KVAdapter()


### PR DESCRIPTION
EOS-26874: Used constants to filter node type info from conf-store

Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>

# Problem Statement
- Earlier hare uses node type value from conf-store to identify if its a data node (running ioservices) or not. Utils Team had provided a new set of constants ans search API which can be used to extract the information of node type from the conf-store by making use of appropriate key. Thus, creating a strict binding contract between the provisioner and the components.

# Solution
-  Removed hardcoded node_type value with appropriate constants key and search API.
-  Renamed function name from _get_server_nodes to _get_data_nodes and get_storage_set_nodes to get_data_nodes.


# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- This PR is going to commit in 'K8s_pod_separation' branch.

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
