### PR TITLE
EOS-27305: hare setup config command fails

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -70,6 +70,8 @@ class CdfGenerator:
         machine_ids.extend(conf.get_machine_ids_for_service(
             Const.SERVICE_S3_SERVER.value))
 
+        machine_ids = list(set(machine_ids))
+
         for machine_id in machine_ids:
             nodes.append(self._create_node(machine_id))
         return nodes


### PR DESCRIPTION
While generating machine-id list for nodes we are duplicating machine-ids in case
of regular deployment method which is causing deployment failure.
This is because in regular deployment Motr and S3 are present on same node

**Solution**: 
De-duplicate machine-ids from the list.

**Testing**:

Tested deployment(both redefined as well as regular) using http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.9/job/cortx-all-image-custom-ci/1782/