### PR TITLE
hctl: bootstrap-node script is broken

### DIFF
--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -2,6 +2,7 @@ nodes:
   - hostname: localhost
     data_iface: eth1
     data_iface_type: tcp
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -1,6 +1,7 @@
 nodes:
   - hostname: ssu1
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:
@@ -18,6 +19,7 @@ nodes:
         other: 2
   - hostname: ssu2
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - io_disks:
           data:

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -1,6 +1,7 @@
 nodes:
   - hostname: ssu1
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:
@@ -18,6 +19,7 @@ nodes:
         other: 2
   - hostname: ssu2
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -1,6 +1,7 @@
 nodes:
   - hostname: ssu1
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:
@@ -18,6 +19,7 @@ nodes:
         other: 2
   - hostname: ssu2
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:
@@ -35,6 +37,7 @@ nodes:
         other: 2
   - hostname: ssu3
     data_iface: eth1
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -6,6 +6,7 @@ nodes:
     data_iface: eth1_c1     # name of data network interface
     data_iface_type: o2ib   # LNet type of network interface (optional);
                             # supported values: "tcp" (default), "o2ib"
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:
@@ -22,6 +23,7 @@ nodes:
   - hostname: pod-c2
     data_iface: eth1_c2
     data_iface_type: o2ib
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -2,6 +2,7 @@ nodes:
   - hostname: srvnode-1
     data_iface: enp175s0f1_c1
     data_iface_type: o2ib
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:
@@ -22,6 +23,7 @@ nodes:
   - hostname: srvnode-2
     data_iface: enp175s0f1_c2
     data_iface_type: o2ib
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -7,6 +7,7 @@ nodes:
     data_iface: eth1        # name of data network interface
     #data_iface_type: o2ib  # type of network interface (optional);
                             # supported values: "tcp" (default), "o2ib"
+    transport_type: libfab
     m0_servers:
       - runs_confd: true
         io_disks:

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -49,6 +49,9 @@ Positional arguments:
 Options:
   --debug      Print commands and their arguments as they are executed.
   --mkfs       Execute m0mkfs.  *CAUTION* This wipes all Motr data!
+  --xprt       Use given motr transport type to generate corresponding motr
+               process endpoints. Supported transport types are lnet and libfab.
+               Transport type defaults to libfab if not specified.
   -h, --help   Show this help and exit.
 ```
 
@@ -68,6 +71,25 @@ $ hctl bootstrap --mkfs /tmp/ldr1-cluster.yaml
 2020-09-03 09:55:16: Starting Motr (phase2, m0d)... OK
 2020-09-03 09:55:19: Checking health of services... OK
 ```
+OR (specifying transport type)
+
+```
+$ hctl bootstrap --mkfs --xprt libfab /opt/seagate/cortx/hare/share/cfgen/examples/singlenode.yaml
+2021-12-29 10:38:57: Generating cluster configuration... OK
+2021-12-29 10:38:58: Stopping Consul on this node... OK
+2021-12-29 10:39:10: Stopping Consul on other nodes... OK
+2021-12-29 10:39:10: Starting Consul server on this node............ OK
+2021-12-29 10:39:20: Importing configuration into the KV store... OK
+2021-12-29 10:39:20: Starting Consul on other nodes...Consul ready on all nodes
+2021-12-29 10:39:20: Updating Consul configuraton from the KV store... OK
+2021-12-29 10:39:21: Waiting for the RC Leader to get elected.......... OK
+2021-12-29 10:39:28: Starting Motr (phase1, mkfs)... OK
+2021-12-29 10:39:35: Starting Motr (phase1, m0d)... OK
+2021-12-29 10:39:37: Starting Motr (phase2, mkfs)... OK
+2021-12-29 10:39:42: Starting Motr (phase2, m0d)... OK
+2021-12-29 10:39:45: Checking health of services... OK
+```
+
 
 ## Cluster shutdown
 

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -67,6 +67,7 @@ while true; do
         --mkfs)              do_mkfs=mkfs; shift ;;
         --mkfs-only)         do_mkfs=mkfs-only; shift ;;
         -p|--phase)          phase=$2; shift 2 ;;
+        --xprt)              xprt=$2; shift 2 ;;
         --)                  shift; break ;;
         *)                   echo 'getopt: internal error...'; exit 1 ;;
     esac

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -42,6 +42,7 @@ Options:
   --mkfs       Execute m0mkfs.  *CAUTION* This wipes all Motr data!
   --xprt       Use given motr transport type to generate corresponding motr
                process endpoints. Supported transport types are lnet and libfab.
+               Transport type defaults to libfab if not specified.
   -h, --help   Show this help and exit.
 EOF
 }
@@ -237,7 +238,7 @@ eval set -- "$TEMP"
 conf_dir=
 opt_mkfs=
 debug_p=false
-xprt='lnet'
+xprt='libfab'
 
 while true; do
     case "$1" in

--- a/utils/hare-node-join
+++ b/utils/hare-node-join
@@ -44,6 +44,7 @@ Options:
   -h, --help    Show this help and exit.
   --xprt        Use given motr transport type to generate corresponding motr
                 endpoints. Supported transport types are lnet and libfab.
+                Transport type defaults to libfab if not specified.
 EOF
 }
 

--- a/utils/hare-start
+++ b/utils/hare-start
@@ -40,6 +40,7 @@ Options:
   --node       Starts hare and motr services on current node only.
   --xprt       Use given motr transport type to generate corresponding motr
                process endpoints. Supported transport types are lnet and libfab.
+               Transport type defaults to libfab if not specified.
   -h, --help   Shows this help and exit.
 EOF
 
@@ -54,7 +55,7 @@ eval set -- "$TEMP"
 
 conf_dir=/var/lib/hare
 node=false
-xprt='lnet'
+xprt='libfab'
 
 while true; do
     case "$1" in

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -67,7 +67,7 @@ log_dir=/var/log/seagate/hare
 kv_file=/var/lib/hare/consul-kv.json
 dry_run=false
 server=false
-xprt='lnet'
+xprt='libfab'
 # custom_config flag will tell if custom config dir is provided or not
 # In case of mini-provisioning, conf_dir will be provided(derived from confstore)
 # In case conf_dir is not provided then below flat will be false and we will use
@@ -139,7 +139,6 @@ get_ios_meta_data_from_kv_file() {
 get_service_ids_from_kv_file() {
     local filter=$1
     local key="m0conf/nodes/$(get_node_name)/processes/*"
-    # echo "key: $key fiter: $filter"
     local cmd="jq -r '.[] | select(.key|test(\"$key\"))' $kv_file |
                   $filter | sed 's/.*processes.//' | cut -d/ -f1"
     eval $cmd || true
@@ -148,7 +147,6 @@ get_service_ids_from_kv_file() {
 get_service_ep_from_kv_file() {
     local process_fidk=$1
     local key="m0conf/nodes/$(get_node_name)/processes/$process_fidk/endpoint"
-    # echo "key: $key"
     local cmd="jq -r '.[] | select(.key==\"$key\") |
                   .value' $kv_file | head -n 1"
     eval $cmd || true


### PR DESCRIPTION
While the multiple transport type support was added, a related change was
missed in `utils/bootstrap-node` script. Although the nw `xprt` argument was
added to `getopt` it was not parsed and that lead to failure of `hctl bootstrap`
command.

Solution:
- Fix bootstrap-node script to parse xprt argument.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>