### PR TITLE
EOS-28564: RGW sysconfig path needs changes

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -292,7 +292,8 @@ def post_install(args):
     checkRpm('consul')
     checkRpm('cortx-hare')
     checkRpm('cortx-py-utils')
-    checkRpm('cortx-s3server')
+    # we need to check for 'rgw' rpm
+    # checkRpm('cortx-s3server')
 
     if args.report_unavailable_features:
         unsupported_feature(args.config[0])

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -205,8 +205,9 @@ install_motr_conf() {
 
 install_motr_client_conf() {
     local motr_client_conf_file=$1
+    local motr_client_type=$2
     if $custom_config; then
-        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
+        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/$motr_client_type/$(get_node_name)/
     else
         sudo install $motr_client_conf_file $sysconfig_dir/
     fi
@@ -216,14 +217,10 @@ create_motr_conf_dir() {
     mkdir -p $conf_dir/$sysconfig_dir/motr/$(get_node_name)
 }
 
-create_s3_conf_dir() {
-    mkdir -p $conf_dir/$sysconfig_dir/s3/$(get_node_name)
+create_client_conf_dir() {
+    local motr_client_type=$1
+    mkdir -p $conf_dir/$sysconfig_dir/$motr_client_type/$(get_node_name)
 }
-
-if $custom_config ; then
-    create_motr_conf_dir
-    create_s3_conf_dir
-fi
 
 if $custom_config ; then
     [ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -265,6 +262,14 @@ if $dry_run; then
     return 0  # we must not `exit`, because the script is sourced
 fi
 # --------------------------------------------------------------------
+
+if $custom_config ; then
+    create_motr_conf_dir
+    for motr_client_type in $MOTR_CLIENT_TYPES; do
+        motr_client_type=$(echo $motr_client_type | tr -d ',' | tr -d '"')
+        create_client_conf_dir $motr_client_type
+    done
+fi
 
 mkdir -p $conf_dir/consul-server-conf/
 mkdir -p $conf_dir/consul-client-conf/
@@ -425,7 +430,7 @@ MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 MOTR_${motr_client_type^^}_PORT=$client_port
 EOF
-    install_motr_client_conf /tmp/$motr_client_type-$fid
+    install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }
 
 for id in $HAX_ID; do


### PR DESCRIPTION
Problem: Currently 'rgw' sysconfig file are generated under path
<config-path>/s3/sysconfig/<machine-id>/
We need to change that path to following
<config-path>/rgw/sysconfig/<machine-id>/

Solution: Changed path of motr client's(such as rgw, s3server etc) sysconfig files
to following format
<config-path>/rgw/sysconfig/<machine-id>/

**Test:**
Tested by running config stage in LC environment
```
[root@cortx-server-headless-svc-ssc-vm-g2-rhev4-2785 cortx-hare]# cat /etc/cortx/rgw/sysconfig/b1616a564b424663ae7a0926621656a8/rgw-0x7200000000000001\:0x9f
MOTR_PROFILE_FID=0x7000000000000001:0xe1
MOTR_RGW_EP='inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2785@5004'
MOTR_HA_EP='inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2785@2001'
MOTR_PROCESS_FID='0x7200000000000001:0x9f'
MOTR_RGW_PORT=28074
```

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>