### PR TITLE
EOS-27467: Integrate motr apis in Hare for fetching degraded bytecount.

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -22,7 +22,7 @@ from threading import Event
 
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
-from hax.types import FsStatsWithTime, StoppableThread
+from hax.types import Fid, FsStatsWithTime, ObjT, StoppableThread
 from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
@@ -55,6 +55,14 @@ class FsStatsUpdater(StoppableThread):
                         not all(self.consul.ensure_ioservices_running()))):
                     wait_for_event(self.event, self.interval_sec)
                     continue
+                # Testing purpose and usage
+                proc_fid = Fid(ObjT.PROCESS.value, 15)
+                byte_count = motr.get_proc_bytecount(proc_fid)
+                LOG.debug('Received bytecount: %s', byte_count)
+                pver_fid = Fid(ObjT.PVER.value, 8)
+                pver_status = motr.get_pver_status(pver_fid)
+                LOG.debug('Received pver: %s', pver_status)
+
                 stats = motr.get_filesystem_stats()
                 if not stats:
                     continue

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -27,10 +27,10 @@ from hax.message import (EntrypointRequest, FirstEntrypointRequest,
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.motr.planner import WorkPlanner
-from hax.types import (ConfHaProcess, Fid, FidStruct, FsStats,
+from hax.types import (ByteCountStats, ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
-                       MessageId, ObjT, Profile, ReprebStatus, ServiceHealth,
-                       m0HaProcessEvent, m0HaProcessType)
+                       MessageId, ObjT, Profile, PverState, ReprebStatus,
+                       ServiceHealth, m0HaProcessEvent, m0HaProcessType)
 from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
 
 LOG = logging.getLogger('hax')
@@ -657,6 +657,24 @@ class Motr:
             raise ConfdQuorumException(
                 'Confd quorum lost, filesystem statistics is unavailable')
         return stats
+
+    def get_proc_bytecount(self, proc_fid: Fid) -> ByteCountStats:
+        bytecount: ByteCountStats = self._ffi.proc_bytecount_fetch(
+            self._ha_ctx, proc_fid.to_c())
+        if not bytecount:
+            raise RuntimeError('Bytecount stats unavailable')
+        LOG.debug('Bytecount status for proc fid: %s, stats =%s',
+                  str(bytecount.proc_fid),
+                  bytecount.pvers)
+        return bytecount
+
+    def get_pver_status(self, pver_fid: Fid) -> PverState:
+        status = self._ffi.pver_status_fetch(
+            self._ha_ctx, pver_fid.to_c())
+        if status < 0:
+            raise RuntimeError('Pool version status unavailable')
+        LOG.debug('Pver status for pver %s: %s', pver_fid, status)
+        return PverState(status)
 
     def get_repair_status(self, pool_fid: Fid) -> List[ReprebStatus]:
         LOG.debug('Fetching repair status for pool %s', pool_fid)

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -129,6 +129,16 @@ class HaxFFI:
         lib.m0_ha_filesystem_stats_fetch.restype = c.py_object
         self.filesystem_stats_fetch = lib.m0_ha_filesystem_stats_fetch
 
+        lib.m0_ha_proc_counters_fetch.argtypes = [c.c_void_p,
+                                                  c.POINTER(FidStruct)]
+        lib.m0_ha_proc_counters_fetch.restype = c.py_object
+        self.proc_bytecount_fetch = lib.m0_ha_proc_counters_fetch
+
+        lib.m0_ha_pver_status.argtypes = [c.c_void_p,
+                                          c.POINTER(FidStruct)]
+        lib.m0_ha_pver_status.restype = c.c_int
+        self.pver_status_fetch = lib.m0_ha_pver_status
+
         lib.repair_status.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
         lib.repair_status.restype = c.py_object
         self.repair_status = lib.repair_status

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -29,6 +29,7 @@
 #include "fid/fid.h"		/* M0_FID_TINIT */
 #include "ha/halon/interface.h" /* m0_halon_interface */
 #include "spiel/spiel.h"	/* m0_spiel, m0_spiel_filesystem_stats_fetch */
+#include "conf/pvers.h"
 #include "module/instance.h"
 #include "lib/assert.h"   /* M0_ASSERT */
 #include "lib/memory.h"   /* M0_ALLOC_ARR */
@@ -204,6 +205,95 @@ PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx)
 	Py_DECREF(hax_mod);
 	PyGILState_Release(gstate);
 	return fs_stats;
+}
+
+/*
+ * To be invoked from python land.
+ */
+PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
+	struct m0_fid *proc_fid)
+{
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
+
+	struct hax_context *hc = (struct hax_context *)ctx;
+	struct m0_halon_interface *hi = hc->hc_hi;
+	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
+
+	struct m0_proc_counter count_stats;
+	int rc;
+	// call the motr api
+	Py_BEGIN_ALLOW_THREADS rc =
+	    m0_spiel_proc_counters_fetch(spiel, proc_fid, &count_stats);
+	Py_END_ALLOW_THREADS if (rc != 0)
+	{
+		PyGILState_Release(gstate);
+		// This returns None python object (which is a singleton)
+		// properly with respect to reference counters.
+		Py_RETURN_NONE;
+	}
+
+	PyObject *hax_mod = getModule("hax.types");
+	PyObject *py_fid = toFid(&count_stats.pc_proc_fid);
+	int len = count_stats.pc_cnt;
+	// Fetch all byte count stats per pver.
+	PyObject *list = PyList_New(len);
+	int i;
+	for (i = 0; i < len; ++i) {
+		PyObject *pver_fid = toFid(&count_stats.pc_bckey[i]->sbk_fid);
+		PyObject *pver_bc = PyObject_CallMethod(
+			hax_mod, "PverBC", "(OKKI)",
+			pver_fid,
+			count_stats.pc_bckey[i]->sbk_user_id,
+			count_stats.pc_bcrec[i]->sbr_byte_count,
+			count_stats.pc_bcrec[i]->sbr_object_count
+		);
+		PyList_SET_ITEM(list, i, pver_bc);
+	}
+
+	PyObject *bc_stats = PyObject_CallMethod(
+	    hax_mod, "ByteCountStats", "(OO)",
+		py_fid,
+		list);
+
+	Py_DECREF(list);
+	Py_DECREF(hax_mod);
+
+	PyGILState_Release(gstate);
+	return bc_stats;
+}
+
+/*
+ * To be invoked from python land.
+ */
+int m0_ha_pver_status(unsigned long long ctx,
+	struct m0_fid *pver_fid)
+{
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
+	// TODO use motr spiel API for fetching pver_status.
+	/*
+	struct hax_context *hc = (struct hax_context *)ctx;
+	struct m0_halon_interface *hi = hc->hc_hi;
+	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
+	struct m0_confc *confc = spiel->spl_core.spc_confc;
+	struct m0_conf_pver_info pver_info;
+
+	int rc;
+	// call the motr api
+	Py_BEGIN_ALLOW_THREADS rc =
+	    m0_conf_pver_status(pver_fid, confc, &pver_info);
+	Py_END_ALLOW_THREADS if (rc != 0)
+	{
+		PyGILState_Release(gstate);
+		// This returns error code.
+		return M0_ERR(rc);
+	}
+	M0_LOG(M0_INFO, "FID:"FID_F", Status:%d",
+		FID_P(&pver_info.cpi_fid), pver_info.cpi_state);
+	enum m0_conf_pver_state status  = pver_info.cpi_state;*/
+	PyGILState_Release(gstate);
+	return 2;
 }
 
 static void handle_failvec(const struct hax_msg *hm)
@@ -738,7 +828,7 @@ int start_rconfc(unsigned long long ctx, const struct m0_fid *profile_fid)
 
 
 int stop_rconfc(unsigned long long ctx)
-{	
+{
         struct hax_context *hc = (struct hax_context *)ctx;
 
 	if (hc->hc_rconfc_initialized) {

--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -106,6 +106,22 @@ void m0_ha_broadcast_test(unsigned long long ctx);
  */
 PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx);
 
+/*
+ * Invokes m0_spiel_proc_counters_fetch() which fetches bytecount per pool
+ * versions for all pvers under the ios service.
+ * @param proc_fid - Fid of the ios service
+ *
+ * @return Python object of type hax.types.ByteCountStats
+ */
+PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
+	struct m0_fid *proc_fid);
+
+/*
+ * Invokes XXX api to fetch the status of the pool version fid,
+ * provided as an input.
+ */
+int m0_ha_pver_status(unsigned long long ctx, struct m0_fid *pver_fid);
+
 PyObject *m0_hax_stop(unsigned long long ctx, const struct m0_fid *process_fid,
 		      const char *hax_endpoint);
 void m0_hax_link_stopped(unsigned long long ctx, const char *proc_ep);

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -161,6 +161,26 @@ FsStatsWithTime = NamedTuple('FsStatsWithTime', [('stats', FsStats),
                                                  ('timestamp', float),
                                                  ('date', str)])
 
+# pver byte count
+PverBC = NamedTuple('PverBC', [('pver_fid', Fid),
+                               ('user_id', int),
+                               ('byte_count', int),
+                               ('object_count', int)])
+
+
+# struct m0_proc_counter
+class ByteCountStats(NamedTuple):
+    proc_fid: Fid
+    pvers: List[PverBC]
+
+
+# enum m0_conf_pver_state
+class PverState(IntEnum):
+    M0_CPS_HEALTHY = 0
+    M0_CPS_DEGRADED = 1
+    M0_CPS_CRITICAL = 2
+    M0_CPS_DAMAGED = 3
+
 
 # enum m0_cm_status
 class SnsCmStatus(Enum):


### PR DESCRIPTION
### Description
1. m0_spiel_proc_counters_fetch() in spiel/spiel.h
2. m0_conf_pver_status() in conf/pvers.h

Fetch bytecount stats from motr land to python land in hax.

### Testing

Motr code
```
        count_stats->pc_proc_fid = *proc_fid;
	count_stats->pc_bckey[0]->sbk_fid = M0_FID_TINIT('v', 1, 8);
	count_stats->pc_bckey[0]->sbk_user_id = 1;

	count_stats->pc_bcrec[0]->sbr_byte_count = 4096;
	count_stats->pc_bcrec[0]->sbr_object_count = 1;
 ```
 Output received in hax
```
Jan 18 01:39:27 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[31390]: 2022-01-18 01:39:27,093 [DEBUG] {fs-stats-updater} Shreya got bytecount : ByteCountStats(proc_fid=0x7200000000000001:0xf, pvers=[PverBC(pver_fid=0x7600000000000001:0x8, user_id=1, byte_count=4096, object_count=1)])
```