### PR TITLE
EOS-27617: Populate CDF with rgw client details fetched from conf-store

### DIFF
--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -45,6 +45,7 @@
 , ClusterDesc  = ./types/ClusterDesc.dhall
 , NodeDesc     = ./types/NodeDesc.dhall
 , M0ServerDesc = ./types/M0ServerDesc.dhall
+, M0ClientDesc = ./types/M0ClientDesc.dhall
 , Disk         = ./types/IODisk.dhall
 , PoolDesc     = ./types/PoolDesc.dhall
 , DiskRef      = ./types/DiskRef.dhall

--- a/cfgen/dhall/types/M0ClientDesc.dhall
+++ b/cfgen/dhall/types/M0ClientDesc.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -21,9 +21,9 @@ nodes:
             - path: /dev/loop7
             - path: /dev/loop8
             - path: /dev/loop9
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -29,9 +29,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu3
     data_iface: eth1
     transport_type: libfab
@@ -50,9 +50,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/sde
             - path: /dev/sdf
             - path: /dev/sdg
-    m0_clients:
-        s3: 0           # number of S3 servers to start
-        other: 2        # max quantity of other Motr clients this node may have
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: pod-c2
     data_iface: eth1_c2
     data_iface_type: o2ib
@@ -34,9 +34,9 @@ nodes:
             - path: /dev/sdi
             - path: /dev/sdj
             - path: /dev/sdk
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathd
             - path: /dev/disk/by-id/dm-name-mpathe
             - path: /dev/disk/by-id/dm-name-mpathf
-    m0_clients:
-      s3: 11
-      other: 3
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: srvnode-2
     data_iface: enp175s0f1_c2
     data_iface_type: o2ib
@@ -38,9 +38,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathj
             - path: /dev/disk/by-id/dm-name-mpathk
             - path: /dev/disk/by-id/dm-name-mpathl
-    m0_clients:
-      s3: 11
-      other: 3
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: tier1-nvme
     disk_refs:

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -25,9 +25,9 @@ nodes:
             - path: /dev/loop8 
             - path: /dev/loop9 
           meta_data: null
-    m0_clients:
-      s3: 0         # number of S3 servers to start
-      other: 2      # max quantity of other Motr clients this host may have
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 create_aux: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -92,10 +92,7 @@ in
                 }
             }
           ]
-      , m0_clients =
-          { s3 = 0
-          , other = 2
-          }
+      , m0_clients = None (List { name : Text, instances : Natural })
       }
     ]
 , pools =

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -2,7 +2,7 @@ import os.path as P
 import subprocess as S
 from dataclasses import dataclass
 from string import Template
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 from math import floor, ceil
 import pkg_resources
 
@@ -11,7 +11,7 @@ from hare_mp.store import ValueProvider
 from hare_mp.types import (ClusterDesc, DiskRef, DList, Maybe, NodeDesc,
                            PoolDesc, PoolType, ProfileDesc, Protocol, Text,
                            M0ServerDesc, DisksDesc, AllowedFailures, Layout,
-                           FdmiFilterDesc)
+                           FdmiFilterDesc, M0ClientDesc)
 from hare_mp.utils import func_log, func_enter, func_leave, Utils
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
@@ -66,15 +66,18 @@ class CdfGenerator:
         # Skipping for controller and HA pod
         machines = conf.get_machine_ids_for_service(
             Const.SERVICE_MOTR_IO.value)
+        # Get all the pods which runs the client components
+        client_machines = []
+        for client in conf.get_motr_clients():
+            name = str(client.get('name'))
+            client_machines.extend(conf.get_machine_ids_for_component(name))
 
-        s3_machines = conf.get_machine_ids_for_service(
-            Const.SERVICE_S3_SERVER.value)
-        # Avoid adding duplicate machine ids if s3 and data node
+        # Avoid adding duplicate machine ids if client and data node
         # are the same. We do not use list(set()) mechanism as it
         # changes the order and since this code is executed on all
         # the nodes in-parallel, the configuration generated on
         # every node must follow the same order to maintain consistency.
-        for machine in s3_machines:
+        for machine in client_machines:
             if machine not in machines:
                 machines.append(machine)
 
@@ -349,6 +352,24 @@ class CdfGenerator:
         length = 1
         return length
 
+    def _get_node_clients(self, machine_id: str) -> Iterator[M0ClientDesc]:
+        """
+        For all the motr clients present in the cluster return only those
+        clients that are present in the components list for the given
+        node>{machine_id} according to the ConfStore.
+
+        cortx>motr>clients=[rgw, other]
+        node>{machine_id}>components=[motr, other]
+
+        return 'other' only.
+        """
+        for client in self.provider.get_motr_clients():
+            name = str(client.get('name'))
+            if self.utils.is_component(machine_id, name):
+                yield M0ClientDesc(
+                    name=Text(name),
+                    instances=int(str(client.get('num_instances'))))
+
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
 
@@ -356,16 +377,7 @@ class CdfGenerator:
         # node>{machine-id}>name
         iface = self._get_iface(machine_id)
         servers = None
-        no_m0clients = 0
-        nr_s3_instances = 0
         if(self.utils.is_motr_component(machine_id)):
-            try:
-                # cortx>motr>client_instances
-                no_m0clients = int(store.get(
-                    'cortx>motr>client_instances',
-                    allow_null=True))
-            except TypeError:
-                no_m0clients = 2
             # Currently, there is 1 m0d per cvg.
             # We will create 1 IO service entry in CDF per cvg.
             # An IO service entry will use data  and metadat devices
@@ -393,8 +405,12 @@ class CdfGenerator:
                     meta_data=Maybe(None, 'Text')),
                 runs_confd=Maybe(True, 'Bool')))
 
-        if (self.utils.is_s3_component(machine_id)):
-            nr_s3_instances = int(store.get('cortx>s3>service_instances'))
+        # adding clients
+        clients = DList([
+            client
+            for client in self._get_node_clients(machine_id)
+        ], 'List M0ClientDesc')
+        m0_clients = clients if clients else None
 
         node_facts = self.utils.get_node_facts()
         return NodeDesc(
@@ -407,10 +423,5 @@ class CdfGenerator:
             data_iface_type=Maybe(self._get_iface_type(machine_id), 'P'),
             transport_type=Text(self.utils.get_transport_type()),
             m0_servers=Maybe(servers, 'List M0ServerDesc'),
-            #
-            # [KN] This is a hotfix for singlenode deployment
-            # TODO in the future the value must be taken from a correct
-            # ConfStore key (it doesn't exist now).
-            # cortx>s3>service_instances
-            s3_instances=nr_s3_instances,
-            client_instances=no_m0clients)
+            m0_clients=Maybe(m0_clients, 'List M0ClientDesc')
+        )

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -21,6 +21,11 @@ let M0ServerDesc =
       , io_disks : IODisks
       }
 
+let M0ClientDesc =
+      { name : Text
+      , instances : Natural
+      }
+
 let NodeInfo =
       { hostname : Text
       , machine_id : Optional Text
@@ -31,8 +36,7 @@ let NodeInfo =
       , data_iface_type : Optional T.Protocol
       , transport_type : Text
       , m0_servers : Optional (List M0ServerDesc)
-      , s3_instances : Natural
-      , client_instances : Natural
+      , m0_clients : Optional (List M0ClientDesc)
       }
 
 let AllowedFailures =
@@ -77,7 +81,7 @@ let toNodeDesc
           , data_iface = n.data_iface
           , data_iface_type = n.data_iface_type
           , transport_type = n.transport_type
-          , m0_clients = { other = n.client_instances, s3 = n.s3_instances }
+          , m0_clients = n.m0_clients
           , m0_servers = n.m0_servers
           }
 

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -85,9 +85,9 @@ class Text:
 
 
 @dataclass(repr=False)
-class M0Clients(DhallTuple):
-    s3: int
-    other: int
+class M0ClientDesc(DhallTuple):
+    name: Text
+    instances: int
 
 
 @dataclass(repr=False)
@@ -120,8 +120,7 @@ class NodeDesc(DhallTuple):
     data_iface_type: Maybe[Protocol]
     transport_type: Text
     m0_servers: Maybe[DList[M0ServerDesc]]
-    s3_instances: int
-    client_instances: int
+    m0_clients: Maybe[DList[M0ClientDesc]]
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -152,35 +152,25 @@ class Utils:
     def is_motr_component(self, machine_id: str) -> bool:
         """
         Returns True if motr component is present in the components list
-        for the given node>{machine_id} according to the
-        ConfStore (ValueProvider).
+        for the given node>{machine_id}.
         """
-        comp_names = self.provider.get(f'node>{machine_id}>'
-                                       f'components')
-        for component in comp_names:
-            if(component.get('name') == Const.COMPONENT_MOTR.value):
-                rc = True
-                break
-            else:
-                rc = False
-        return rc
+        return self.is_component(machine_id, Const.COMPONENT_MOTR.value)
 
     @func_log(func_enter, func_leave)
-    def is_s3_component(self, machine_id: str) -> bool:
+    def is_component(self, machine_id: str, name: str) -> bool:
         """
-        Returns True if s3 component is present in the components list
-        for the given node>{machine_id} according to the
+        Returns True if the given component is present in the components
+        list for the given node>{machine_id} according to the
         ConfStore (ValueProvider).
         """
         comp_names = self.provider.get(f'node>{machine_id}>'
                                        f'components')
+        found = False
         for component in comp_names:
-            if(component.get('name') == Const.COMPONENT_S3.value):
-                rc = True
+            if(component.get('name') == name):
+                found = True
                 break
-            else:
-                rc = False
-        return rc
+        return found
 
     @func_log(func_enter, func_leave)
     def save_drives_info(self):

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -29,7 +29,7 @@ import pkg_resources
 
 from hare_mp.cdf import CdfGenerator
 from hare_mp.store import ConfStoreProvider, ValueProvider
-from hare_mp.types import (DisksDesc, Disk, DList, M0Clients, M0ServerDesc, Maybe,
+from hare_mp.types import (DisksDesc, Disk, DList, M0ClientDesc, M0ServerDesc, Maybe,
                            MissingKeyError, PoolDesc, PoolType, Protocol, Text,
                            AllowedFailures, Layout)
 from hare_mp.utils import Utils
@@ -38,8 +38,8 @@ from hax.util import KVAdapter
 
 class TestTypes(unittest.TestCase):
     def test_m0clients(self):
-        val = M0Clients(s3=5, other=2)
-        self.assertEqual('{ s3 = 5, other = 2 }', str(val))
+        val = M0ClientDesc(name='other', instances=2)
+        self.assertEqual('{ name = other, instances = 2 }', str(val))
 
     def test_protocol(self):
         self.assertEqual('P.tcp', str(Protocol.tcp))
@@ -111,6 +111,7 @@ class TestCDF(unittest.TestCase):
 
             store.get_machine_id = Mock(return_value='1114a50a6bf6f9c93ebd3c49d07d3fd4')
             store.get_machine_ids_for_service = Mock(return_value=['1114a50a6bf6f9c93ebd3c49d07d3fd4'])
+            store.get_motr_clients = Mock(return_value=[])
             utils = Utils(store)
             kv = KVAdapter()
             def my_get(key: str, recurse: bool = False):
@@ -234,6 +235,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -307,7 +309,8 @@ class TestCDF(unittest.TestCase):
                 'node': {'MACH_ID': {'cluster_id': 'CLUSTER_ID'}},
                 'node>MACH_ID>cluster_id': 'CLUSTER_ID',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_ID>storage>cvg_count': 2,
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
@@ -323,13 +326,16 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'cortx>motr>client_instances':                2,
             }
             return data.get(value)
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=
+                                      [{'name': 'other',
+                                        'num_instances' : 2}])
+        store.get_machine_ids_for_component = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -375,8 +381,11 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
-        self.assertEqual(1, ret[0].s3_instances)
-        self.assertEqual(2, ret[0].client_instances)
+        clients = ret[0].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
 
 
         cdf = CdfGenerator(provider=store)
@@ -586,6 +595,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         cdf._get_m0d_per_cvg = Mock(return_value=1)
         utils = Utils(store)
@@ -908,6 +918,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -992,7 +1003,8 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1'],
                 'node>MACH_ID>storage>cvg':
@@ -1008,7 +1020,8 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_2_ID>network>data>private_fqdn':
                     'srvnode-2.data.private',
                 'node>MACH_2_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_2_ID>network>data>private_interfaces':
                 ['eth1'],
                 'cortx>motr>transport_type':
@@ -1029,6 +1042,11 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID',
                                                                'MACH_2_ID'])
+        store.get_motr_clients = Mock(return_value=
+                                [{'name': 'other',
+                                'num_instances' : 2}])
+        store.get_machine_ids_for_component = Mock(return_value=['MACH_ID',
+                                                                 'MACH_2_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -1077,13 +1095,19 @@ class TestCDF(unittest.TestCase):
         self.assertIn(Text('srvnode-1.data.private'),
                       [ret[0].hostname, ret[1].hostname])
         self.assertEqual(Text('eth1'), ret[0].data_iface)
-        self.assertEqual(1, ret[0].s3_instances)
-        self.assertEqual(2, ret[0].client_instances)
+        clients = ret[0].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
         self.assertIn(Text('srvnode-2.data.private'),
                       [ret[0].hostname, ret[1].hostname])
         self.assertEqual(Text('eth1'), ret[1].data_iface)
-        self.assertEqual(1, ret[1].s3_instances)
-        self.assertEqual(2, ret[1].client_instances)
+        clients = ret[1].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
         self.assertEqual('Some (P.tcp)', str(ret[0].data_iface_type))
         self.assertEqual('Some (P.tcp)', str(ret[1].data_iface_type))
 
@@ -1136,6 +1160,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         utils = Utils(store)
         kv = KVAdapter()


### PR DESCRIPTION
Reading from Confstore - motr clients
```
cortx:
  motr:
   ...
    num_clients: 2                 # Number of Clients
    clients:                       # Motr Client Settings
    - name: rgw_s3                 # rgw_s3|s3|cclient (Motr Clients)
      num_instances: 1             # Client instances per node (pod)
      endpoints:
      - tcp://server1-node1:21001  # Format: <protocol>://<hostname_ip>:21001
      - tcp://server1-node2:21001  # Num endpoints will be same as num of client instances
                                   # Port range would be 21001 - 21001+num_instances
    - name: motr_client
      num_instances: 0             # Optional client. Only for Dev.
      endpoints:
      - tcp://server1-node1:21001
      - tcp://server1-node2:21001
```

and generate CDF
```
nodes:
- transport_type: libfab
  m0_servers:
...
  m0_clients:
  - name: rgw_s3
    instance: 1
  - name: motr_client
    instance: 0
  memorysize_mb: 15866.52734375
```
### Note: Needs cfgen file from https://github.com/Seagate/cortx-hare/pull/1963/ for bootstrap to pass. 