### PR TITLE
Problem: Fix issues seen during RGW deployment

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -891,8 +891,15 @@ def generate_config(url: str, path_to_cdf: str) -> None:
            '--log-dir', get_log_dir(url),
            '--log-file', LOG_FILE,
            '--uuid', provider.get_machine_id()]
-    execute(cmd, env={'PYTHONPATH': python_path, 'PATH': path,
-                      'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
+
+    locale_info = execute(['locale', '-a'])
+    env = {'PYTHONPATH': python_path, 'PATH': path}
+
+    if 'en_US.utf-8' in locale_info or 'en_US.utf8' in locale_info:
+        env.update({'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
+
+    execute(cmd, env)
+
     utils.copy_conf_files(conf_dir)
     utils.copy_consul_files(conf_dir, mode='client')
     utils.import_kv(conf_dir)

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -223,6 +223,10 @@ create_client_conf_dir() {
 }
 
 if $custom_config ; then
+    create_motr_conf_dir
+fi
+
+if $custom_config ; then
     [ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
 else
     [ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -264,7 +268,6 @@ fi
 # --------------------------------------------------------------------
 
 if $custom_config ; then
-    create_motr_conf_dir
     for motr_client_type in $MOTR_CLIENT_TYPES; do
         motr_client_type=$(echo $motr_client_type | tr -d ',' | tr -d '"')
         create_client_conf_dir $motr_client_type


### PR DESCRIPTION
**Problem**: Fix issues seen during RGW deployment

**Solution**:
motr configuration path was not getting created, modified code
to create motr conf directory.
While executing 'configure' command wrong locale was getting set
Now we are checking if locale is present then we will set UTF locale

**Test:**
Tested by running 'config' stage on CentOS 7.9 and Rocky Linux machines