### PR TITLE
provisioning: mini provisioning unit tests are failing

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -70,6 +70,7 @@ class CdfGenerator:
         machine_ids.extend(conf.get_machine_ids_for_service(
             Const.SERVICE_S3_SERVER.value))
 
+        machine_ids = list(set(machine_ids))
         for machine_id in machine_ids:
             nodes.append(self._create_node(machine_id))
         return nodes

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -32,6 +32,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
@@ -34,6 +34,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -39,6 +39,11 @@
       "hostname": "ssc-vm-1623.colo.seagate.com",
       "name": "srvnode-1",
       "type": "storage_node",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "srvnode-1.data.private",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
@@ -32,6 +32,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -34,6 +34,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
@@ -32,6 +32,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
@@ -34,6 +34,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
@@ -32,6 +32,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -34,6 +34,11 @@
       "hostname": "TMPL_HOSTNAME",
       "name": "TMPL_SERVER_NODE_NAME",
       "type": "TMPL_NODE_TYPE",
+      "components": [
+        { "name": "hare" },
+        { "name": "motr" },
+        { "name": "s3"}
+      ],
       "network": {
         "data": {
           "private_fqdn": "TMPL_PRIVATE_FQDN_1",

--- a/provisioning/miniprov/test/test_templates.py
+++ b/provisioning/miniprov/test/test_templates.py
@@ -62,12 +62,13 @@ def is_content_ok(content: str, mocker, kv_adapter) -> bool:
 
         store = ConfStoreProvider(f'json://{path}')
         mocker.patch.object(store, 'get_machine_id', return_value='machine-id')
+        mocker.patch.object(store, 'get_machine_ids_for_service', return_value=['machine-id'])
         motr_store = ValueProvider()
         mocker.patch.object(motr_store, '_raw_get', return_value='/dev/dummy')
         #
         # the method will raise an exception if either
         # Dhall is unhappy or some values are not found in ConfStore
-        generator = CdfGenerator(provider=store, motr_provider=motr_store)
+        generator = CdfGenerator(provider=store)
         generator.utils.kv = kv_adapter
         generator.generate()
         return True


### PR DESCRIPTION
Due to recent changes to the mini provisioner code corresponding unit
tests are failing.

Solution:
Make test code compatible with the related changes in the mini provisioner.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>