### PR TITLE
EOS-25926: mkfs is getting stuck in case Hax is not ready for entrypoint request

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -18,7 +18,6 @@
 
 import ctypes as c
 import logging
-from errno import EAGAIN
 from typing import Any, List, Optional, Tuple
 
 from hax.consul.cache import supports_consul_cache, uses_consul_cache
@@ -188,7 +187,6 @@ class Motr:
         req_id = message.req_id
         remote_rpc_endpoint = message.remote_rpc_endpoint
         process_fid = message.process_fid
-        e_rc = EAGAIN
 
         LOG.debug('Processing entrypoint request from remote endpoint'
                   " '{}', process fid {}".format(remote_rpc_endpoint,
@@ -250,17 +248,17 @@ class Motr:
                     rm_eps = svc.address
                     break
             if confds and (not self.is_stopping) and (not rm_eps):
-                if util.m0ds_stopping():
-                    e_rc = 0
                 raise RuntimeError('No RM node found in Consul')
         except Exception:
+            # In case of exception we are dropping the entrypoint requests
+            # silently at hax and hax will not send any entrypoint reply.
+            # In such a case we will let motr timeout and Hare will then
+            # expect a subsequent entrypoint request from Motr
+            # Note that this is short term fix and we have created
+            # EOS-27068 to solve it properly
             LOG.exception('Failed to get the data from Consul.'
-                          ' Replying with EAGAIN error code.')
-            self._ffi.entrypoint_reply(reply_context, req_id.to_c(), e_rc, 0,
-                                       make_array(FidStruct, []),
-                                       make_array(c.c_char_p, []), 0,
-                                       Fid(0, 0).to_c(), None)
-            LOG.debug('Reply sent')
+                          ' dropping the entrypoint request.')
+            LOG.debug('Entrypoint request ignored')
             return
 
         confd_fids = [x.fid.to_c() for x in confds]


### PR DESCRIPTION
# Problem Statement
- mkfs is getting stuck in case Hax is not ready for entrypoint request

# Design
-  In case of exception while replying to entrypoint request Hare will drop
the entrypoint requests silently at hax and hax will not send any entrypoint reply.
In such a case we will let motr timeout and Hare will then expect a subsequent
entrypoint request from Motr

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
