### PR TITLE
Problem: bootstrap doesn't work in LR

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -411,7 +411,12 @@ done
 echo 'Consul ready on all nodes'
 
 say 'Updating Consul configuraton from the KV store...'
-update-consul-conf --server &
+runs_server=''
+if get_server_nodes | grep -w $(node-name) >/dev/null 2>&1; then
+    runs_server='--server'
+fi
+update-consul-conf $runs_server &
+
 pid=($!)
 wait4 ${pid[@]}
 


### PR DESCRIPTION
# Problem Statement
In LR environment, it is presumed that the head node hosts Consul server.

At the head node, bootstrap script always tries to use
consul-server-conf.json file (even if the node doesn't have host the
Consul server).

# Design
- Solution: pass `--server` flag to update-consul-conf if the node runs Consul server.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
