### PR TITLE
Bug EOS-26873: hctl status shows NoneType exception when called immediately after ./deploy-cortx-cloud.sh script

### DIFF
--- a/utils/hare-status
+++ b/utils/hare-status
@@ -164,7 +164,7 @@ def processes(cns: Consul, consul_util: ConsulUtil,
 
 def process_status(node_health: str, proc_states: Dict[str, str],
                    fid: Fid) -> str:
-    if node_health != 'passing':
+    if node_health != 'passing' or proc_states is None:
         return 'offline'
     if str(fid) in proc_states:
         return proc_states[str(fid)]
@@ -176,6 +176,10 @@ def get_node_process_states(cns: Consul, node_name: str) -> Dict[str, str]:
     key = f'{node_name}/processes/'
     proc_list = kv_item(cns, key, recurse=True)
     process_states: Dict[str, str] = {}
+
+    if proc_list is None:
+        return process_states
+
     for proc in proc_list:
         key_split = proc['Key'].split('/')
         if len(key_split) != 3:


### PR DESCRIPTION
During the deployment through jenkins job, we might get an exception in hctl status as consul data might not be updated.
This happens when deploy script has just completed and we immediately call hctl status. Since consul data might not be updated, we get a NoneType object which cannot be iterated.

> 16:37:01 Traceback (most recent call last):
16:37:01 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 362, in
16:37:01 sys.exit(main())
16:37:01 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 356, in main
16:37:01 show_text_status(cns, cns_util, opts.devices)
16:37:01 File "/opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/util.py", line 143, in wrapper
16:37:01 return f(*args, **kwds)
16:37:01 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 330, in show_text_status
16:37:01 for p in processes(cns, consul_util, h):
16:37:01 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 152, in processes
16:37:01 process_states = get_node_process_states(cns, node_name)
16:37:01 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 179, in get_node_process_states
16:37:01 for proc in proc_list:
16:37:01 TypeError: 'NoneType' object is not iterable
16:37:01 command terminated with exit code 1
16:37:01 Unable to use a TTY - input is not a terminal or the right kind of file
16:37:03 Traceback (most recent call last):
16:37:03 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 362, in
16:37:03 sys.exit(main())
16:37:03 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 356, in main
16:37:03 show_text_status(cns, cns_util, opts.devices)
16:37:03 File "/opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/util.py", line 143, in wrapper
16:37:03 return f(*args, **kwds)
16:37:03 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 330, in show_text_status
16:37:03 for p in processes(cns, consul_util, h):
16:37:03 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 152, in processes
16:37:03 process_states = get_node_process_states(cns, node_name)
16:37:03 File "/opt/seagate/cortx/hare/bin/../libexec/hare-status", line 179, in get_node_process_states
16:37:03 for proc in proc_list:
16:37:03 TypeError: 'NoneType' object is not iterable
16:37:03 command terminated with exit code 1

Solution: Handle the exception generated in the code by identifying where this exception has occured and make to changes to safely exit if such exception occurs.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
