### PR TITLE
EOS-27231: Support Bundle generate is failing for hare

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -1057,6 +1057,8 @@ def create_parser() -> argparse.ArgumentParser:
                                    help_str='Generates support bundle',
                                    handler_fn=generate_support_bundle)
 
+    add_service_argument(sb_sub_parser)
+
     sb_sub_parser.add_argument(
         '-b',
         type=str,
@@ -1088,14 +1090,6 @@ def create_parser() -> argparse.ArgumentParser:
         help='Limit set on per component for its support bundle size.'
              'eg. "1G" for 1GB or "100M" for 100 MB. Default -> 0, '
              'for no size limit.',
-        action='store')
-
-    sb_sub_parser.add_argument(
-        '--services',
-        type=str,
-        nargs=1,
-        help='"|" pipe separated service names for the services for '
-             'which logs needs to be collected. Default is "All".',
         action='store')
 
     sb_sub_parser.add_argument(

--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -58,7 +58,7 @@ conf_dir=$DEFAULT_CONF_DIR
 use_systemd=true
 
 TEMP=$(getopt --options hm:b:t:c:l: \
-              --longoptions help,systemd-disabled \
+              --longoptions help,systemd-disabled,no-systemd \
               --name "$PROG" -- "$@" || true)
 
 eval set -- "$TEMP"


### PR DESCRIPTION
Support bundle is not supported for '-s' parameter.

Solution:
Added -s parameter to support bundle generation process.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>