### PR TITLE
EOS-24483: hare does not support dtm recovery transitions for processes

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -281,9 +281,8 @@ class Motr:
                             broadcast_hax_only=False) -> List[MessageId]:
         LOG.debug('Broadcasting HA states %s over ha_link', ha_states)
 
-        def ha_obj_state(st):
-            return HaNoteStruct.M0_NC_ONLINE if st.status == ServiceHealth.OK \
-                else HaNoteStruct.M0_NC_FAILED
+        def ha_obj_state(st: ServiceHealth):
+            return st.to_ha_note_status()
 
         def _update_process_tree(proc_fid: Fid, state: ServiceHealth) -> bool:
             return (st.status in (ServiceHealth.FAILED, ServiceHealth.OK) and
@@ -296,7 +295,7 @@ class Motr:
         for st in ha_states:
             if st.status in (ServiceHealth.UNKNOWN, ServiceHealth.OFFLINE):
                 continue
-            note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st))
+            note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st.status))
             notes.append(note)
 
             # For process failure, we report failure for the corresponding

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -89,8 +89,27 @@ class HaNoteStruct(c.Structure):
     # * copied from spare space to the replacement storage.
     # */
     M0_NC_REBALANCE = 6
+    # /**
+    #  * Recovery is triggered by the incoming DTM_RECOVERING HA state
+    #  * message. During this state, processes iterate over their DTM logs,
+    #  * pack elements of them, TXRs, into REDO messages and send REDO
+    #  * messages to corresponding participants of TXR. Any subsequent failure
+    #  * of the process in the cluster restarts the recovery process on all
+    #  * alive participants.
+    #  *
+    #  * DTM_RECOVERING state is transitive for client applications and mkfs,
+    #  * meaning that transition from NC_DTM_RECOVERING to NC_ONLINE is
+    #  * immediate.
+    #  *
+    #  * For m0ds(md-, io-services) indicates that the process waits for the
+    #  * completion of ongoing dtm recovery process. When client
+    #  * leans the process in DTM_RECOVERING state it treats the process as
+    #  * read-only, at least for the metadata, and skips sending modification
+    #  * requests to it.
+    #  */
+    M0_NC_DTM_RECOVERING = 7
 
-    M0_NC_NR = 7
+    M0_NC_NR = 8
 
     _fields_ = [("no_id", FidStruct), ("no_state", c.c_uint32)]
 
@@ -223,6 +242,7 @@ class ServiceHealth(Enum):
     UNKNOWN = (2, HaNoteStruct.M0_NC_UNKNOWN)
     OFFLINE = (3, HaNoteStruct.M0_NC_TRANSIENT)
     STOPPED = (4, HaNoteStruct.M0_NC_TRANSIENT)
+    RECOVERING = (5, HaNoteStruct.M0_NC_DTM_RECOVERING)
 
     def __repr__(self):
         """Return human-readable constant name (useful in log output)."""
@@ -257,6 +277,7 @@ class m0HaProcessEvent(IntEnum):
     M0_CONF_HA_PROCESS_STARTED = 1
     M0_CONF_HA_PROCESS_STOPPING = 2
     M0_CONF_HA_PROCESS_STOPPED = 3
+    M0_CONF_HA_PROCESS_DTM_RECOVERED = 4
 
     @staticmethod
     def str_to_Enum(evt: str):
@@ -267,7 +288,9 @@ class m0HaProcessEvent(IntEnum):
                   'M0_CONF_HA_PROCESS_STOPPING':
                   m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING,
                   'M0_CONF_HA_PROCESS_STOPPED':
-                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED}
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
+                  'M0_CONF_HA_PROCESS_DTM_RECOVERED':
+                  m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED}
         return events[evt]
 
     def __repr__(self):
@@ -277,6 +300,8 @@ class m0HaProcessEvent(IntEnum):
         m0ProcessEvToSvcHealth = {
             m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTING: ServiceHealth.OK,
             m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED: ServiceHealth.OK,
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED:
+                ServiceHealth.OK,
             m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING: ServiceHealth.FAILED,
             m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED: ServiceHealth.FAILED}
         return m0ProcessEvToSvcHealth[self]
@@ -288,12 +313,18 @@ class m0HaProcessType(IntEnum):
     M0_CONF_HA_PROCESS_M0MKFS = 2
     M0_CONF_HA_PROCESS_M0D = 3
 
-    def str_to_Enum(self):
-        types = {'M0_CONF_HA_PROCESS_OTHER': self.M0_CONF_HA_PROCESS_OTHER,
-                 'M0_CONF_HA_PROCESS_KERNEL': self.M0_CONF_HA_PROCESS_KERNEL,
-                 'M0_CONF_HA_PROCESS_M0MKFS': self.M0_CONF_HA_PROCESS_M0MKFS,
-                 'M0_CONF_HA_PROCESS_M0D': self.M0_CONF_HA_PROCESS_M0D}
-        return types[self.name]
+    @staticmethod
+    def str_to_Enum(typ: str):
+        types = {
+            'M0_CONF_HA_PROCESS_OTHER':
+            m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+            'M0_CONF_HA_PROCESS_KERNEL':
+            m0HaProcessType.M0_CONF_HA_PROCESS_KERNEL,
+            'M0_CONF_HA_PROCESS_M0MKFS':
+            m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
+            'M0_CONF_HA_PROCESS_M0D':
+            m0HaProcessType.M0_CONF_HA_PROCESS_M0D}
+        return types[typ]
 
     def __repr__(self):
         return self.name
@@ -306,6 +337,7 @@ class m0HaObjState(IntEnum):
     M0_NC_TRANSIENT = HaNoteStruct.M0_NC_TRANSIENT
     M0_NC_REPAIRED = HaNoteStruct.M0_NC_REPAIRED
     M0_NC_REBALANCE = HaNoteStruct.M0_NC_REBALANCE
+    M0_NC_DTM_RECOVERING = HaNoteStruct.M0_NC_DTM_RECOVERING
     M0_NC_NR = HaNoteStruct.M0_NC_NR
 
     def __repr__(self):
@@ -321,6 +353,7 @@ class m0HaObjState(IntEnum):
             'M0_NC_TRANSIENT': m0HaObjState.M0_NC_TRANSIENT,
             'M0_NC_REPAIRED': m0HaObjState.M0_NC_REPAIRED,
             'M0_NC_REBALANCE': m0HaObjState.M0_NC_REBALANCE,
+            'M0_NC_DTM_RECOVERING': m0HaObjState.M0_NC_DTM_RECOVERING,
             'M0_NC_NR': m0HaObjState.M0_NC_NR
         }
         return states[state]

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -742,7 +742,8 @@ def all_services_started(url: str, processes: Dict[str, List[Fid]]) -> bool:
             if proc_state:
                 proc_state_val = proc_state[0]['Value']
                 state = json.loads(proc_state_val.decode('utf8'))['state']
-                if state != 'M0_CONF_HA_PROCESS_STARTED':
+                if state not in ('M0_CONF_HA_PROCESS_STARTED',
+                                 'M0_CONF_HA_PROCESS_DTM_RECOVERED'):
                     return False
             else:
                 return False

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -138,7 +138,7 @@ wait_active() {
 
 process_started() {
     local fid=$1
-    if [[ $(get-process-state $fid) == M0_CONF_HA_PROCESS_STARTED ]]; then
+    if [[ $(get-process-state $fid) == M0_CONF_HA_PROCESS_DTM_RECOVERED ]]; then
         return 0
     fi
     return 1


### PR DESCRIPTION
- Transition motr process to ONLINE on receiving M0_CONF_HA_PROCESS_RECOVERED.
- Transition motr process to RECOVERING state on receiving
  M0_CONF_HA_PROCESS_STARTED event from motr process.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>