### PR TITLE
Problem: h0q is broken because of inject library

### DIFF
--- a/hax/hax/queue/cli.py
+++ b/hax/hax/queue/cli.py
@@ -3,6 +3,9 @@ import sys
 from typing import NamedTuple
 
 import click
+import inject
+
+from hax.common import di_configuration
 from hax.queue.publish import BQPublisher, EQPublisher, Publisher
 
 AppCtx = NamedTuple('AppCtx', [('payload', str), ('type', str),
@@ -46,6 +49,7 @@ def parse_opts(ctx, queue: str, type: str, payload: str):
 
 def main():
     _setup_logging()
+    inject.configure(di_configuration)
     try:
         raw_ctx = parse_opts(args=sys.argv[1:],
                              standalone_mode=False,


### PR DESCRIPTION
# Problem Statement
After inject library is introdued, @repeat_if_fails() decorator can't be
used until inject DI engine is configured. It seems like we forgot to
update h0q CLI utility.

Up to this PR neither EQ nor BQ would work from command line.

# Design
Solution: configure DI in the main function of queue/cli.py


# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
