### PR TITLE
EOS-26323: interface to allocate and return a new fid in hax

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -21,6 +21,8 @@ from typing import (Any, Callable, Dict, Iterable, Iterator, List, NamedTuple,
                     Optional, Set, Type, Tuple)
 from math import floor, ceil
 from hax.log import create_logger_directory
+from hax.types import ObjTMaskMap, QW_F, Fid
+from hax.types import ObjT as HaxObjT
 from helper.exec import CliException, Executor, Program
 import yaml
 import logging
@@ -774,6 +776,29 @@ ObjT = Enum('ObjT', 'root fdmi_flt_grp fdmi_filter'
 ObjT.__doc__ = 'Motr conf object type'
 
 
+def ObjT_to_HaxObjT(t: ObjT):
+    ObjTMap = {
+        ObjT.root: HaxObjT.ROOT,
+        ObjT.fdmi_flt_grp: HaxObjT.FDMI_FLT_GRP,
+        ObjT.fdmi_filter: HaxObjT.FDMI_FILTER,
+        ObjT.node: HaxObjT.NODE,
+        ObjT.process: HaxObjT.PROCESS,
+        ObjT.service: HaxObjT.SERVICE,
+        ObjT.sdev: HaxObjT.SDEV,
+        ObjT.site: HaxObjT.SITE,
+        ObjT.rack: HaxObjT.RACK,
+        ObjT.enclosure: HaxObjT.ENCLOSURE,
+        ObjT.controller: HaxObjT.CONTROLLER,
+        ObjT.drive: HaxObjT.DRIVE,
+        ObjT.pool: HaxObjT.POOL,
+        ObjT.pver: HaxObjT.PVER,
+        ObjT.objv: HaxObjT.OBJV,
+        ObjT.profile: HaxObjT.PROFILE,
+        ObjT.pver_f: ObjT.pver_f
+    }
+    return ObjTMap[t]
+
+
 def objT_to_dhall(t: ObjT) -> str:
     return 'types.ObjT.' + ''.join(s.capitalize() for s in t.name.split('_'))
 
@@ -781,21 +806,6 @@ def objT_to_dhall(t: ObjT) -> str:
 Oid = NamedTuple('Oid', [('type', ObjT), ('fidk', int)])
 Oid.__doc__ = 'Motr conf object identifier'
 Oid.fidk.__doc__ = '.f_key part of the corresponding m0_fid'
-
-
-ObjTMask = NamedTuple('ObjTMask', [('cont', int), ('key', int)])
-ObjTMask.__doc__ = 'Motr conf object identifier mask'
-ObjTMask.key.__doc__ = '.f_key part mask of the corresponding m0_fid'
-
-
-DW_F = 0xffffffff           # DW = DoubleWord
-QW_F = 0xffffffffffffffff   # QW = QuadWord
-
-
-ObjT_Mask_Map = {
-    # here for object key - higher 32 bits is masked for dynamic part.
-    ObjT.process: ObjTMask(QW_F, DW_F)
-}
 
 
 def oid_to_fidstr(oid: Oid) -> str:
@@ -862,7 +872,8 @@ def __allocate_base_fidkey(objt: ObjT, fidk: int) -> int:
     >>> hex(result & mask)
     '0x5'
     """
-    obj_mask = ObjT_Mask_Map.get(objt)
+
+    obj_mask: Optional[Fid] = ObjTMaskMap.get(ObjT_to_HaxObjT(objt))
     if obj_mask:
         fidk = (((obj_mask.key ^ QW_F) * fidk + fidk) &
                 obj_mask.key)

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -29,8 +29,8 @@ from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.motr.planner import WorkPlanner
 from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
-                       MessageId, ObjT, Profile, ReprebStatus, ServiceHealth,
-                       m0HaProcessEvent, m0HaProcessType)
+                       MessageId, ObjT, Profile, ReprebStatus,
+                       ServiceHealth, m0HaProcessEvent, m0HaProcessType)
 from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
 
 LOG = logging.getLogger('hax')
@@ -191,6 +191,9 @@ class Motr:
         LOG.debug('Processing entrypoint request from remote endpoint'
                   " '{}', process fid {}".format(remote_rpc_endpoint,
                                                  str(process_fid)))
+        if self.consul_util.is_proc_client(process_fid):
+            if message.is_first_request:
+                self.consul_util.alloc_next_process_fid(process_fid)
         sess = principal_rm = confds = None
         try:
             util = self.consul_util
@@ -296,6 +299,12 @@ class Motr:
         for st in ha_states:
             if st.status in (ServiceHealth.UNKNOWN, ServiceHealth.OFFLINE):
                 continue
+            # If its a client process then update the base fid to its full
+            # fid.
+            if (st.fid.container == ObjT.PROCESS.value and
+                    self.consul_util.is_proc_client(st.fid)):
+                proc_full_fid = self.consul_util.get_process_full_fid(st.fid)
+                st.fid = proc_full_fid
             note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st))
             notes.append(note)
 

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -20,6 +20,7 @@ import ctypes as c
 from enum import Enum, IntEnum
 from threading import Thread
 from typing import List, NamedTuple, Set
+from recordclass import recordclass
 
 
 class FidStruct(c.Structure):
@@ -139,6 +140,16 @@ class Fid:
         return self.__repr__()
 
 
+DW_F = 0xffffffff           # DW = DoubleWord
+QW_F = 0xffffffffffffffff   # QW = QuadWord
+
+
+ObjTMaskMap = {
+    # here for object key - higher 32 bits is masked for dynamic part.
+    ObjT.PROCESS: Fid(QW_F, DW_F)
+}
+
+
 class Uint128:
     def __init__(self, hi, lo):
         self.hi = hi
@@ -249,7 +260,7 @@ class ServiceHealth(Enum):
         return ha_note
 
 
-HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])
+HAState = recordclass('HAState', [('fid', Fid), ('status', ServiceHealth)])
 
 
 class m0HaProcessEvent(IntEnum):

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -37,9 +37,9 @@ from urllib3.exceptions import HTTPError
 from hax.common import HaxGlobalState
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.types import (ConfHaProcess, Fid, FsStatsWithTime,
-                       ObjT, ServiceHealth, Profile, m0HaProcessEvent,
-                       m0HaProcessType, KeyDelete, HaNoteStruct,
-                       m0HaObjState)
+                       ObjT, ObjTMaskMap, ServiceHealth, Profile,
+                       m0HaProcessEvent, m0HaProcessType, KeyDelete,
+                       HaNoteStruct, m0HaObjState)
 
 from hax.consul.cache import (uses_consul_cache, invalidates_consul_cache,
                               supports_consul_cache)
@@ -1422,15 +1422,24 @@ class ConsulUtil:
                            fid: Fid,
                            proc_node=None,
                            kv_cache=None) -> MotrConsulProcInfo:
+        proc_base_fid = self.get_process_base_fid(fid)
         if not proc_node:
-            proc_node = self.get_process_node(fid, kv_cache=kv_cache)
-        key = f'{proc_node}/processes/{fid}'
+            proc_node = self.get_process_node(proc_base_fid, kv_cache=kv_cache)
+        key = f'{proc_node}/processes/{proc_base_fid}'
         status = self.kv.kv_get(key, kv_cache=kv_cache)
         if status:
             val = json.loads(status['Value'])
             return MotrConsulProcInfo(val['state'], val['type'])
         else:
             return MotrConsulProcInfo('Unknown', 'Unknown')
+
+    @repeat_if_fails()
+    def get_process_full_fid(self, proc_base_fid: Fid) -> Optional[Fid]:
+        proc_fid = self.kv.kv_get(str(proc_base_fid), recurse=False)
+        if proc_fid is not None:
+            pfid: Fid = Fid.parse(json.loads(proc_fid['Value']))
+            return pfid
+        return proc_base_fid
 
     def get_process_local_status(self, fid: Fid) -> str:
         local_node = self.get_local_nodename()
@@ -1621,14 +1630,15 @@ class ConsulUtil:
 
     @uses_consul_cache
     def get_process_node(self, proc_fid: Fid, kv_cache=None) -> str:
-        fidk = proc_fid.key
+        proc_base_fid = self.get_process_base_fid(proc_fid)
+        fidk = proc_base_fid.key
         # 'node/<node_name>/process/<process_fidk>/service/type'
         node_items = self.kv.kv_get('m0conf/nodes',
                                     recurse=True,
                                     kv_cache=kv_cache)
-        if ObjT.PROCESS.value == proc_fid.container:
+        if ObjT.PROCESS.value == proc_base_fid.container:
             keys = self.get_process_keys(node_items, fidk)
-        elif ObjT.SERVICE.value == proc_fid.container:
+        elif ObjT.SERVICE.value == proc_base_fid.container:
             keys = self.get_service_keys(node_items, fidk)
         if len(keys) != 1:
             raise RuntimeError(f'XXX proc_fid:{proc_fid} fidk:{fidk}'
@@ -1792,18 +1802,18 @@ class ConsulUtil:
             ServiceHealth.UNKNOWN: 'unknown',
             ServiceHealth.STOPPED: 'stopped',
         }
+        proc_base_fid = self.get_process_base_fid(process_fid)
 
         # Example key is as follows
         # m0conf/nodes/0x6e00000000000001:0x3/processes/0x7200000000000001:
         # 0x15:{"name": "m0_server", "state": "M0_NC_UNKNOWN"}
         node_items = self.kv.kv_get('m0conf/nodes', recurse=True)
         regex = re.compile(
-            f'^m0conf\\/nodes\\/.*\\/processes\\/{process_fid}$')
+            f'^m0conf\\/nodes\\/.*\\/processes\\/{proc_base_fid}$')
         for item in node_items:
             match_result = re.match(regex, item['Key'])
             if not match_result:
                 continue
-#            value = item['Value']
             value = json.loads(item['Value'])
             value['state'] = process_state_map[state]
             self.kv.kv_put(item['Key'], json.dumps(value))
@@ -1818,6 +1828,65 @@ class ConsulUtil:
         logging.info('Deleting Hare KV entries (%s)', keys)
         if not self.kv.kv_delete_in_transaction(keys):
             raise HAConsistencyException('KV deletion failed')
+
+    @repeat_if_fails()
+    def process_dynamic_fidk_lock(self) -> bool:
+        # Acquire lock to update last_updated_base_fidk.
+        # This will block until lock is acquired.
+        # Will break if any other exception than
+        # HAConsistencyException occurs.
+        try:
+            while not self.kv.kv_put('fidk_update_lock', 'true', cas=0):
+                sleep(1)
+            return True
+        except Exception:
+            return False
+
+    @repeat_if_fails()
+    def process_dynamic_fidk_unlock(self):
+        # Release fidk_update_lock.
+        # This will block until released.
+        try:
+            keys: List[KeyDelete] = [
+                KeyDelete(name='fidk_update_lock', recurse=True),
+            ]
+            while not self.kv.kv_delete_in_transaction(keys):
+                sleep(1)
+        except Exception:
+            raise RuntimeError('Unreachable')
+
+    @repeat_if_fails()
+    def get_process_next_dynamic_fidk_lock(self) -> int:
+        if self.process_dynamic_fidk_lock():
+            fidk = self.kv.kv_get('last_dynamic_fid_key/process',
+                                  recurse=False)
+            new_fidk = int(json.loads(fidk['Value'])) + 1
+            # Update dynamic fid key.
+            while not self.kv.kv_put('last_dynamic_fid_key/process',
+                                     json.dumps(str(new_fidk))):
+                sleep(1)
+            self.process_dynamic_fidk_unlock()
+        return new_fidk
+
+    @repeat_if_fails()
+    def alloc_next_process_fid(self, process_fid: Fid) -> Fid:
+        next_fidk = self.get_process_next_dynamic_fidk_lock()
+        fid_mask: Fid = ObjTMaskMap[ObjT.PROCESS]
+        fid_cont = process_fid.container
+        fid_key = process_fid.key + ((fid_mask.key * next_fidk) + next_fidk)
+        new_proc_fid = Fid(fid_cont, fid_key)
+        base_fid = self.get_process_base_fid(new_proc_fid)
+        # Save base fid to actualy fid mapping in Consul.
+        while not self.kv.kv_put(f'{base_fid}',
+                                 json.dumps(str(new_proc_fid))):
+            sleep(1)
+        return new_proc_fid
+
+    def get_process_base_fid(self, proc_fid: Fid) -> Fid:
+        fid_mask: Fid = ObjTMaskMap[ObjT.PROCESS]
+        base_fid = Fid(proc_fid.container,
+                       (proc_fid.key & fid_mask.key))
+        return base_fid
 
 
 def dump_json(obj) -> str:

--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -15,6 +15,7 @@ pytest==6.2.4
 pytest-aiohttp==0.3.0
 pytest-mock==3.6.1
 pytest-timeout==1.4.2
+recordclass
 
 #:runtime-requirements:
 idna==2.10
@@ -27,3 +28,4 @@ tcpping==0.2
 pytest-cov
 coverage
 inject==4.3.1
+recordclass

--- a/stubs/recordclass/__init__.pyi
+++ b/stubs/recordclass/__init__.pyi
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+def recordclass(typename, fields, defaults=None, *,
+                rename=False, readonly=False,
+                hashable=False, gc=False,
+                use_dict=False, use_weakref=False,
+                fast_new=False, mapping=False, module=None): ...


### PR DESCRIPTION
For dtm to understand if a motr client logs must be discarded, everytime
a motr client restarts, a new fid must be allocated by Hare when Hare
receives an entrypoint request from that motr client.

Solution:
- Hare reserves 32 bits from motr object fid to be used at runtime.
- On motr client restart, when hax receives an entrypoint request,
  hax increments the corresponding motr configuration object type
  sequence and sets it in the reserved 32 bit of the motr process
  configuration object fid.
- Updated fid is saved the Consul corresponding to its base fid.
- Updated motr client process fid is piggy backed over the outgoing
  ha messages for a given process from hax to other motr processes.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>