### PR TITLE
EOS-27236: Improve http command for hctl status

### DIFF
--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -264,7 +264,7 @@ class ServerRunner:
         app = self._create_server()
         app.add_routes([
             web.get('/', hello_reply),
-            web.get('/cluster/status', hctl_stat),
+            web.get('/v1/cluster/status', hctl_stat),
             web.post('/', process_ha_states(planner, consul_util)),
             web.post(
                 '/watcher/bq',


### PR DESCRIPTION
```
Previously hctl status command over http was like below:
curl http://<data-pod:port>/cluster/status
It is required to add version parameters like below:
curl http://<hare-pod/svc:port>/v1/cluster/status

Solution: 
Modified string value as "/v1/cluster/status" in place of
"/cluster/status" in server.py.
```


Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>