### PR TITLE
EOS-27107: Refactoring and optimization of similar function

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -29,7 +29,6 @@ import os
 import shutil
 import subprocess
 import sys
-import re
 from enum import Enum
 from sys import exit
 from time import sleep, perf_counter
@@ -148,19 +147,10 @@ def get_server_type(url: str) -> str:
 
 def is_mkfs_required(url: str) -> bool:
     try:
-        provider = ConfStoreProvider(url)
-        machine_id = provider.get_machine_id()
-        # Query results into a list of keys where, Const.SERVICE_MOTR_IO
-        # is found as one of the services under `services`.
-        # e.g.
-        # node>aaa120a9e051d103c164f605615c32a4>components[1]>services[0]
-        # node>bbb340f79047df9bb52fa460615c32a5>components[1]>services[0]
-        # node>ccc8700fe6797ed532e311b0615c32a7>components[1]>services[0]
-        # We try to find this node's machine id in the query result.
-        services = provider.search_val('node', 'services',
-                                       Const.SERVICE_MOTR_IO.value)
-        check_id = re.compile(f".*{machine_id}.*")
-        return any(check_id.match(service) for service in services)
+        conf = ConfStoreProvider(url)
+        utils = Utils(conf)
+        machine_id = conf.get_machine_id()
+        return utils.is_motr_component(machine_id)
     except Exception as error:
         logging.warn('Failed to get pod type (%s). Current stage will '
                      'be assumed as not required by default', error)
@@ -489,7 +479,8 @@ def init(args):
         if not is_mkfs_required(url):
             return
 
-        utils = Utils(ConfStoreProvider(url))
+        conf = ConfStoreProvider(url)
+        utils = Utils(conf)
         cns_utils = ConsulUtil()
         stop_event = Event()
         config_dir = get_config_dir(url)
@@ -504,11 +495,13 @@ def init(args):
         start_mkfs_parallel(hostname, config_dir)
         # Update mkfs state
         set_mkfs_done_for(hostname, cns_utils)
-        nodes = utils.get_io_nodes()
+        data_nodes = conf.get_hostnames_for_service(
+            Const.SERVICE_MOTR_IO.value)
+
         # Wait for other nodes to complete.
         # This will block.
         while not is_mkfs_done_on_all_nodes(utils, cns_utils,
-                                            nodes):
+                                            data_nodes):
             sleep(5)
         # Stopping hax and consul
         hax_starter.stop()

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -24,7 +24,7 @@ import json
 import io
 import os
 import logging
-from typing import List, Dict, Any
+from typing import List
 from distutils.dir_util import copy_tree
 import shutil
 
@@ -192,23 +192,6 @@ class Utils:
 
     def is_hare_stopping(self) -> bool:
         return self.hare_stop
-
-    def get_io_nodes(self) -> List[str]:
-        nodes: List[str] = []
-        conf = self.provider
-        machines: Dict[str, Any] = conf.get('node')
-        # Query results into a list of keys where, Const.SERVICE_MOTR_IO
-        # is found as one of the services under `services`.
-        # e.g.
-        # node>0b9cf99f07574422a45f9b61d2f5b746>components[1]>services[0]
-        # node>0b9cf99f07574422a45f9b61d2f5b746>components[3]>services[0]
-        services = conf.search_val('node', 'services',
-                                   Const.SERVICE_MOTR_IO.value)
-        for machine_id in machines.keys():
-            result = list(filter(lambda svc: machine_id in svc, services))
-            if result:
-                nodes.append(conf.get(f'node>{machine_id}>hostname'))
-        return nodes
 
     def get_transport_type(self) -> str:
         transport_type = self.provider.get(


### PR DESCRIPTION
    Problem: Refactoring and optimization of similar function which having
    same business logic.
             1. get_io_nodes(self) in utils.py
             2. get_data_nodes(self) in store.py
             3. _get_data_nodes(self, pool: PoolHandle) in cdf.py
    All above functions are returning either a list of machine_id or a list
    of hostname w.r.t service_type(SERVICE_MOTR_IO).

    Solution: Defined 2 new function, "get_machine_ids_for_service(service_type)"
    and "get_hostnames_for_service(service_type)" which will accept 1st (service_type)
    as mandatory arguments and will return a list of nodes with it's machine_id and
    a list of nodes with it's hostname respectively.


Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>
