### PR TITLE
EOS-27498: util: process statuses are duplicate

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -84,7 +84,6 @@ class Motr:
 
         rm_fid = _get_rm_fid()
         # Cleanup old process states.
-        self.consul_util.cleanup_node_process_states()
         result = self._ffi.start(self._ha_ctx, make_c_str(rpc_endpoint),
                                  process.to_c(), ha_service.to_c(),
                                  rm_fid.to_c())
@@ -143,8 +142,7 @@ class Motr:
                                                    str(process_fid)) +
                   ' The request will be processed in another thread.')
         try:
-            if (is_first_request
-                    and (not self.consul_util.is_proc_client(process_fid))):
+            if is_first_request:
                 # This is the first start of this process or the process has
                 # restarted.
                 # Let everyone know that the process has restarted so that
@@ -308,7 +306,7 @@ class Motr:
         hax_fid = self.consul_util.get_hax_fid()
         notes = []
         for st in ha_states:
-            if st.status in (ServiceHealth.UNKNOWN, ServiceHealth.OFFLINE):
+            if st.status == ServiceHealth.UNKNOWN:
                 continue
             note = HaNoteStruct(st.fid.to_c(), ha_obj_state(st))
             notes.append(note)

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -288,12 +288,17 @@ class m0HaProcessType(IntEnum):
     M0_CONF_HA_PROCESS_M0MKFS = 2
     M0_CONF_HA_PROCESS_M0D = 3
 
-    def str_to_Enum(self):
-        types = {'M0_CONF_HA_PROCESS_OTHER': self.M0_CONF_HA_PROCESS_OTHER,
-                 'M0_CONF_HA_PROCESS_KERNEL': self.M0_CONF_HA_PROCESS_KERNEL,
-                 'M0_CONF_HA_PROCESS_M0MKFS': self.M0_CONF_HA_PROCESS_M0MKFS,
-                 'M0_CONF_HA_PROCESS_M0D': self.M0_CONF_HA_PROCESS_M0D}
-        return types[self.name]
+    @staticmethod
+    def str_to_Enum(t: str):
+        types = {'M0_CONF_HA_PROCESS_OTHER':
+                 m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+                 'M0_CONF_HA_PROCESS_KERNEL':
+                 m0HaProcessType.M0_CONF_HA_PROCESS_KERNEL,
+                 'M0_CONF_HA_PROCESS_M0MKFS':
+                 m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
+                 'M0_CONF_HA_PROCESS_M0D':
+                 m0HaProcessType.M0_CONF_HA_PROCESS_M0D}
+        return types[t]
 
     def __repr__(self):
         return self.name

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -611,9 +611,9 @@ def test_broadcast_node_failure(mocker, motr, consul_util):
         elif key == 'm0conf/nodes/localhost/processes/7/services/rms':
             return new_kv('m0conf/nodes/localhost/processes/7/services/rms',
                           '17')
-        elif key == 'localhost/processes/0x7200000000000001:0x15':
+        elif key == 'processes/0x7200000000000001:0x15':
             return new_kv(
-                'localhost/processes/0x7200000000000001',
+                'processes/0x7200000000000001',
                 json.dumps({
                     'type': 'M0_CONF_HA_PROCESS_OTHER',
                     'state': 'Unknown'
@@ -711,9 +711,9 @@ def create_stub_get(process_type: str) -> Callable[[str, bool], Any]:
                   '/ctrls/0x6300000000000001:0x6',
                   json.dumps({"state": "M0_NC_UNKNOWN"}))]
             ]
-        elif key == 'localhost/processes/0x7200000000000001:0x15':
+        elif key == 'processes/0x7200000000000001:0x15':
             return new_kv(
-                'localhost/processes/0x7200000000000001',
+                'processes/0x7200000000000001',
                 json.dumps({
                     'type': process_type,
                     'state': 'Unknown'
@@ -968,9 +968,9 @@ def test_broadcast_io_service_failure(mocker, planner, motr, consumer,
         elif key == 'm0conf/nodes/localhost/processes/7/services/rms':
             return new_kv('m0conf/nodes/localhost/processes/7/services/rms',
                           '17')
-        elif key == 'localhost/processes/0x7200000000000001:0x15':
+        elif key == 'processes/0x7200000000000001:0x15':
             return new_kv(
-                'localhost/processes/0x7200000000000001',
+                'processes/0x7200000000000001',
                 json.dumps({
                     'type': 'M0_CONF_HA_PROCESS_OTHER',
                     'state': 'Unknown'
@@ -1151,9 +1151,9 @@ def test_broadcast_more_than_1024_objects(mocker, planner, motr, consumer,
         elif key == 'm0conf/nodes/localhost/processes/7/services/rms':
             return new_kv('m0conf/nodes/localhost/processes/7/services/rms',
                           '17')
-        elif key == 'localhost/processes/0x7200000000000001:0x15':
+        elif key == 'processes/0x7200000000000001:0x15':
             return new_kv(
-                'localhost/processes/0x7200000000000001',
+                'processes/0x7200000000000001',
                 json.dumps({
                     'type': 'M0_CONF_HA_PROCESS_OTHER',
                     'state': 'Unknown'

--- a/utils/get-process-state
+++ b/utils/get-process-state
@@ -54,4 +54,4 @@ get_node_name() {
     /opt/seagate/cortx/hare/libexec/node-name
 }
 
-consul kv get $(get_node_name)/processes/$fid 2> /dev/null | jq -r '.state'
+consul kv get processes/$fid 2> /dev/null | jq -r '.state'

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -199,7 +199,7 @@ def process_status(node_health: str, proc_states: Dict[str, str],
 
 
 def get_node_process_states(cns: Consul, node_name: str) -> Dict[str, str]:
-    key = f'{node_name}/processes/'
+    key = 'processes/'
     proc_list = kv_item(cns, key, recurse=True)
     process_states: Dict[str, str] = {}
 
@@ -208,7 +208,7 @@ def get_node_process_states(cns: Consul, node_name: str) -> Dict[str, str]:
 
     for proc in proc_list:
         key_split = proc['Key'].split('/')
-        if len(key_split) != 3:
+        if len(key_split) != 2:
             continue
         fid = key_split[-1]
         val = json.loads(proc['Value'])


### PR DESCRIPTION
hax saves all the motr processes states per node. This can be avoided
now to further optimize the process state transition algorithm.

Solution:
- Maintain single copy of motr processes state in Consul KV.
- No need to check for client process while handling entrypoint requests.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>