### PR TITLE
hctl: fetch-fids command returns un-parseble error string

### DIFF
--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -24,7 +24,7 @@ import json
 import re
 import sys
 from typing import List, NamedTuple, Optional
-
+import logging
 import simplejson
 from hax.types import ObjT
 
@@ -49,8 +49,8 @@ class Node:
                 services.append(svc)
         if services:
             return services
-        print(f'Service {service} not found on node {self.name}.',
-              file=sys.stderr)
+
+        logging.error('No services found')
         return None
 
     def __repr__(self):
@@ -92,8 +92,7 @@ def get_keys_for_processes(data: List) -> List[str]:
             continue
         keys.append(match_result.group(0))
     if not keys:
-        raise RuntimeError(
-            'No ioservice, confd, or s3servers found in the cluster')
+        logging.error('No services found')
     return keys
 
 
@@ -121,7 +120,6 @@ def get_service_for_node(nodes: List[Node], node_name: str,
         if node.name == node_name:
             return node.get_service(service)
 
-    print(f'Node {node_name} not found in cluster.', file=sys.stderr)
     return None
 
 
@@ -136,10 +134,9 @@ def process_all_keys(keys: List, nodes: List[Node]) -> None:
         process_fidk = parts[-3]
         add_service_to_node(nodes, node_name, names[svc_type],
                             to_fid(ObjT.PROCESS.value, int(process_fidk)))
-
     for node in nodes:
         if not node.svcs:
-            raise RuntimeError(
+            logging.error(
                 'No ioservice, confd, or s3servers found on the '
                 f'node {node.name}')
 
@@ -156,9 +153,6 @@ def get_nodes_for_cluster(path: str) -> List[Node]:
     nodes: List[Node] = []
     for n in node_names(file_data):
         nodes.append(Node(n))
-
-    if not nodes:
-        raise RuntimeError('No nodes configured in the cluster')
 
     keys = get_keys_for_processes(file_data)
     process_all_keys(keys, nodes)


### PR DESCRIPTION
If fetch-fids command does not find any of the motr services configured
on a node, it returns an error string, If `hctl fetch-fids` is invoked
though a program, the error string in such a case is not parseble. And
user may not understand if its a valid result or not.

Solution:
Return whatever is configured for a given node, return empty if
nothing is configured.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>