### PR TITLE
README: update about facter installation on el7

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ and health-checking mechanisms.
   On CentOS 7, if the facter version is less than 3.14 or not installed, then run the following commands to update/install it:
   
   ```sh
-  sudo yum erase -y $(rpm -q --whatprovides $(readlink -f /usr/bin/facter)) || sudo rm -fv /usr/bin/facter
   sudo yum localinstall -y https://yum.puppetlabs.com/puppet/el/7/x86_64/puppet-agent-7.0.0-1.el7.x86_64.rpm
   sudo ln -sf /opt/puppetlabs/bin/facter /usr/bin/facter
   ```


### PR DESCRIPTION
`yum erase -y $(rpm -q --whatprovides $(readlink -f /usr/bin/facter))`
removes existing facter rpm along with the motr rpm, which depends on it.

Solution: don't erase existing facter rpm, the facter binary will be
overwritten by the following `ln -sf` command.

-----
[View rendered README.md](https://github.com/Seagate/cortx-hare/blob/andriytk-patch-1/README.md)