### PR TITLE
EOS-26610: Don't run elect-rc-leader on s3server pods

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -449,6 +449,16 @@ class ConsulUtil:
             raise HAConsistencyException(
                 'Could not get the leader from Consul')
 
+    def is_leader_value_present_for_session(self) -> bool:
+        leader = self.kv.kv_get('leader')
+        if leader is None:
+            return False
+
+        node: bytes = leader['Value']
+        if node is None:
+            return False
+        return True
+
     def destroy_session(self, session: str) -> None:
         """
         Destroys the given Consul Session by name.

--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -2,13 +2,6 @@
   "enable_local_script_checks": true,
   "watches": [
     {
-      "type": "key",
-      "key": "leader",
-      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader",
-                "--conf-dir", "TMP_CONF_DIR",
-                "--log-dir", "TMP_LOG_DIR" ]
-    },
-    {
       "type": "service",
       "service": "ios",
       "handler_type": "http",

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -3,13 +3,6 @@
   "leave_on_terminate": true,
   "watches": [
     {
-      "type": "key",
-      "key": "leader",
-      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader",
-                "--conf-dir", "TMP_CONF_DIR",
-                "--log-dir", "TMP_LOG_DIR" ]
-    },
-    {
       "type": "keyprefix",
       "prefix": "bq/",
       "handler_type": "http",

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -239,10 +239,6 @@ else
     CONF_FILE=$conf_dir/consul-client-conf/consul-client-conf.json
 fi
 
-pwdesc=$(echo $conf_dir | sed 's_/_\\/_g')
-sed -i "s/TMP_CONF_DIR/$pwdesc/" $CONF_FILE
-sed -i "s|TMP_LOG_DIR|$log_dir|" $CONF_FILE
-
 SVCS_CONF=''
 
 append_hax_svc() {
@@ -400,6 +396,20 @@ done
 tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)
 trap "rm -f $tmpfile" EXIT # delete automatically on exit
 jq ".services = [$SVCS_CONF]" <$CONF_FILE >$tmpfile
+
+if [[ $CONFD_IDs ]]; then
+    jq '.watches += [{"type": "key",
+                      "key": "leader",
+                      "args": [ "/opt/seagate/cortx/hare/libexec/elect-rc-leader",
+                                "--conf-dir",
+                                "TMP_CONF_DIR",
+                                "--log-dir",
+                                "TMP_LOG_DIR" ]}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
+fi
+
+sed -i "s|TMP_CONF_DIR|$conf_dir|" $tmpfile
+sed -i "s|TMP_LOG_DIR|$log_dir|" $tmpfile
+
 sudo cp $tmpfile $CONF_FILE
 # Copy consul-server-conf for this node to consul dir.
 mkdir -p /etc/consul.d/


### PR DESCRIPTION
# Problem Statement
- We don't need to run elect rc leader on s3server pods as they don't have confd running

# Design
-  We will check if node has confd then only we will add leader watch key
Also we fixed issue where RC election was not happenning due to stale session.
If there is session present for leader without 'value' then we will destroy it
which will trigger RC re-election

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
