### PR TITLE
EOS-26606: Improve logging for hare mini-provisioning

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -12,7 +12,7 @@ from hare_mp.types import (ClusterDesc, DiskRef, DList, Maybe, NodeDesc,
                            PoolDesc, PoolType, ProfileDesc, Protocol, Text,
                            M0ServerDesc, DisksDesc, AllowedFailures, Layout,
                            FdmiFilterDesc)
-from hare_mp.utils import Utils
+from hare_mp.utils import func_log, func_enter, func_leave, Utils
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
 DHALL_EXE = '/opt/seagate/cortx/hare/bin/dhall'
@@ -264,6 +264,7 @@ class CdfGenerator:
                                                      params=params_text)
         return gencdf
 
+    @func_log(func_enter, func_leave)
     def generate(self) -> str:
         gencdf = self._get_cdf_dhall()
 

--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -20,7 +20,8 @@ import logging
 from typing import List
 from threading import Event
 from hax.types import StoppableThread
-from hare_mp.utils import execute_no_communicate, LogWriter, Utils
+from hare_mp.utils import (execute_no_communicate, func_log, func_enter,
+                           func_leave, LogWriter, Utils)
 
 LOG = logging.getLogger('consul')
 LOG_FILE_SIZE = 1024 * 1024 * 1024
@@ -46,6 +47,7 @@ class ConsulStarter(StoppableThread):
         self.bind_addr = bind_addr
         self.client_addr = client_addr
 
+    @func_log(func_enter, func_leave)
     def stop(self):
         try:
             if self.process:
@@ -53,6 +55,7 @@ class ConsulStarter(StoppableThread):
         except Exception:
             pass
 
+    @func_log(func_enter, func_leave)
     def _execute(self):
         try:
             log_file = f'{self.log_dir}/hare-consul.log'

--- a/provisioning/miniprov/hare_mp/hax_starter.py
+++ b/provisioning/miniprov/hare_mp/hax_starter.py
@@ -21,7 +21,8 @@ import sys
 from threading import Event
 import os
 from hax.types import StoppableThread
-from hare_mp.utils import execute_no_communicate, LogWriter, Utils
+from hare_mp.utils import (execute_no_communicate, func_log, func_enter,
+                           func_leave, LogWriter, Utils)
 
 LOG = logging.getLogger('hax')
 LOG_FILE_SIZE = 1024 * 1024 * 1024
@@ -41,6 +42,7 @@ class HaxStarter(StoppableThread):
         self.home_dir = home_dir
         self.log_dir = log_dir
 
+    @func_log(func_enter, func_leave)
     def stop(self):
         try:
             if self.process:
@@ -48,6 +50,7 @@ class HaxStarter(StoppableThread):
         except Exception:
             pass
 
+    @func_log(func_enter, func_leave)
     def _execute(self):
         try:
             hax_log_file = f'{self.log_dir}/hare-hax.log'

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -47,7 +47,7 @@ from hare_mp.cdf import CdfGenerator
 from hare_mp.store import ConfStoreProvider
 from hare_mp.systemd import HaxUnitTransformer
 from hare_mp.validator import Validator
-from hare_mp.utils import execute, Utils
+from hare_mp.utils import execute, func_log, func_enter, func_leave, Utils
 from hare_mp.consul_starter import ConsulStarter
 from hare_mp.hax_starter import HaxStarter
 
@@ -105,6 +105,7 @@ def setup_logging(url) -> None:
                         format='%(asctime)s [%(levelname)s] %(message)s')
 
 
+@func_log(func_enter, func_leave)
 def get_data_from_provisioner_cli(method, output_format='json') -> str:
     try:
         process = subprocess.run(
@@ -131,6 +132,7 @@ def _report_unsupported_features(features_unavailable):
         uf_db.store_unsupported_features('hare', features_unavailable))
 
 
+@func_log(func_enter, func_leave)
 def get_server_type(url: str) -> str:
     try:
         provider = ConfStoreProvider(url)
@@ -145,6 +147,7 @@ def get_server_type(url: str) -> str:
         return 'unknown'
 
 
+@func_log(func_enter, func_leave)
 def is_mkfs_required(url: str) -> bool:
     try:
         conf = ConfStoreProvider(url)
@@ -158,6 +161,7 @@ def is_mkfs_required(url: str) -> bool:
         return False
 
 
+@func_log(func_enter, func_leave)
 def logrotate_generic(url: str):
     try:
         with open('/opt/seagate/cortx/hare/conf/logrotate/hare',
@@ -175,6 +179,7 @@ def logrotate_generic(url: str):
         logging.error('Cannot configure logrotate for hare (%s)', error)
 
 
+@func_log(func_enter, func_leave)
 def logrotate(url: str):
     ''' This function is kept incase needed in future.
         This function configures logrotate based on
@@ -200,6 +205,7 @@ def logrotate(url: str):
         logging.error('Cannot configure logrotate for hare (%s)', error)
 
 
+@func_log(func_enter, func_leave)
 def unsupported_feature(url: str):
     try:
         features_unavailable = []
@@ -220,6 +226,7 @@ def unsupported_feature(url: str):
         logging.error('Error reporting hare unsupported features (%s)', error)
 
 
+@func_log(func_enter, func_leave)
 def _create_consul_namespace(hare_local_dir: str):
     log_dir = f'{hare_local_dir}/consul/log'
     if not os.path.exists(log_dir):
@@ -232,6 +239,7 @@ def _create_consul_namespace(hare_local_dir: str):
         os.makedirs(config_dir)
 
 
+@func_log(func_enter, func_leave)
 def _start_consul(utils: Utils,
                   stop_event: Event,
                   hare_local_dir: str,
@@ -262,6 +270,7 @@ def _start_consul(utils: Utils,
     return consul_starter
 
 
+@func_log(func_enter, func_leave)
 def _start_hax(utils: Utils,
                stop_event: Event,
                hare_local_dir: str,
@@ -276,6 +285,7 @@ def _start_hax(utils: Utils,
     return hax_starter
 
 
+@func_log(func_enter, func_leave)
 def post_install(args):
 
     checkRpm('cortx-motr')
@@ -301,6 +311,7 @@ def disable_hare_consul_agent() -> None:
     execute(cmd)
 
 
+@func_log(func_enter, func_leave)
 def prepare(args):
     url = args.config[0]
     utils = Utils(ConfStoreProvider(url))
@@ -358,6 +369,7 @@ def start_crond():
     execute(cmd)
 
 
+@func_log(func_enter, func_leave)
 def start_hax_and_consul_without_systemd(url: str, utils: Utils):
     conf_dir = get_config_dir(url)
     log_dir = get_log_dir(url)
@@ -395,13 +407,14 @@ class ProcessStartInfo:
     fid: str
 
 
+@func_log(func_enter, func_leave)
 def start_mkfs(proc_to_start: ProcessStartInfo) -> int:
     try:
-        logging.debug('Starting mkfs process [fid=%s] at hostname=%s',
-                      proc_to_start.fid, proc_to_start.hostname)
+        logging.info('Starting mkfs process [fid=%s] at hostname=%s',
+                     proc_to_start.fid, proc_to_start.hostname)
         command = proc_to_start.cmd
         execute(command)
-        logging.debug('Started mkfs process [fid=%s]', proc_to_start.fid)
+        logging.info('Started mkfs process [fid=%s]', proc_to_start.fid)
         rc = 0
     except Exception as error:
         logging.error('Error launching mkfs [fid=%s] at hostname=%s: %s',
@@ -410,6 +423,7 @@ def start_mkfs(proc_to_start: ProcessStartInfo) -> int:
     return rc
 
 
+@func_log(func_enter, func_leave)
 def start_mkfs_parallel(hostname: str, hare_config_dir: str):
     # TODO: path needs to be updated according to the new conf-store key
     sysconfig_dir = '/etc/sysconfig/'
@@ -458,6 +472,7 @@ def is_mkfs_done_on_all_nodes(utils: Utils,
     return True
 
 
+@func_log(func_enter, func_leave)
 @repeat_if_fails()
 def cleanup_mkfs_state(utils: Utils, cns_utils: ConsulUtil):
     hostname = utils.get_local_hostname()
@@ -469,11 +484,13 @@ def cleanup_mkfs_state(utils: Utils, cns_utils: ConsulUtil):
         logging.error('Delete transaction failed for %s', keys)
 
 
+@func_log(func_enter, func_leave)
 @repeat_if_fails()
 def set_mkfs_done_for(node: str, cns_utils: ConsulUtil):
     cns_utils.kv.kv_put(f'mkfs_done/{node}', 'true')
 
 
+@func_log(func_enter, func_leave)
 def init(args):
     try:
         url = args.config[0]
@@ -516,6 +533,7 @@ def init(args):
         raise RuntimeError(f'Error while initializing cluster :key={error}')
 
 
+@func_log(func_enter, func_leave)
 def test(args):
     try:
         url = args.config[0]
@@ -598,6 +616,7 @@ def pre_factory(url):
     motr_cleanup()
 
 
+@func_log(func_enter, func_leave)
 def get_log_dir(url) -> str:
     provider = ConfStoreProvider(url)
     machine_id = provider.get_machine_id()
@@ -605,6 +624,7 @@ def get_log_dir(url) -> str:
     return log_path + LOG_DIR_EXT + machine_id
 
 
+@func_log(func_enter, func_leave)
 def get_config_dir(url) -> str:
     provider = ConfStoreProvider(url)
     machine_id = provider.get_machine_id()
@@ -673,6 +693,7 @@ def motr_cleanup():
         raise RuntimeError(f'Error during motr cleanup: key={error}')
 
 
+@func_log(func_enter, func_leave)
 def generate_support_bundle(args):
     try:
         # Default target directory is /tmp/hare
@@ -718,6 +739,7 @@ def noop(args):
     pass
 
 
+@func_log(func_enter, func_leave)
 def checkRpm(rpm_name):
     rpm_list = subprocess.Popen(["rpm", "-qa"],
                                 stdin=subprocess.PIPE,
@@ -730,8 +752,9 @@ def checkRpm(rpm_name):
                                   stderr=subprocess.PIPE,
                                   encoding='utf8')
     out, err = rpm_search.communicate()
-    logging.debug("Output: {}".format(out))
-    logging.debug("stderr: {}".format(err))
+    logging.info(f"Output: {out}")
+    logging.info(f"rpm: {rpm_name} found")
+    logging.info(f"stderr: {err}")
     if rpm_search.returncode != 0:
         raise RuntimeError(f"rpm {rpm_name} is missing")
 
@@ -839,6 +862,7 @@ def check_cluster_status(path_to_cdf: str):
     return 0
 
 
+@func_log(func_enter, func_leave)
 def generate_cdf(url: str) -> str:
     generator = CdfGenerator(ConfStoreProvider(url))
     return generator.generate()
@@ -851,6 +875,7 @@ def save(filename: str, contents: str) -> None:
         f.write(contents)
 
 
+@func_log(func_enter, func_leave)
 def generate_config(url: str, path_to_cdf: str) -> None:
     provider = ConfStoreProvider(url)
     utils = Utils(provider)
@@ -872,6 +897,7 @@ def generate_config(url: str, path_to_cdf: str) -> None:
     utils.import_kv(conf_dir)
 
 
+@func_log(func_enter, func_leave)
 def update_hax_unit(filename: str) -> None:
     try:
         with open(filename) as f:
@@ -882,6 +908,7 @@ def update_hax_unit(filename: str) -> None:
         raise RuntimeError('Failed to update hax systemd unit: ' + str(e))
 
 
+@func_log(func_enter, func_leave)
 def config(args):
     consul_starter = None
     try:


### PR DESCRIPTION
Problem: Current logs are not enough to understand the root
cause in many cases.

Solution:
a) Update the logging.debug statements to logging.info to
increase visibility
b) Add extra log statements for important functions using
decorators

Signed-off-by: Yash Bhamare <yash.bhamare@seagate.com>