### PR TITLE
EOS-23618: Motr endpoint ports are not configurable

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -424,6 +424,18 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
                      if pool_type(pool) is PoolT.sns]
         desc['profiles'] = [{'name': 'default', 'pools': sns_pools}]
 
+    portalgroup = PortalGroup
+    if 'network_ports' not in desc or not bool(desc['network_ports']):
+        desc['network_ports'] = {port_type.name: port_type.value
+                                 for port_type in portalgroup}
+    else:
+        for key, value in desc['network_ports'].items():
+            if value is None:
+                desc['network_ports'][key] = portalgroup[key].value
+        for srv in [port_type.name for port_type in portalgroup]:
+            if srv not in desc['network_ports']:
+                desc['network_ports'][srv] = portalgroup[srv].value
+
 
 def validate_cluster_desc(desc: Dict[str, Any]) -> None:
     validate_nodes_desc(desc['nodes'])
@@ -835,18 +847,40 @@ ProcT = Enum('ProcT', 'hax m0_server m0_client_s3 m0_client_other')
 ProcT.__doc__ = 'Type of process'
 
 
-class LnetPortalGroup(IntEnum):
-    hax = 1,
-    m0_server = 2,
-    m0_client_s3 = 3,
-    m0_client_other = 4
+class PortalGroup(IntEnum):
+    hax = 22000,
+    m0_server = 21000,
+    m0_client_s3 = 22500,
+    m0_client_other = 21500
 
 
-class LibfabPortalGroup(IntEnum):
-    hax = 2000,
-    m0_server = 3000,
-    m0_client_s3 = 4000,
-    m0_client_other = 5000
+class Portals:
+    def __init__(self, hax=22000, m0_server=21000, m0_client_s3=22500,
+                 m0_client_other=21500):
+        self.hax = hax
+        self.m0_server = m0_server
+        self.m0_client_s3 = m0_client_s3
+        self.m0_client_other = m0_client_other
+
+    def get_portal_group(self):
+        return IntEnum('PortalGroup',
+                       {'hax': self.hax,
+                        'm0_server': self.m0_server,
+                        'm0_client_s3': self.m0_client_s3,
+                        'm0_client_other': self.m0_client_other})
+
+
+def get_lnet_portal_group(hax=1, m0_server=2,
+                          m0_client_s3=3, m0_client_other=4) -> Portals:
+    return Portals(hax=hax, m0_server=m0_server, m0_client_s3=m0_client_s3,
+                   m0_client_other=m0_client_other)
+
+
+def get_libfab_portal_group(hax=22000, m0_server=21000,
+                            m0_client_s3=22500,
+                            m0_client_other=21500) -> Portals:
+    return Portals(hax=hax, m0_server=m0_server, m0_client_s3=m0_client_s3,
+                   m0_client_other=m0_client_other)
 
 
 class Endpoint:
@@ -857,7 +891,7 @@ class LnetEndpoint(Endpoint):
     _tmids: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, proto: NetProtocol, ipaddr: str,
-                 portalgroup: LnetPortalGroup,
+                 portalgroup: PortalGroup,
                  tmid: int = None):
         self.proto = proto
         assert ipaddr
@@ -892,7 +926,7 @@ class LibfabricEndpoint(Endpoint):
     ep_map: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, NetFamily: str, proto: NetProtocol, ipaddr: str,
-                 portalgroup: LibfabPortalGroup):
+                 portalgroup: PortalGroup):
         self.netfamily = NetFamily
         self.proto = proto
         assert ipaddr
@@ -1080,6 +1114,7 @@ class ConfProcess(ToDhall):
     def build(cls,
               m0conf: Dict[Oid, Any],
               parent: Oid,
+              portalgroup: Portals,
               node_desc: Dict[str, Any],
               proc_t: ProcT,
               proc_desc: Dict[str, Any] = None,
@@ -1094,17 +1129,18 @@ class ConfProcess(ToDhall):
         facts = node_desc['facts']
         proto = node_desc.get('data_iface_type', 'tcp')
         transport_type = node_desc.get('transport_type', 'libfab')
+        portal_group = portalgroup.get_portal_group()
         ep: Any = (
             LibfabricEndpoint(NetFamily='inet', proto=NetProtocol[proto],
                               ipaddr=facts[ipaddr_key(
                                            node_desc['data_iface'])],
-                              portalgroup=LibfabPortalGroup[proc_t.name]))
+                              portalgroup=portal_group[proc_t.name]))
         if transport_type == 'lnet':
             # Creates Lnet endpoint, remove once deprecated.
             ep = LnetEndpoint(proto=NetProtocol[proto],
                               ipaddr=facts[ipaddr_key(
                                            node_desc['data_iface'])],
-                              portalgroup=LnetPortalGroup[proc_t.name])
+                              portalgroup=portal_group[proc_t.name])
         proc_id = new_oid(ObjT.process)
         meta_data = None
         if proc_desc is not None and proc_t is ProcT.m0_server:
@@ -2484,6 +2520,22 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     other_clients: Dict[str, List[Tuple[Oid, Oid]]] = {}
     io_ctrls: Dict[Oid, Any] = {}
 
+    ports = cluster_desc.get('network_ports')
+    if ports:
+        lnet_portals = get_lnet_portal_group(
+                           hax=ports['hax'],
+                           m0_server=ports['m0_server'],
+                           m0_client_s3=ports['m0_client_s3'],
+                           m0_client_other=ports['m0_client_other'])
+        libfab_portals = get_libfab_portal_group(
+                             hax=ports['hax'],
+                             m0_server=ports['m0_server'],
+                             m0_client_s3=ports['m0_client_s3'],
+                             m0_client_other=ports['m0_client_other'])
+    else:
+        lnet_portals = get_lnet_portal_group()
+        libfab_portals = get_libfab_portal_group()
+
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
         encl_id = ConfEnclosure.build(conf, rack_id, node_id)
@@ -2497,8 +2549,13 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                     io_ctrls[ctrl_oid] = m0d
                 else:
                     ctrl_ids.append((None, m0d))
+        transport_type = node.get('transport_type', 'libfab')
+        if transport_type == 'lnet':
+            portalgroup = lnet_portals
+        else:
+            portalgroup = libfab_portals
 
-        ConfProcess.build(conf, node_id, node, ProcT.hax)
+        ConfProcess.build(conf, node_id, portalgroup, node, ProcT.hax)
 
         m0srv = node.get('m0_servers')
         confd_p = False
@@ -2506,8 +2563,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
             for ctrl_id in ctrl_ids:
                 m0d = ctrl_id[1]
                 conf_ctrl_id: Optional[Oid] = ctrl_id[0]
-                ConfProcess.build(conf, node_id, node, ProcT.m0_server, m0d,
-                                  conf_ctrl_id)
+                ConfProcess.build(conf, node_id, portalgroup, node,
+                                  ProcT.m0_server, m0d, conf_ctrl_id)
                 if m0d['runs_confd']:
                     confd_p = True
 
@@ -2520,7 +2577,8 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         for client_t, proc_t in [('s3', ProcT.m0_client_s3),
                                  ('other', ProcT.m0_client_other)]:
             for _ in range(node['m0_clients'][client_t]):
-                proc_id = ConfProcess.build(conf, node_id, node, proc_t)
+                proc_id = ConfProcess.build(conf, node_id, portalgroup, node,
+                                            proc_t)
                 cluster.m0_clients[proc_id] = new_oid(ObjT.service)
                 if client_t == 'other':
                     if node['hostname'] not in other_clients:

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -52,6 +52,7 @@
 , PoolType     = ./types/PoolType.dhall
 , PoolsRef     = ./types/PoolsRef.dhall
 , FdmiFilterDesc = ./types/FdmiFilterDesc.dhall
+, NetworkPorts = ./types/Ports.dhall
 
 , Obj         = ./types/Obj.dhall
 , ObjT        = ./types/ObjT.dhall

--- a/cfgen/dhall/types/Ports.dhall
+++ b/cfgen/dhall/types/Ports.dhall
@@ -1,10 +1,8 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
+  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
@@ -12,23 +10,14 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-
   For any questions about this software or licensing,
   please email opensource@seagate.com or cortx-questions@seagate.com.
 
 -}
 
-let M0Server = ./M0ServerDesc.dhall
-
-let Node = ./NodeDesc.dhall
-
-let Pool = ./PoolDesc.dhall
-
-in
-{ create_aux : Optional Bool
-, nodes : List Node
-, pools : List Pool
-, network_ports : Optional ./Ports.dhall
-, profiles : Optional (List ./PoolsRef.dhall)
-, fdmi_filters: Optional (List ./FdmiFilterDesc.dhall)
+-- network ports
+{ hax : Optional Natural
+, m0_server : Optional Natural
+, m0_client_s3 : Optional Natural
+, m0_client_other : Optional Natural
 }

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -79,3 +79,9 @@ profiles:
     pools: [ tier3-hdd ]
   - name: all
     pools: [ tier1-nvme, tier2-ssd, tier3-hdd ]
+#network_ports:
+#    hax: 22000
+#    m0_server: 21000
+#    m0_client_s3: 22500
+#    m0_client_other: 21500
+

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -55,3 +55,9 @@ pools:
 #    node: localhost
 #    client_index: 1
 #    substrings: ["Bucket-Name", "Object-Name", "Object-URI"]
+#network_ports:
+#    hax: 22000
+#    m0_server: 21000
+#    m0_client_s3: 22500
+#    m0_client_other: 21500
+

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -136,4 +136,11 @@ in
           , substrings : List Text
           }
       )
+,  network_ports =
+     None
+     { hax : Optional Natural
+     , m0_server : Optional Natural
+     , m0_client_s3 : Optional Natural
+     , m0_client_other : Optional Natural
+     }
 } : types.ClusterDesc

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -62,6 +62,7 @@ let ClusterInfo =
       { create_aux : Optional Bool
       , node_info: List NodeInfo
       , pool_info: List PoolInfo
+      , ports_info: Optional T.NetworkPorts
       , profile_info: List ProfileInfo
       , fdmi_filter_info: Optional (List T.FdmiFilterDesc)
       }
@@ -99,6 +100,7 @@ let genCdf
       ->  { create_aux = cluster_info.create_aux
           , nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
           , pools = Prelude.List.map PoolInfo T.PoolDesc toPoolDesc cluster_info.pool_info
+          , network_ports = cluster_info.ports_info
           , profiles = Some cluster_info.profile_info
           , fdmi_filters = cluster_info.fdmi_filter_info
           }

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -165,11 +165,20 @@ class FdmiFilterDesc(DhallTuple):
 
 
 @dataclass(repr=False)
+class NetworkPorts(DhallTuple):
+    hax: Maybe[int]
+    m0_server: Maybe[int]
+    m0_client_s3: Maybe[int]
+    m0_client_other: Maybe[int]
+
+
+@dataclass(repr=False)
 class ClusterDesc(DhallTuple):
     create_aux: Maybe[bool]
     node_info: DList[NodeDesc]
     pool_info: DList[PoolDesc]
     profile_info: DList[ProfileDesc]
+    ports_info: Maybe[NetworkPorts]
     fdmi_filter_info: Maybe[List[FdmiFilterDesc]]
 
 


### PR DESCRIPTION
Hare generates motr processes endpoints and internally generates the
corresponding ports. It is important to make the portal range configurable
so that the corresponding endpoint can be generated such that to facilitate
firewall settings as part of the overall product. 

Solution:
 - Read portal range from cortx provisioner via hare mini-provisioner
 - Update CDF format to optionally include motr processes portal range.
 - Generate motr processes endpoint within the given portal range.

Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>