### PR TITLE
EOS-27069: hare does not support multiple network transports

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -825,6 +825,10 @@ NetProtocol = Enum('NetProtocol', 'tcp o2ib')
 
 
 class Endpoint:
+    pass
+
+
+class LnetEndpoint(Endpoint):
     _tmids: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, proto: NetProtocol, ipaddr: str, portalgroup: int,
@@ -849,7 +853,7 @@ class Endpoint:
         return f'{self.__class__.__name__}({args})'
 
     def to_dhall(self):
-        return f'utils.endpoint types.Protocol.{self.proto.name}' \
+        return f'utils.lnetendpoint types.Protocol.{self.proto.name}' \
             f' "{self.ipaddr}" {self.portalgroup} {self.tmid}'
 
     def __str__(self):
@@ -858,7 +862,7 @@ class Endpoint:
         return f'{ip}@{proto}:12345:{self.portalgroup}:{self.tmid}'
 
 
-class LibfabricEndpoint:
+class LibfabricEndpoint(Endpoint):
     ep_map: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, NetFamily: str, proto: NetProtocol, ipaddr: str,
@@ -1027,7 +1031,7 @@ class ConfProcess(ToDhall):
     _downlinks = {Downlink('services', ObjT.service)}
 
     def __init__(self, nr_cpu: int, memsize_MB: int,
-                 endpoint: LibfabricEndpoint,
+                 endpoint,
                  services: List[Oid], meta_data: str = None):
         _assert(nr_cpu > 0, 'nr_cpu must be positive')
         self.nr_cpu = nr_cpu
@@ -1052,7 +1056,7 @@ class ConfProcess(ToDhall):
         args = ', '.join([f'id = {oid_to_dhall(oid)}',
                           f'nr_cpu = {self.nr_cpu}',
                           f'memsize_MB = {self.memsize_MB}',
-                          f'endpoint = {self.endpoint.to_dhall()}',
+                          f'endpoint = "{self.endpoint}"',
                           f'services = {oids_to_dhall(self.services)}'])
         return '{ %s }' % args
 
@@ -1073,16 +1077,19 @@ class ConfProcess(ToDhall):
 
         facts = node_desc['facts']
         proto = node_desc.get('data_iface_type', 'tcp')
-        # Creates Lnet endpoint, remove once deprecated.
-        # ep = Endpoint(proto=NetProtocol[proto],
-        #               ipaddr=facts[ipaddr_key(node_desc['data_iface'])],
-        #              portal=proc_t.value)
-        ep = LibfabricEndpoint(NetFamily='inet', proto=NetProtocol[proto],
-                               ipaddr=facts[ipaddr_key(
-                                            node_desc['data_iface'])],
-                               portalgroup=proc_t.value)
+        transport_type = node_desc.get('transport_type', 'libfab')
+        ep: Any = (
+            LibfabricEndpoint(NetFamily='inet', proto=NetProtocol[proto],
+                              ipaddr=facts[ipaddr_key(
+                                           node_desc['data_iface'])],
+                              portalgroup=proc_t.value))
+        if transport_type == 'lnet':
+            # Creates Lnet endpoint, remove once deprecated.
+            ep = LnetEndpoint(proto=NetProtocol[proto],
+                              ipaddr=facts[ipaddr_key(
+                                           node_desc['data_iface'])],
+                              portalgroup=proc_t.value)
         proc_id = new_oid(ObjT.process)
-
         meta_data = None
         if proc_desc is not None and proc_t is ProcT.m0_server:
             meta_data = proc_desc['io_disks'].get('meta_data')
@@ -1160,7 +1167,7 @@ class ConfService(ToDhall):
     _objt = ObjT.service
     _downlinks = {Downlink('sdevs', ObjT.sdev)}
 
-    def __init__(self, stype: SvcT, endpoint: LibfabricEndpoint,
+    def __init__(self, stype: SvcT, endpoint,
                  sdevs: List[Oid], ctrl_id: Oid = None):
         self.type = stype
         self.endpoint = endpoint
@@ -1178,13 +1185,13 @@ class ConfService(ToDhall):
         assert oid.type is ObjT.service
         args = ', '.join([f'id = {oid_to_dhall(oid)}',
                           f'type = {self.type.to_dhall()}',
-                          f'endpoint = {self.endpoint.to_dhall()}',
+                          f'endpoint = "{self.endpoint}"',
                           f'sdevs = {oids_to_dhall(self.sdevs)}'])
         return '{ %s }' % args
 
     @classmethod
     def build(cls, m0conf: Dict[Oid, Any], parent: Oid,
-              stype: SvcT, endpoint: LibfabricEndpoint,
+              stype: SvcT, endpoint,
               ctrl: Optional[Oid] = None) -> Oid:
         assert parent.type is ObjT.process
         svc_id = new_oid(ObjT.service)
@@ -2161,7 +2168,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
     m0conf = cluster.m0conf
 
     ConsulService = NamedTuple('ConsulService', [
-        ('node_name', str), ('proc_id', Oid), ('ep', LibfabricEndpoint),
+        ('node_name', str), ('proc_id', Oid), ('ep', Any),
         ('svc_id', Oid), ('stype', str), ('meta_data', Optional[str])])
 
     def processes() -> Iterator[ConsulService]:

--- a/cfgen/dhall/render.dhall
+++ b/cfgen/dhall/render.dhall
@@ -18,7 +18,7 @@
 
 -}
 
-{ Endpoint   = ./render/Endpoint.dhall
+{ LnetEndpoint   = ./render/LnetEndpoint.dhall
 , NetId      = ./render/NetId.dhall
 
 , LibfabricEndpoint = ./render/LibfabricEndpoint.dhall

--- a/cfgen/dhall/render/Endpoint.dhall
+++ b/cfgen/dhall/render/Endpoint.dhall
@@ -21,6 +21,8 @@
 let types = ../types.dhall
 
 in
-\(x : types.Endpoint) ->
-    let nat = Natural/show
-    in "${./NetId.dhall x.nid}:12345:${nat x.portal}:${nat x.tmid}"
+\(ep : types.Endpoint) ->
+    merge
+    { LnetEndpoint = ./LnetEndpoint.dhall
+    , LibfabricEndpoint = ./LibfabricEndpoint.dhall
+    } ep

--- a/cfgen/dhall/render/LnetEndpoint.dhall
+++ b/cfgen/dhall/render/LnetEndpoint.dhall
@@ -18,20 +18,9 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
 let types = ../types.dhall
 
-let named = ./RNamed.dhall
-
 in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+\(x : types.LnetEndpoint) ->
+    let nat = Natural/show
+    in "${./NetId.dhall x.nid}:12345:${nat x.portal}:${nat x.tmid}"

--- a/cfgen/dhall/render/Process.dhall
+++ b/cfgen/dhall/render/Process.dhall
@@ -37,7 +37,7 @@ in
       , named.Natural "mem_limit_rss" memsize_KiB
       , named.Natural "mem_limit_stack" memsize_KiB
       , named.Natural "mem_limit_memlock" memsize_KiB
-      , named.Text "endpoint" (./LibfabricEndpoint.dhall x.endpoint)
+      , named.Text "endpoint" x.endpoint
       , named.Oids "services" x.services
       ]
  ++ ")"

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -33,10 +33,11 @@
     import for all available types.
 -}
 
-{ Addr        = ./types/Addr.dhall
-, Endpoint    = ./types/Endpoint.dhall
-, NetId       = ./types/NetId.dhall
-, Protocol    = ./types/Protocol.dhall
+{ Addr         = ./types/Addr.dhall
+, Endpoint     = ./types/Endpoint.dhall
+, LnetEndpoint = ./types/LnetEndpoint.dhall
+, NetId        = ./types/NetId.dhall
+, Protocol     = ./types/Protocol.dhall
 
 , LibfabricEndpoint = ./types/LibfabricEndpoint.dhall
 , NetFamily   = ./types/NetFamily.dhall

--- a/cfgen/dhall/types/Endpoint.dhall
+++ b/cfgen/dhall/types/Endpoint.dhall
@@ -18,18 +18,6 @@
 
 -}
 
-{-
-   LNet endpoint address.
-
-   Endpoint address format (ABNF):
-
-   endpoint = nid ":12345:" DIGIT+ ":" DIGIT+
-   ; <network id>:<process id>:<portal number>:<transfer machine id>
-   ;
-   nid      = "0@lo" / (ipv4addr  "@" ("tcp" / "o2ib") [DIGIT])
-   ipv4addr = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT ; 0..255
--}
-{ nid : ./NetId.dhall
-, portal : Natural
-, tmid : Natural
-}
+< LnetEndpoint : ./LnetEndpoint.dhall
+| LibfabricEndpoint : ./LibfabricEndpoint.dhall
+>

--- a/cfgen/dhall/types/LibfabricEndpoint.dhall
+++ b/cfgen/dhall/types/LibfabricEndpoint.dhall
@@ -21,6 +21,7 @@
 {-
    Libfabric endpoint address.
 -}
+
 { netfamily : ./NetFamily.dhall
 , nid : ./NetId.dhall
 , portal : Natural

--- a/cfgen/dhall/types/LnetEndpoint.dhall
+++ b/cfgen/dhall/types/LnetEndpoint.dhall
@@ -18,19 +18,18 @@
 
 -}
 
-let types = ../types.dhall
+{-
+   LNet endpoint address.
 
-in
-    \(proto : types.Protocol)
- -> \(ipaddr : Text)
- -> \(portal : Natural)
- -> \(tmid : Natural)
- ->
-    let addr = { ipaddr = ipaddr, mdigit = None Natural }
-    in
-      { nid = merge { tcp = types.NetId.tcp { tcp = addr }
-                    , o2ib = types.NetId.o2ib { o2ib = addr }
-                    } proto
-      , portal = portal
-      , tmid = tmid
-      } : types.Endpoint
+   Endpoint address format (ABNF):
+
+   endpoint = nid ":12345:" DIGIT+ ":" DIGIT+
+   ; <network id>:<process id>:<portal number>:<transfer machine id>
+   ;
+   nid      = "0@lo" / (ipv4addr  "@" ("tcp" / "o2ib") [DIGIT])
+   ipv4addr = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT ; 0..255
+-}
+{ nid : ./NetId.dhall
+, portal : Natural
+, tmid : Natural
+}

--- a/cfgen/dhall/types/NodeDesc.dhall
+++ b/cfgen/dhall/types/NodeDesc.dhall
@@ -25,6 +25,7 @@
 , data_iface : Text
 , data_iface_ip_addr : Optional Text
 , data_iface_type : Optional ./Protocol.dhall
+, transport_type : Text
 , m0_servers : Optional (List ./M0ServerDesc.dhall)
 , m0_clients : { s3 : Natural, other : Natural }
 }

--- a/cfgen/dhall/types/Process.dhall
+++ b/cfgen/dhall/types/Process.dhall
@@ -25,6 +25,6 @@ in
 { id : Oid
 , nr_cpu : Natural
 , memsize_MB : Natural
-, endpoint : ./LibfabricEndpoint.dhall
+, endpoint : Text
 , services : List Oid
 }

--- a/cfgen/dhall/types/Service.dhall
+++ b/cfgen/dhall/types/Service.dhall
@@ -24,6 +24,6 @@ in
 -- m0_confx_service
 { id : Oid
 , type : ./SvcT.dhall
-, endpoint : ./LibfabricEndpoint.dhall
+, endpoint : Text
 , sdevs : List Oid
 }

--- a/cfgen/dhall/utils.dhall
+++ b/cfgen/dhall/utils.dhall
@@ -18,7 +18,7 @@
 
 -}
 
-{ endpoint = ./utils/endpoint.dhall
+{ lnetendpoint = ./utils/lnetendpoint.dhall
 , libfabricendpoint = ./utils/libfabricendpoint.dhall
 , zoid = ./utils/zoid.dhall
 }

--- a/cfgen/dhall/utils/lnetendpoint.dhall
+++ b/cfgen/dhall/utils/lnetendpoint.dhall
@@ -18,20 +18,19 @@
 
 -}
 
-let Prelude = ../Prelude.dhall
-
 let types = ../types.dhall
 
-let named = ./RNamed.dhall
-
 in
-\(x : types.Service) ->
-    "("
- ++ Prelude.Text.concatSep " "
-      [ ./Oid.dhall x.id
-      , named.TextUnquoted "type" ("@" ++ ./SvcT.dhall x.type)
-      , named.Texts "endpoints" [x.endpoint]
-      , "params=[]"
-      , named.Oids "sdevs" x.sdevs
-      ]
- ++ ")"
+    \(proto : types.Protocol)
+ -> \(ipaddr : Text)
+ -> \(portal : Natural)
+ -> \(tmid : Natural)
+ ->
+    let addr = { ipaddr = ipaddr, mdigit = None Natural }
+    in
+      { nid = merge { tcp = types.NetId.tcp { tcp = addr }
+                    , o2ib = types.NetId.o2ib { o2ib = addr }
+                    } proto
+      , portal = portal
+      , tmid = tmid
+      } : types.LnetEndpoint

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -383,6 +383,7 @@ class CdfGenerator:
             data_iface=Text(iface),
             data_iface_ip_addr=Maybe(Text(hostname), 'Text'),
             data_iface_type=Maybe(self._get_iface_type(machine_id), 'P'),
+            transport_type=Text(self.utils.get_transport_type()),
             m0_servers=Maybe(servers, 'List M0ServerDesc'),
             #
             # [KN] This is a hotfix for singlenode deployment

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -29,6 +29,7 @@ let NodeInfo =
       , data_iface : Text
       , data_iface_ip_addr : Optional Text
       , data_iface_type : Optional T.Protocol
+      , transport_type : Text
       , m0_servers : Optional (List M0ServerDesc)
       , s3_instances : Natural
       , client_instances : Natural
@@ -75,6 +76,7 @@ let toNodeDesc
           , data_iface_ip_addr = n.data_iface_ip_addr
           , data_iface = n.data_iface
           , data_iface_type = n.data_iface_type
+          , transport_type = n.transport_type
           , m0_clients = { other = n.client_instances, s3 = n.s3_instances }
           , m0_servers = n.m0_servers
           }

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -842,7 +842,9 @@ def generate_config(url: str, path_to_cdf: str) -> None:
     if path:
         path += os.pathsep + '/opt/seagate/cortx/hare/bin/'
     python_path = os.pathsep.join(sys.path)
+    transport_type = utils.get_transport_type()
     cmd = ['configure', '-c', conf_dir, path_to_cdf,
+           '--transport', transport_type,
            '--log-dir', get_log_dir(url),
            '--log-file', LOG_FILE,
            '--uuid', provider.get_machine_id()]

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -118,6 +118,7 @@ class NodeDesc(DhallTuple):
     data_iface: Text
     data_iface_ip_addr: Maybe[Text]
     data_iface_type: Maybe[Protocol]
+    transport_type: Text
     m0_servers: Maybe[DList[M0ServerDesc]]
     s3_instances: int
     client_instances: int

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -178,6 +178,14 @@ class Utils:
                 nodes.append(conf.get(f'node>{machine_id}>hostname'))
         return nodes
 
+    def get_transport_type(self) -> str:
+        transport_type = self.provider.get(
+            'cortx>motr>transport_type',
+            allow_null=True)
+        if transport_type is None:
+            return 'libfab'
+        return transport_type
+
 
 class LogWriter:
     def __init__(self, logger: logging.Logger, logging_handler):

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -38,6 +38,8 @@ The required parameter is one of the following:
 Options:
   --mkfs-only   Do m0mkfs only (CAUTION: wipes Motr data).
   --mkfs        Do m0mkfs (CAUTION: wipes Motr data) and start Motr servers.
+  --xprt        Use given motr transport type to generate corresponding motr
+                process endpoints. Supported transport types are lnet and libfab.
   --m0d         Skip m0mkfs, start Motr servers.
   -h, --help    Show this help and exit.
 EOF
@@ -50,9 +52,10 @@ die() {
 
 do_mkfs=
 phase=-
+xprt='lnet'
 
 TEMP=$(getopt --options hp: \
-              --longoptions help,mkfs,mkfs-only,m0d,phase: \
+              --longoptions help,mkfs,mkfs-only,m0d,phase:,xprt: \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -75,6 +78,8 @@ done
 if [[ $do_mkfs ]] && [[ $phase == 'phase3' ]]; then
     die '--mkfs conflicts with --phase3'
 fi
+
+[[ $xprt == 'lnet' ]] || [[ $xprt == 'libfab' ]] || die "Invalid transport type $xprt"
 
 # If motr-kernel.service is not installed, the script will fail
 # anyway, with or without this check.  The purpose of the check is to
@@ -112,7 +117,7 @@ EOF
     die "'motr-kernel' systemd service is not installed"
 fi
 
-. update-consul-conf --dry-run  # import CONFD_IDs, IOS_IDs, S3_IDs, id2fid()
+. update-consul-conf --dry-run --xprt $xprt # import CONFD_IDs, IOS_IDs, S3_IDs, id2fid()
 
 sysconfig_dir='/etc/sysconfig'
 [ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -40,6 +40,8 @@ Positional arguments:
 Options:
   --debug      Print commands and their arguments as they are executed.
   --mkfs       Execute m0mkfs.  *CAUTION* This wipes all Motr data!
+  --xprt       Use given motr transport type to generate corresponding motr
+               process endpoints. Supported transport types are lnet and libfab.
   -h, --help   Show this help and exit.
 EOF
 }
@@ -225,7 +227,7 @@ check_consul_failure() {
 # main
 
 TEMP=$(getopt --options hc: \
-              --longoptions help,mkfs,conf-dir:,debug \
+              --longoptions help,mkfs,xprt:,conf-dir:,debug \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -235,11 +237,13 @@ eval set -- "$TEMP"
 conf_dir=
 opt_mkfs=
 debug_p=false
+xprt='lnet'
 
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --mkfs)              opt_mkfs=--mkfs; shift ;;
+        --xprt)              xprt=$2; shift 2 ;;
         -c|--conf-dir)       conf_dir=$2; shift 2 ;;
         --debug)             debug_p=true; shift ;;
         --)                  shift; break ;;
@@ -256,6 +260,8 @@ esac
 $debug_p && set -x
 
 cdf=${1:-}
+
+[[ $xprt == 'lnet' ]] || [[ $xprt == 'libfab' ]] || die "Invalid transport type $xprt"
 
 if sudo systemctl --quiet is-active hare-hax; then
     die 'hare-hax is active ==> cluster is already running'
@@ -411,7 +417,7 @@ done
 echo 'Consul ready on all nodes'
 
 say 'Updating Consul configuraton from the KV store...'
-update-consul-conf --server &
+update-consul-conf --server --xprt $xprt &
 pid=($!)
 wait4 ${pid[@]}
 
@@ -419,7 +425,7 @@ pids=
 
 while read node _; do
     scp -qr /var/lib/hare/consul-kv.json $node:/var/lib/hare/
-    ssh_error_info "$node" "PATH=$PATH $(which update-consul-conf)" --server &
+    ssh_error_info "$node" "PATH=$PATH $(which update-consul-conf)" --server --xprt $xprt &
     pids+=($!)
 done < <(get_all_nodes | grep -vw $(node-name) || true)
 wait4 ${pids[@]}
@@ -461,11 +467,11 @@ start_motr() {
 
     say "Starting Motr ($phase, $op)..."
     [[ $op == 'mkfs' ]] && op='--mkfs-only' || op=
-    bootstrap-node $op --phase $phase &
+    bootstrap-node $op --phase $phase --xprt $xprt &
     pids=($!)
 
     while read node _; do
-        ssh_error_info "$node" "PATH=$PATH $(which bootstrap-node) $op --phase $phase" &
+        ssh_error_info "$node" "PATH=$PATH $(which bootstrap-node) $op --phase $phase --xprt $xprt" &
         pids+=($!)
     done < <(get_nodes $phase | grep -vw $(node-name) || true)
     wait4 ${pids[@]}
@@ -488,15 +494,15 @@ bootstrap_nodes phase1
 # Start ioservices
 bootstrap_nodes phase2
 
-. update-consul-conf --server --dry-run  # import S3_IDs
+. update-consul-conf --server --dry-run --xprt $xprt # import S3_IDs
 if [[ -n $S3_IDs ]]; then
     # Now the 3rd phase (s3servers).
     say 'Starting S3 servers (phase3)...'
-    bootstrap-node --phase phase3 &
+    bootstrap-node --phase phase3 --xprt $xprt &
     pids=($!)
 
     while read node _; do
-        ssh_error_info "$node" "PATH=$PATH $(which bootstrap-node) --phase phase3" &
+        ssh_error_info "$node" "PATH=$PATH $(which bootstrap-node) --phase phase3 --xprt $xprt" &
         pids+=($!)
     done < <(get_all_nodes | grep -vw $(node-name) || true)
     wait4 ${pids[@]}

--- a/utils/hare-node-join
+++ b/utils/hare-node-join
@@ -42,6 +42,8 @@ Positional arguments:
   --consul-port <port>   Active Consul server port.
 Options:
   -h, --help    Show this help and exit.
+  --xprt        Use given motr transport type to generate corresponding motr
+                endpoints. Supported transport types are lnet and libfab.
 EOF
 }
 
@@ -143,7 +145,7 @@ is_localhost() {
 
 TEMP=$(getopt --options hc: \
               --longoptions help,conf-dir:,consul-addr:,consul-port: \
-              --longoptions mkfs,conf-create,debug \
+              --longoptions mkfs,conf-create,debug,xprt: \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -154,6 +156,7 @@ conf_dir=
 debug_p=false
 conf_create=false
 opt_mkfs=
+xprt='libfab'
 
 while true; do
     case "$1" in
@@ -162,6 +165,7 @@ while true; do
         --consul-addr)  CONSUL_ADDR=$2; shift 2 ;;
         --consul-port)  CONSUL_PORT=$2; shift 2 ;;
         --mkfs)         opt_mkfs=--mkfs; shift ;;
+        --xprt)         xprt=$2; shift 2 ;;
         --conf-create)  conf_create=true; shift ;;
         --)             shift; break ;;
         *)              break ;;
@@ -182,6 +186,7 @@ if sudo systemctl --quiet is-active hare-consul-agent; then
     die 'hare-consul-agent is active ==> cluster is already running'
 fi
 
+[[ $xprt == 'lnet' ]] || [[ $xprt == 'libfab' ]] || die "Invalid transport type $xprt"
 
 if [[ -z $conf_dir ]]; then
     conf_dir=/var/lib/hare
@@ -282,7 +287,7 @@ done
 
 if $conf_create; then
     say 'Updating Consul agents configs from the KV store...'
-    update-consul-conf &
+    update-consul-conf --xprt $xprt &
     pids=($!)
     echo ' OK'
 fi
@@ -318,7 +323,7 @@ start_motr() {
 
     say "Starting Motr ($phase, $op)..."
     [[ $op == 'mkfs' ]] && op='--mkfs-only' || op=
-    bootstrap-node $op --phase $phase &
+    bootstrap-node $op --phase $phase --xprt $xprt &
     pids=($!)
     wait4 ${pids[@]}
     echo ' OK'
@@ -340,11 +345,11 @@ bootstrap_nodes phase1
 # Start ioservices
 bootstrap_nodes phase2
 
-. update-consul-conf --dry-run  # import S3_IDs
+. update-consul-conf --dry-run --xprt $xprt # import S3_IDs
 if [[ -n $S3_IDs ]]; then
     # Now the 3rd phase (s3servers).
     say 'Starting S3 servers (phase3)...'
-    bootstrap-node --phase phase3 &
+    bootstrap-node --phase phase3 --xprt $xprt &
     pids=($!)
     wait4 ${pids[@]}
     echo ' OK'

--- a/utils/hare-start
+++ b/utils/hare-start
@@ -38,6 +38,8 @@ Starts Hare and Motr services on local or all the nodes in the cluster.
 
 Options:
   --node       Starts hare and motr services on current node only.
+  --xprt       Use given motr transport type to generate corresponding motr
+               process endpoints. Supported transport types are lnet and libfab.
   -h, --help   Shows this help and exit.
 EOF
 
@@ -45,18 +47,20 @@ EOF
 }
 
 TEMP=$(getopt --options h \
-              --longoptions help,node \
+              --longoptions help,node,xprt: \
               --name "$PROG" -- "$@" || true)
 
 eval set -- "$TEMP"
 
 conf_dir=/var/lib/hare
 node=false
+xprt='lnet'
 
 while true; do
     case "$1" in
         -h|--help)           usage ;;
         --node)              node=true; shift ;;
+        --xprt)              xprt=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
@@ -70,9 +74,11 @@ if  hctl status > /dev/null 2>&1; then
     die 'Cluster is up and running.'
 fi
 
+[[ $xprt == 'lnet' ]] || [[ $xprt == 'libfab' ]] || die "Invalid transport type $xprt"
+
 if $node; then
     start-node
 else
-    hctl bootstrap -c $conf_dir
+    hctl bootstrap -c $conf_dir --xprt $xprt
 fi
 

--- a/utils/start-node
+++ b/utils/start-node
@@ -38,6 +38,50 @@ is_server_node() {
     get_server_nodes | grep -w $(node-name) > /dev/null
 }
 
+usage() {
+    cat <<EOF
+Usage: $PROG [<option>]...
+
+Starts Hare and Motr services on local node.
+
+Options:
+  --xprt       Use given motr transport type to generate corresponding motr
+               process endpoints. Supported transport types are lnet and libfab.
+  -h, --help   Shows this help and exit.
+EOF
+
+    exit 1;
+}
+
+TEMP=$(getopt --options h \
+              --longoptions help,xprt: \
+              --name "$PROG" -- "$@" || true)
+
+eval set -- "$TEMP"
+
+conf_dir=/var/lib/hare
+xprt='lnet'
+
+while true; do
+    case "$1" in
+        -h|--help)           usage ;;
+        --xprt)              xprt=$2; shift 2 ;;
+        --)                  shift; break ;;
+        *)                   break ;;
+    esac
+done
+
+if ! [[ -d $conf_dir ]]; then
+    die 'Cluster is not configured on this node.'
+fi
+
+if  hctl status > /dev/null 2>&1; then
+    die 'Cluster is up and running.'
+fi
+
+[[ $xprt == 'lnet' ]] || [[ $xprt == 'libfab' ]] || die "Invalid transport type $xprt"
+
+
 if sudo systemctl --quiet is-active hare-consul-agent; then
     die 'hare-consul-agent is active ==> cluster is already running'
 fi
@@ -57,16 +101,16 @@ echo ' OK'
 
 if is_server_node; then
     # Starting phase 1 (confd servers)
-    start_motr m0d phase1
+    start_motr m0d phase1 $xprt
 fi
 
 # Starting phase 2 (ios)
-start_motr m0d phase2
+start_motr m0d phase2 $xprt
 
-. update-consul-conf --dry-run  # import S3_IDs
+. update-consul-conf --dry-run  --xprt $xprt # import S3_IDs
 if [[ -n $S3_IDs ]]; then
     # Starting phase 3 (s3servers).
-    start_s3server
+    start_s3server $xprt
 fi
 
 say 'Checking health of services...'

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -47,11 +47,13 @@ Create Consul agent configuration file.
   -n, --dry-run   Do not create configuration file, only export variables
                   and function definitions.
   -s, --server    Configure Consul server, by default configure Consul client.
+  -x, --xprt      Generate motr endpoint with respect to the given motr
+                  transport type. Support transport types are lnet and libfab.
 EOF
 }
 
-TEMP=$(getopt --options hns: \
-              --longoptions help,dry-run,conf-dir:,kv-file:,uuid: \
+TEMP=$(getopt --options hnsx: \
+              --longoptions help,dry-run,conf-dir:,kv-file:,uuid:,xprt:\
               --longoptions log-dir: \
               --longoptions server \
               --name "$PROG" -- "$@" || true)
@@ -65,6 +67,7 @@ log_dir=/var/log/seagate/hare
 kv_file=/var/lib/hare/consul-kv.json
 dry_run=false
 server=false
+xprt='lnet'
 # custom_config flag will tell if custom config dir is provided or not
 # In case of mini-provisioning, conf_dir will be provided(derived from confstore)
 # In case conf_dir is not provided then below flat will be false and we will use
@@ -80,6 +83,7 @@ while true; do
         -l|--log-dir)        log_dir=$2; shift 2 ;;
         -k|--kv-file)        kv_file=$2; shift 2 ;;
         -s|--server)         server=true; shift ;;
+        -x|--xprt)           xprt=$2; shift 2 ;;
         --uuid)              uuid=$2; shift 2 ;;
         --dry-run)           dry_run=true; shift ;;
         --)                  shift; break ;;
@@ -135,6 +139,7 @@ get_ios_meta_data_from_kv_file() {
 get_service_ids_from_kv_file() {
     local filter=$1
     local key="m0conf/nodes/$(get_node_name)/processes/*"
+    # echo "key: $key fiter: $filter"
     local cmd="jq -r '.[] | select(.key|test(\"$key\"))' $kv_file |
                   $filter | sed 's/.*processes.//' | cut -d/ -f1"
     eval $cmd || true
@@ -143,6 +148,7 @@ get_service_ids_from_kv_file() {
 get_service_ep_from_kv_file() {
     local process_fidk=$1
     local key="m0conf/nodes/$(get_node_name)/processes/$process_fidk/endpoint"
+    # echo "key: $key"
     local cmd="jq -r '.[] | select(.key==\"$key\") |
                   .value' $kv_file | head -n 1"
     eval $cmd || true
@@ -155,7 +161,13 @@ get_profile_from_kv_file() {
 }
 
 get_service_addr() {
-    echo ${1%@*}
+    if [[ $xprt == 'lnet' ]]; then
+        echo ${1%:*}
+    elif [[ $xprt == 'libfab' ]]; then
+        echo ${1%@*}
+    else
+        die "Invalid transport $xprt"
+    fi
 }
 
 get_service_ip_addr() {
@@ -163,7 +175,13 @@ get_service_ip_addr() {
 }
 
 get_service_port() {
-    echo ${1##*@}
+    if [[ $xprt == 'lnet' ]]; then
+        echo ${1##*:}
+    elif [[ $xprt == 'libfab' ]]; then
+        echo ${1##*@}
+    else
+        die "Invalid transport $xprt"
+    fi
 }
 
 get_service_host() {

--- a/utils/util
+++ b/utils/util
@@ -39,10 +39,11 @@ get_leader() {
 start_motr() {
     local op=$1
     local phase=$2
+    local xprt=$3
 
     say "Starting Motr ($phase, $op)..."
     [[ $op == 'mkfs' ]] && op='--mkfs-only' || op=
-    bootstrap-node $op --phase $phase &
+    bootstrap-node $op --phase $phase --xprt $xprt &
     pids=($!)
     wait4 ${pids[@]}
     echo ' OK'
@@ -50,7 +51,7 @@ start_motr() {
 
 start_s3server() {
     say 'Starting S3 servers (phase3)...'
-    bootstrap-node --phase phase3 &
+    bootstrap-node --phase phase3 --xprt $xprt&
     pids=($!)
     wait4 ${pids[@]}
     echo ' OK'


### PR DESCRIPTION
Presently Hare supports just libfabric in Containers. This restricts testing
Hare and Motr using different transports, e.g. lnet.

Solution:
- Update Hare configuration to support multiple transports.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>