### PR TITLE
EOS-27016: device info accessed before saving

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2491,8 +2491,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         ConfProcess.build(conf, node_id, node, ProcT.hax)
 
         m0srv = node.get('m0_servers')
+        confd_p = False
         if m0srv is not None:
-            confd_p = False
             for ctrl_id in ctrl_ids:
                 m0d = ctrl_id[1]
                 conf_ctrl_id: Optional[Oid] = ctrl_id[0]

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1636,9 +1636,6 @@ class ConsulUtil:
             keys = self.get_process_keys(node_items, fidk)
         elif ObjT.SERVICE.value == proc_fid.container:
             keys = self.get_service_keys(node_items, fidk)
-        if len(keys) != 1:
-            raise RuntimeError(f'XXX proc_fid:{proc_fid} fidk:{fidk}'
-                               f'len:{len(keys)}')
         key = keys[0].split('/')
         node_key = ('/'.join(key[:3]))
         node_val = self.kv.kv_get(node_key, kv_cache=kv_cache)

--- a/hax/helper/configure.py
+++ b/hax/helper/configure.py
@@ -178,7 +178,7 @@ class ConfGenerator:
         cns_file = f'{self.conf_dir}/consul-agents.json'
 
         def get_join_ip() -> str:
-            for node, ip in self._get_data_nodes(cns_file):
+            for node, ip in self._get_nodes(cns_file):
                 if node == node_name:
                     return ip
             raise RuntimeError(f'Logic error: node_name={node_name}'

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -64,15 +64,22 @@ class CdfGenerator:
         nodes: List[NodeDesc] = []
         conf = self.provider
         # Skipping for controller and HA pod
-        machine_ids = conf.get_machine_ids_for_service(
+        machines = conf.get_machine_ids_for_service(
             Const.SERVICE_MOTR_IO.value)
 
-        machine_ids.extend(conf.get_machine_ids_for_service(
-            Const.SERVICE_S3_SERVER.value))
+        s3_machines = conf.get_machine_ids_for_service(
+            Const.SERVICE_S3_SERVER.value)
+        # Avoid adding duplicate machine ids if s3 and data node
+        # are the same. We do not use list(set()) mechanism as it
+        # changes the order and since this code is executed on all
+        # the nodes in-parallel, the configuration generated on
+        # every node must follow the same order to maintain consistency.
+        for machine in s3_machines:
+            if machine not in machines:
+                machines.append(machine)
 
-        machine_ids = list(set(machine_ids))
-        for machine_id in machine_ids:
-            nodes.append(self._create_node(machine_id))
+        for machine in machines:
+            nodes.append(self._create_node(machine))
         return nodes
 
     # cluster>storage_set[N]>durability>{type}>data/parity/spare

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -7,11 +7,11 @@
           "sns": {
             "data": "4",
             "parity": "2",
-            "spare": "2"
+            "spare": "0"
           },
           "dix": {
             "data": "1",
-            "parity": "2",
+            "parity": "1",
             "spare": "0"
           }
         },


### PR DESCRIPTION
1. Hare mini provisioner saves local storage devices facts and information
during mini-provisioner config stage. This information is read during the
config stage to generate motr configuration. hare requires devices
information form all the nodes to be available in Consul to generate the
motr configuration on every node. All the nodes in a cluster are provisioned
in-parallel, thus, it is possible that a node might be executing prepare
stage while the othe might already have started with config. This can be
illustrated as follows,
Node 0
```
2022-01-25 22:05:24 cortx_setup [62]: INFO [_provision_components] /opt/seagate/cortx/hare/bin/hare_setup config --config yaml:///etc/cortx/cluster.conf --services all
2022-01-25 22:05:32 cortx_setup [62]: ERROR [main] error(1): config phase of hare, failed. b''
2022-01-25 22:05:32 cortx_setup [62]: ERROR [main] Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/cortx/setup/cortx_setup.py", line 132, in main
    rc = command.process()
  File "/usr/lib/python3.6/site-packages/cortx/setup/cortx_setup.py", line 120, in process
    CortxProvisioner.cluster_bootstrap(self._args.cortx_conf, force_override)
  File "/usr/lib/python3.6/site-packages/cortx/provisioner/provisioner.py", line 263, in cluster_bootstrap
    CortxProvisioner._provision_components(cortx_conf, mini_prov_interfaces, apply_phase)
  File "/usr/lib/python3.6/site-packages/cortx/provisioner/provisioner.py", line 230, in _provision_components
    component_name, err)
cortx.provisioner.error.CortxProvisionerError: error(1): config phase of hare, failed. b''
```
Node 1
```
2022-01-25 22:05:23 cortx_setup [63]: INFO [_provision_components] /opt/seagate/cortx/hare/bin/hare_setup prepare --config yaml:///etc/cortx/cluster.conf --services all
```
As above, node1 is already executing config stage while node1 is still preparing
and thus, node1 config stage fails.

2. `confd_p` variable accessed without being set in cfgen
3. RuntimeError exception hit with latest KV structure,
```
  File "/opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/util.py", line 1656, in get_process_node
    raise RuntimeError(f'XXX proc_fid:{proc_fid} fidk:{fidk}'
RuntimeError: XXX proc_fid:0x7200000000000001:0x17e fidk:382len:2

[root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2279 /]# consul kv get -recurse | grep "processes/0x7200000000000001:0x17e:"
cortx-data-headless-svc-ssc-vm-g3-rhev4-2107/processes/0x7200000000000001:0x17e:{"state": "M0_CONF_HA_PROCESS_STARTING", "type": "M0_CONF_HA_PROCESS_M0D"}
m0conf/nodes/0x6e00000000000001:0x168/processes/0x7200000000000001:0x17e:{"name": "m0_server", "state": "online"}
m0conf/nodes/0x6e00000000000001:0x17a/processes/0x7200000000000001:0x17e:{"name": "hax", "state": "online"}
```
Apprently, there can be multiple keys for the given query.

Solution:
1. Repeat Consul fetch operation until the corresponding device information is
available.
2. Declare and initialize `confd_p` unconditionally.
3. Allow length of the query result to be > 1.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>