### PR TITLE
EOS-26960: Update cfgen to allocate base fid

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -783,6 +783,21 @@ Oid.__doc__ = 'Motr conf object identifier'
 Oid.fidk.__doc__ = '.f_key part of the corresponding m0_fid'
 
 
+ObjTMask = NamedTuple('ObjTMask', [('cont', int), ('key', int)])
+ObjTMask.__doc__ = 'Motr conf object identifier mask'
+ObjTMask.key.__doc__ = '.f_key part mask of the corresponding m0_fid'
+
+
+DW_F = 0xffffffff           # DW = DoubleWord
+QW_F = 0xffffffffffffffff   # QW = QuadWord
+
+
+ObjT_Mask_Map = {
+    # here for object key - higher 32 bits is masked for dynamic part.
+    ObjT.process: ObjTMask(QW_F, DW_F)
+}
+
+
 def oid_to_fidstr(oid: Oid) -> str:
     """Convert Oid to string representation of fid.
 
@@ -810,11 +825,55 @@ def _infinite_counter(start: int = 0) -> Iterator[int]:
         k += 1
 
 
-fidk_gen = _infinite_counter()  # fid key generator
+# fid key generator per object type
+ObjT_last_fidk = dict((type, _infinite_counter()) for type in ObjT)
+
+# FIDs : Hare allocates motr identifiers aka fids for every motr object as
+# part of motr cluster configuration.
+# fid (128 bits)= fid.container (64 bits) + fid.key (64 bits)
+
+# This fid is divided into to parts, a base fid and a dynamic fid.
+# Base Fid :
+# Base fid (96 bits) is a combination of higher 64 bits of FID container and
+# 32 bits of FID key (higher or lower, based on key mask).
+# This is the static part, unique across the cluster.
+# Dynamic Fid :
+# Consists of 32 bits, updated for motr clients during client restarts,
+# entrypoint reply failures.
+# For intial configuration, it is set to 0.
+
+# Purpose: Maintaining an unique base fid helps to update the fid as well as
+# avoids invalidating the entire motr configuration cache.
+
+
+def __allocate_base_fidkey(objt: ObjT, fidk: int) -> int:
+    """
+    This function sets the given 'fidk' to the base-key fid (32 bits),
+    based on the object type mask.
+
+    1. Gets the mask for the key based on ObjT.
+    mask = 0x00000000ffffffff
+    2. Inverts the mask to set the key in the previosly ON bits.
+    mask ^ 0xffffffffffffffff = 0xffffffff00000000
+    >>> fidk=5
+    >>> hex((mask ^ 0xffffffffffffffff) * fidk + fidk)
+    '0x4fffffffb00000005'
+    3. Reset to '0' the remaining 32 bits by ANDing with original mask.
+    >>> hex(result & mask)
+    '0x5'
+    """
+    obj_mask = ObjT_Mask_Map.get(objt)
+    if obj_mask:
+        fidk = (((obj_mask.key ^ QW_F) * fidk + fidk) &
+                obj_mask.key)
+    return fidk
 
 
 def new_oid(objt: ObjT) -> Oid:
-    return Oid(objt, next(fidk_gen))
+    # get the next fid sequence based on the object type
+    fidk = next(ObjT_last_fidk[objt])
+    key = __allocate_base_fidkey(objt, fidk)
+    return Oid(objt, key)
 
 
 def oid_to_dhall(oid: Oid) -> str:
@@ -2161,15 +2220,24 @@ def consul_kv_sdevs(m0conf: Dict[Oid, Any]) -> Dict[str, str]:
     return d
 
 
+def consul_kv_fidk() -> Dict[str, int]:
+    """
+    Prepares a dict for storing last generated base and dynamic fid keys per
+    object type in consul KV.
+    """
+    d = {}
+    for objt, fidk in ObjT_last_fidk.items():
+        base_key = f'last_base_fid_key/{objt.name}'
+        d[base_key] = next(fidk)
+        dynamic_key = f'last_dynamic_fid_key/{objt.name}'
+        d[dynamic_key] = 0
+    return d
+
+
 def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
     logging.debug('Generating consul KV structure')
     assert all(k.type is ObjT.process and v.type is ObjT.service
                for k, v in cluster.m0_clients.items())
-
-    global fidk_gen
-    _fidk_gen = next(fidk_gen)
-    # Give up ownership of `fidk_gen`, passing it to the Consul KV.
-    del fidk_gen
 
     m0conf = cluster.m0conf
 
@@ -2214,7 +2282,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('epoch', 1),
         ('eq-epoch', 1),
         ('leader', ''),
-        ('last_fidk', _fidk_gen),
+        *consul_kv_fidk().items(),
         ('failvec', ''),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node


### PR DESCRIPTION
### Description: 
Presently Hare cfgen allocates entire motr fid for motr
objects. To accommodate updates to an existing fid dynamically, cfgen
must now allocate only the base fid and reserve the 32 bits based on
object mask for the updates.

### Solution: 
- generate motr configuration with base fids with two-part key
- dynamic key set to 0 for motr processes.
- Dynamic part of object fid is decided based on MASK Map.

### Testing
consul-kv.json file generated with fids

1. for processess
```
{
    "key": "m0conf/nodes/localhost/processes/55834574848/services/ios",
    "value": 15
  },
  {
    "key": "m0conf/nodes/0x6e00000000000001:0x3/processes/0x7200000000000001:0xd00000000/services/0x7300000000000001:0xf",
    "value": "{\"name\": \"ios\", \"state\": \"M0_NC_UNKNOWN\"}"
  },
 {
    "key": "m0conf/nodes/0x6e00000000000001:0x3/processes/0x7200000000000001:0x3900000000",
    "value": "{\"name\": \"m0_client_s3\", \"state\": \"M0_NC_UNKNOWN\"}"
  },
  {
    "key": "m0conf/nodes/0x6e00000000000001:0x3/processes/0x7200000000000001:0xa00000000/services/0x7300000000000001:0xc",
    "value": "{\"name\": \"confd\", \"state\": \"M0_NC_UNKNOWN\"}"
  },
```

2. for other objects like sites, racks, nodes (no change)
```
{
    "key": "m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2/encls/0x6500000000000001:0x4",
    "value": "{\"node\": \"0x6e00000000000001:0x3\", \"state\": \"M0_NC_UNKNOWN\"}"
  },
{
    "key": "m0conf/sites/0x5300000000000001:0x1",
    "value": "{\"state\": \"M0_NC_UNKNOWN\"}"
  },
  {
    "key": "m0conf/sites/0x5300000000000001:0x1/racks/0x6100000000000001:0x2",
    "value": "{\"state\": \"M0_NC_UNKNOWN\"}"
  },
```

3. Bootstrap working
```
root@ssc-vm-g3-rhev4-2743.colo.seagate.com:/root/test2/hare3 (basefid)
$ hctl bootstrap --mkfs ./cfgen/examples/singlenode.yaml
2022-01-05 01:07:53: Generating cluster configuration... OK
2022-01-05 01:07:55: Starting Consul server on this node....... OK
2022-01-05 01:08:02: Importing configuration into the KV store... OK
2022-01-05 01:08:03: Starting Consul on other nodes...Consul ready on all nodes
2022-01-05 01:08:04: Updating Consul configuraton from the KV store... OK
2022-01-05 01:08:06: Waiting for the RC Leader to get elected.......... OK
2022-01-05 01:08:18: Starting Motr (phase1, mkfs)... OK
2022-01-05 01:08:27: Starting Motr (phase1, m0d)... OK
2022-01-05 01:08:30: Starting Motr (phase2, mkfs)... OK
2022-01-05 01:08:45: Starting Motr (phase2, m0d)... OK
2022-01-05 01:08:51: Checking health of services...localhost ["passing","warning"]
Check 'confd' service on the node(s) listed above.
```
4. hctl status
```
root@ssc-vm-g3-rhev4-2743.colo.seagate.com:/root/test2/hare3 (basefid)
$ hctl status
Data pool:
    # fid name
    0x6f00000000000001:0x2f 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x600000000  inet:tcp:192.168.56.39@2001
    [started]  confd      0x7200000000000001:0x900000000  inet:tcp:192.168.56.39@3001
    [started]  ioservice  0x7200000000000001:0xc00000000  inet:tcp:192.168.56.39@3002
    [unknown]  m0_client  0x7200000000000001:0x2900000000  inet:tcp:192.168.56.39@5001
    [unknown]  m0_client  0x7200000000000001:0x2c00000000  inet:tcp:192.168.56.39@5002
```