### PR TITLE
EOS-27315: hctl bootstrap is failing in latest hare main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,7 @@ devinstall-hax: hax/requirements.txt $(HAX_EGG_LINK)
 	@ln -v -sf $(PY_VENV_DIR)/bin/q $(DESTDIR)/$(PREFIX)/bin
 	@ln -v -sf $(PY_VENV_DIR)/bin/configure $(DESTDIR)/$(PREFIX)/bin
 	@ln -v -sf $(PY_VENV_DIR)/bin/update-conf $(DESTDIR)/$(PREFIX)/bin
+	@ln -v -sf $(PY_VENV_DIR)/bin/m0ping $(DESTDIR)/$(PREFIX)/bin
 
 .PHONY: devinstall-miniprov
 devinstall-miniprov: MP_INSTALL_CMD = $(SETUP_PY) develop

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -38,8 +38,7 @@ from hax.motr.rconfc import RconfcStarter
 from hax.server import ServerRunner
 from hax.types import Fid, Profile, StoppableThread
 from hax.util import ConsulUtil, repeat_if_fails
-from cortx.utils.conf_store import Conf
-from cortx.utils.message_bus import MessageBus
+
 
 __all__ = ['main']
 
@@ -117,21 +116,6 @@ def _run_rconfc_starter_thread(motr: Motr,
     return rconfc_starter
 
 
-def _ha_message_bus_init(util: ConsulUtil):
-    configpath = util.get_configpath()
-    Conf.load('cortx_conf', configpath)
-
-    message_server_endpoints = Conf.get('cortx_conf',
-                                        'cortx>external>kafka>endpoints')
-
-    """
-    This creates a MessageBus internal global in-memory object which is
-    indirectly part of the process address space. Thus
-    `MessageBus.init()` must be invoked within process's address space.
-    """
-    MessageBus.init(message_server_endpoints)
-
-
 def main():
     # Note: no logging must happen before this call.
     # Otherwise the log configuration will not apply.
@@ -171,8 +155,6 @@ def main():
     LOG.info(f'Setting up ha_link interface with the options as follows: '
              f'hax fid = {cfg.hax_fid}, hax endpoint = {cfg.hax_ep}, '
              f'HA fid = {cfg.ha_fid}')
-
-    _ha_message_bus_init(util)
 
     ffi = HaxFFI()
     herald = DeliveryHerald()


### PR DESCRIPTION
hctl bootstrap hangs in main,
```
[root@ssc-vm-g2-rhev4-1947 ~]# hctl bootstrap --mkfs --xprt libfab ~/1n.yaml
2022-01-07 10:44:17: Generating cluster configuration... OK
2022-01-07 10:44:20: Starting Consul server on this node......... OK
2022-01-07 10:44:29: Importing configuration into the KV store... OK
2022-01-07 10:44:31: Starting Consul on other nodes...Consul ready on all nodes
2022-01-07 10:44:31: Updating Consul configuraton from the KV store... OK
2022-01-07 10:44:33: Waiting for the RC Leader to get elected.... OK
2022-01-07 10:44:36: Starting Motr (phase1, mkfs)...
```

Because config_path kv is missing is missing in Consul, config_path is added through hare mini provisioner, which is not invoked as part of hctl bootstrap.
```
Jan 07 10:49:18 ssc-vm-g2-rhev4-1947.colo.seagate.com hare-hax[6027]: 2022-01-07 10:49:18,919 [DEBUG] {MainThread} Got HAConsistencyException: config path not present in consul while invokingJan 07 10:49:23 ssc-vm-g2-rhev4-1947.colo.seagate.com hare-hax[6027]: 2022-01-07 10:49:23,924 [DEBUG] {MainThread} KVGET key=config_path, kwargs={}
```

This is a regression from commit 28869a4f.

Solution:
Move `MessageBus.init` to ha module, thus the relevant code will be
invoked only if deployed with cortx-ha component.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>