### PR TITLE
cfgen: default ConfDrive object is not created for CAS service type

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1128,18 +1128,16 @@ class ConfProcess(ToDhall):
 
             if stype is SvcT.M0_CST_CAS:
                 assert proc_desc is not None
-                if meta_data is None:
-                    disk = '/dev/null'
+                disk = '/dev/null'
                 if meta_data:
                     disk = proc_desc['io_disks'].get('meta_data')
-                    assert ctrl is not None
-                    ConfDrive.build(m0conf, ctrl,
-                                    ConfSdev.build(
-                                        m0conf, svc_id,
-                                        Disk(
-                                            path=disk,
-                                            size=1024,
-                                            blksize=1)))
+                assert ctrl is not None
+                ConfDrive.build(m0conf, ctrl,
+                                ConfSdev.build(
+                                    m0conf, svc_id,
+                                    Disk(path=disk,
+                                         size=1024,
+                                         blksize=1)))
         return proc_id
 
 


### PR DESCRIPTION
Hare cfgen create motr configuration object instances corresponding to
motr data and metadata devices associated with motr ioservice and CAS
service types. If an explicitly metadata device is not specified in Hare
CDF, then cfgen does not create a default metadata device for CAS service
type.

Solution:
Create a default ConfDrive object corresponding to `/dev/null` device for
motr CAS service type.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>