### PR TITLE
EOS-27290: Broken link on cortx-hare rfc 10 document

### DIFF
--- a/rfc/10/README.md
+++ b/rfc/10/README.md
@@ -23,7 +23,7 @@ required to get Hare going.  For example, Hare will obtain the IP
 address of the given host by itself, but first it must be told which
 host(s) to work with.
 
-See: [3/CFGEN](rfc/3/README.md)
+See: [3/CFGEN](../3/README.md)
 
 <!-- XXX Other definitions that we might want to add:
 


### PR DESCRIPTION
Hi,

While browser the cortx-hare/rfc/10/readme.md , found that link for 3CFGEN is broken.

Instead of

<https://github.com/Seagate/cortx-hare/blob/main/rfc/10/rfc/3/README.md>

the correct one should be

<https://github.com/Seagate/cortx-hare/blob/main/rfc/3/README.md>
