### PR TITLE
EOS-27356: hare pre-merge CICD job is failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,7 @@ install-systemd: $(wildcard systemd/*)
 
 .PHONY: install-hax
 install-hax: HAX_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(HAX_WHL:hax/%=%)
+install-hax: export PYTHONPATH = $(DESTDIR)/$(PREFIX)/lib/python3.$(PY3_VERSION_MINOR)/site-packages
 install-hax: $(HAX_EXE)
 
 $(HAX_EGG_LINK) $(HAX_EXE): $(HAX_WHL)
@@ -320,6 +321,7 @@ $(HAX_EGG_LINK) $(HAX_EXE): $(HAX_WHL)
 
 .PHONY: install-miniprov
 install-miniprov: MP_INSTALL_CMD = $(PIP) install --ignore-installed --prefix $(DESTDIR)/$(PREFIX) $(MP_WHL:provisioning/miniprov/%=%)
+install-miniprov: export PYTHONPATH = $(DESTDIR)/$(PREFIX)/lib/python3.$(PY3_VERSION_MINOR)/site-packages
 install-miniprov: $(MP_EXE)
 	@cd provisioning/miniprov && $(SETUP_PY) install
 

--- a/jenkins/prepare-yum-repos
+++ b/jenkins/prepare-yum-repos
@@ -27,7 +27,7 @@ STORAGE='http://cortx-storage.colo.seagate.com'
 
 cat <<EOF > /etc/yum.repos.d/motr_last_successful.repo
 [motr-dev]
-baseurl=$STORAGE/releases/cortx/github/main/centos-7.8.2003/last_successful/
+baseurl=$STORAGE/releases/cortx/github/main/centos-7.9.2009/last_successful/
 gpgcheck=0
 name=motr-dev
 enabled=1
@@ -35,7 +35,7 @@ EOF
 
 cat <<EOF > /etc/yum.repos.d/motr_uploads.repo
 [motr-uploads]
-baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.8.2003-2.0.0-latest/motr_uploads/
+baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.9.2009-2.0.0-k8/motr_uploads/
 gpgcheck=0
 name=motr-uploads
 enabled=1
@@ -43,7 +43,7 @@ EOF
 
 cat <<EOF > /etc/yum.repos.d/lustre_release.repo
 [lustre]
-baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.8.2003-2.0.0-latest/lustre/custom/tcp/
+baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.9.2009-2.0.0-k8/lustre/custom/tcp/
 gpgcheck=0
 name=lustre
 enabled=1

--- a/jenkins/test-boot1
+++ b/jenkins/test-boot1
@@ -26,7 +26,12 @@ HARE_DIR=/opt/seagate/cortx/hare
 export PATH="$HARE_DIR/bin:$PATH"
 
 do_io() {
-    $HARE_DIR/libexec/m0crate-io-conf > _m0crate-io.yaml
+    local cdf=$1
+    if [ "$( echo $( grep 'transport_type' $cdf ) | awk -F": " '{print $2}' )" = "lnet" ]; then
+        $HARE_DIR/libexec/m0crate-io-conf --xprt lnet > _m0crate-io.yaml
+    else
+        $HARE_DIR/libexec/m0crate-io-conf > _m0crate-io.yaml
+    fi
     dd if=/dev/urandom of=/tmp/128M bs=1M count=128
     time m0crate -S _m0crate-io.yaml
 }
@@ -37,12 +42,12 @@ test_cluster() {
     time hctl bootstrap --mkfs $cdf
     hctl status
     hctl status --json
-    do_io
+    do_io $cdf
     hctl reportbug
     time hctl shutdown
 
     time hctl bootstrap --conf-dir /var/lib/hare  # bootstrap on existing conf
-    do_io
+    do_io cdf
     hctl reportbug bundle-id /tmp
     time hctl shutdown
 }

--- a/jenkins/vm-reset
+++ b/jenkins/vm-reset
@@ -58,13 +58,13 @@ validate_args() {
         die 'Cannot communicate with CloudForms Management Engine'
 }
 
-# Wait till the certain condition (state transition or task completion) is met, 
+# Wait till the certain condition (state transition or task completion) is met,
 # or timeout occurs.
 # Currently power state (on/off) and snapshot task progress is checked.
 # It takes inputs,
-# vm_id         id of VM 
+# vm_id         id of VM
 # wait_timeout  minutes to wait for state or task before timeout
-# state         power state or task whose progress needs to checked  
+# state         power state or task whose progress needs to checked
 wait_till() {
     local vm_id=$1
     local wait_timeout=$2
@@ -84,7 +84,7 @@ wait_till() {
             fi
         else
             if [[ $(vm_task_state $state) == "Finished" ]]; then
-                echo  # add a newline after all those dots                
+                echo  # add a newline after all those dots
                 return
             fi
         fi
@@ -147,11 +147,11 @@ vm_snapshot_revert() {
           )
     >&2 jq -r '.message' <<< "$resp"
     [[ $(jq '.success' <<< "$resp") == true ]] || die 'Cannot revert snapshot'
-    
+
     local snapshot_task_id
     snapshot_task_id=$(jq -r '.task_id' <<< "$resp")
 
-    wait_till $vm_id 5 $snapshot_task_id   
+    wait_till $vm_id 5 $snapshot_task_id
 }
 
 main() {


### PR DESCRIPTION
**Problem:**
Pre-merge tests are failing due to the script used to prepare dependencies
still points to CentOS 7.8 refs and VM used for pre-merge job is running 
on OS CentOS 7.8.
[Jenkins Hare-PreMerge-Test](http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Component-Test/job/Hare-PreMerge-Test/)

**Solution:**
1. Replace current VM with centos 7.9 instead with Specs - 
**centos 7.9 , 16 CPU, 16GB RAM, 4 disks/50GB.**
2. Updated the dependencies info in prepare-yum-repos file by correcting 
the centos 7.9 and also verify/Updated all scripts in [Jenkins folder](https://github.com/Seagate/cortx-hare/blob/main/jenkins/) again
as pre-merge job use most of them.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>