### PR TITLE
EOS-28748: RGW: Update MOTR endpoint key names in Hare generated config

### DIFF
--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -425,10 +425,10 @@ append_motr_client_svc() {
     [[ -n $first_profile_fid ]]  # assert
     cat <<EOF | sudo tee /tmp/$motr_client_type-$fid > /dev/null
 MOTR_PROFILE_FID=$first_profile_fid
-MOTR_${motr_client_type^^}_EP='$ep'
+MOTR_CLIENT_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
-MOTR_${motr_client_type^^}_PORT=$client_port
+MOTR_CLIENT_PORT=$client_port
 EOF
     install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }


### PR DESCRIPTION
**Solution**: Removed client name from keys in sysconfig file
```
MOTR_PROFILE_FID -> MOTR_PROFILE_FID
MOTR_HA_EP -> MOTR_HA_EP 
MOTR_RGW_EP -> MOTR_CLIENT_EP
MOTR_PROCESS_FID -> MOTR_PROCESS_FID
MOTR_RGW_PORT -> MOTR_CLIENT_PORT
```

**Test:**
On VM,
```
[root@ssc-vm-g2-rhev4-2221 cortx-hare]# cat /etc/sysconfig/rgw-0x7200000000000001\:0x2b
MOTR_PROFILE_FID=0x7000000000000001:0x5b
MOTR_CLIENT_EP='inet:tcp:192.168.59.148@5001'
MOTR_HA_EP='inet:tcp:192.168.59.148@2001'
MOTR_PROCESS_FID='0x7200000000000001:0x2b'
MOTR_CLIENT_PORT=28071
```

On server POD,
```
[root@cortx-server-headless-svc-ssc-vm-g2-rhev4-2785 /]# cat /etc/cortx/rgw_s3/sysconfig/b1616a564b424663ae7a0926621656a8/rgw_s3-0x7200000000000001\:0x96
MOTR_PROFILE_FID=0x7000000000000001:0xdb
MOTR_CLIENT_EP='inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2785@5001'
MOTR_HA_EP='inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2785@2001'
MOTR_PROCESS_FID='0x7200000000000001:0x96'
MOTR_CLIENT_PORT=28071
```