### PR TITLE
EOS-27018: Hare to adopt utils logging framework

### DIFF
--- a/hax/hax/ha/events.py
+++ b/hax/hax/ha/events.py
@@ -20,7 +20,7 @@ import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
-from cortx.utils.message_bus import MessageBus, MessageConsumer
+from cortx.utils.message_bus import MessageConsumer
 
 from ha.core.event_manager.subscribe_event import SubscribeEvent
 from ha.core.event_manager.const import EVENT_MANAGER_KEYS
@@ -75,9 +75,7 @@ class EventListener():
         if topic is None:
             raise RuntimeError('Failed to subscribe to events')
 
-        message_bus = MessageBus()
         self.consumer = MessageConsumer(
-            message_bus=message_bus,
             consumer_id=COMPONENT_ID,
             consumer_group=group_id,
             message_types=[topic],

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1825,6 +1825,15 @@ class ConsulUtil:
         if not self.kv.kv_delete_in_transaction(keys):
             raise HAConsistencyException('KV deletion failed')
 
+    @repeat_if_fails()
+    def get_configpath(self):
+        logging.info('Getting config_path')
+        config_path = self.kv.kv_get('config_path')
+        if config_path is None:
+            raise HAConsistencyException('config path not present in consul')
+
+        return config_path['Value'].decode("utf-8")
+
 
 def dump_json(obj) -> str:
     """

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -309,6 +309,7 @@ def prepare(args):
     log_dir = get_log_dir(url)
     _create_consul_namespace(conf_dir)
     consul_starter = _start_consul(utils, stop_event, conf_dir, log_dir, url)
+    utils.save_config_path(url)
     utils.save_node_facts()
     utils.save_drives_info()
     try:
@@ -373,6 +374,7 @@ def start_hax_and_consul_without_systemd(url: str, utils: Utils):
 
 
 def start(args):
+    logging.info('Starting Hare services')
     url = args.config[0]
     utils = Utils(ConfStoreProvider(url))
     logrotate_generic(url)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -201,6 +201,10 @@ class Utils:
             return 'libfab'
         return transport_type
 
+    @repeat_if_fails()
+    def save_config_path(self, path: str):
+        self.kv.kv_put('config_path', path)
+
 
 class LogWriter:
     def __init__(self, logger: logging.Logger, logging_handler):


### PR DESCRIPTION
Problem: MessageBUs class is singleton class and component need to
call MessageBus.init method before making use of Message Bus library

Solution: Calling MessageBus.init method in 'start' interface before
starting other Hare related services

Tested by Manual installation of RPMs.

**Deployment is in progress.**

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>