### PR TITLE
EOS-26608: config, cfgen support nodes without motr srvces and devices

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -404,6 +404,9 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
         if 'm0_servers' not in node:
             continue
 
+        m0d = node.get('m0_servers')
+        if m0d is None:
+            continue
         for m0d in node['m0_servers']:
             m0d.setdefault('runs_confd', False)
             if 'meta_data' in m0d['io_disks']:
@@ -460,6 +463,9 @@ def validate_nodes_desc(nodes_desc: List[Dict[str, Any]]) -> None:
         _assert(node['facts'][ipaddr_key(iface)],
                 f"""{name}: {iface!r} interface has no IP address
 Make sure the value of data_iface in the CDF is correct.""")
+        m0d = node.get('m0_servers')
+        if m0d is None:
+            continue
 
         if 'm0_servers' not in node:
             _assert((node['m0_clients']['s3']
@@ -2420,21 +2426,26 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         node_id = ConfNode.build(conf, root_id, node)
         encl_id = ConfEnclosure.build(conf, rack_id, node_id)
         ctrl_ids: List[Tuple[Optional[Oid], Any]] = []
-        for m0d in node.get('m0_servers', []):
-            if m0d['_io_disks']:
-                ctrl_ids.append((ConfController.build(conf, encl_id), m0d))
-            else:
-                ctrl_ids.append((None, m0d))
+        m0srv = node.get('m0_servers')
+        if m0srv is not None:
+            for m0d in node.get('m0_servers', []):
+                if m0d['_io_disks']:
+                    ctrl_ids.append((ConfController.build(conf, encl_id), m0d))
+                else:
+                    ctrl_ids.append((None, m0d))
+
         ConfProcess.build(conf, node_id, node, ProcT.hax)
 
-        confd_p = False
-        for ctrl_id in ctrl_ids:
-            m0d = ctrl_id[1]
-            conf_ctrl_id: Optional[Oid] = ctrl_id[0]
-            ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
-                              conf_ctrl_id)
-            if m0d['runs_confd']:
-                confd_p = True
+        m0srv = node.get('m0_servers')
+        if m0srv is not None:
+            confd_p = False
+            for ctrl_id in ctrl_ids:
+                m0d = ctrl_id[1]
+                conf_ctrl_id: Optional[Oid] = ctrl_id[0]
+                ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
+                                  conf_ctrl_id)
+                if m0d['runs_confd']:
+                    confd_p = True
 
         ipaddr = node['facts'][ipaddr_key(node['data_iface'])]
         (cluster.consul_servers if confd_p else cluster.consul_clients).\

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -35,7 +35,6 @@ from sys import exit
 from time import sleep, perf_counter
 from typing import Any, Callable, Dict, List
 from threading import Event
-from urllib.parse import urlparse
 
 import yaml
 from cortx.utils.product_features import unsupported_features
@@ -845,13 +844,8 @@ def check_cluster_status(path_to_cdf: str):
     return 0
 
 
-def generate_cdf(url: str, motr_md_url: str) -> str:
-    # ConfStoreProvider creates an empty file, if file does not exist.
-    # So, we are validating the file is present or not.
-    if not os.path.isfile(urlparse(motr_md_url).path):
-        raise FileNotFoundError(f'config file: {motr_md_url} does not exist')
-    motr_provider = ConfStoreProvider(motr_md_url, index='motr_md')
-    generator = CdfGenerator(ConfStoreProvider(url), motr_provider)
+def generate_cdf(url: str) -> str:
+    generator = CdfGenerator(ConfStoreProvider(url))
     return generator.generate()
 
 
@@ -905,14 +899,7 @@ def config(args):
             filename = args.file[0]
         else:
             filename = get_config_dir(url) + '/cluster.yaml'
-
-        provider = ConfStoreProvider(url)
-        config_path = provider.get('cortx>common>storage>local')
-        machine_id = provider.get_machine_id()
-        motr_md_path = config_path + '/motr/' + machine_id
-        motr_md_url = 'json://' + motr_md_path + '/motr_hare_keys.json'
-
-        save(filename, generate_cdf(url, motr_md_url))
+        save(filename, generate_cdf(url))
         update_hax_unit('/usr/lib/systemd/system/hare-hax.service')
         generate_config(url, filename)
         consul_starter.stop()


### PR DESCRIPTION
Currently Hare 'config' stage is assuming that each node / pod will
contain motr services and devices mentioned in CDF file.
In any scenarios, config stage of hare should check, if motr services
are there and then only generate motr related fids.
In case motr services are not there, do not start/intiate motr
dependent services. Also currently 'config' is failing in s3server pod,
if 'motr-hare_keys.json' is not present, this needs to be fixed for
s3server pod.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
