### PR TITLE
EOS-28773: hctl drive-state-set command does not work

### DIFF
--- a/hax/hax/ha/handler/node.py
+++ b/hax/hax/ha/handler/node.py
@@ -23,17 +23,17 @@ from hax.ha.events import Event
 from hax.ha.handler import EventHandler
 from hax.message import BroadcastHAStates
 from hax.motr.planner import WorkPlanner
-from hax.types import HAState, ServiceHealth
+from hax.types import HAState, ObjHealth
 from hax.util import ConsulUtil
 
 LOG = logging.getLogger('hax')
 
 __all__ = ['NodeEventHandler']
 
-status_map: Dict[str, ServiceHealth] = {
-    'online': ServiceHealth.OK,
-    'offline': ServiceHealth.OFFLINE,
-    'failed': ServiceHealth.FAILED,
+status_map: Dict[str, ObjHealth] = {
+    'online': ObjHealth.OK,
+    'offline': ObjHealth.OFFLINE,
+    'failed': ObjHealth.FAILED,
 }
 
 
@@ -68,5 +68,5 @@ class NodeEventHandler(EventHandler):
             ],
                               reply_to=None))
 
-    def _get_status_by_text(self, status: str) -> ServiceHealth:
-        return status_map.get(status, ServiceHealth.UNKNOWN)
+    def _get_status_by_text(self, status: str) -> ObjHealth:
+        return status_map.get(status, ObjHealth.UNKNOWN)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -39,7 +39,7 @@ from hax.motr.planner import WorkPlanner
 from hax.queue import BQProcessor
 from hax.queue.confobjutil import ConfObjUtil
 from hax.queue.offset import InboxFilter, OffsetStorage
-from hax.types import Fid, HAState, ServiceHealth, StoppableThread
+from hax.types import Fid, HAState, ObjHealth, StoppableThread
 from hax.util import ConsulUtil, create_process_fid, dump_json
 from helper.exec import Executor, Program
 LOG = logging.getLogger('hax')
@@ -99,9 +99,9 @@ def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
     if not data:
         return []
 
-    def get_status(checks: List[Dict[str, Any]]) -> ServiceHealth:
+    def get_status(checks: List[Dict[str, Any]]) -> ObjHealth:
         ok = all(x.get('Status') == 'passing' for x in checks)
-        return ServiceHealth.OK if ok else ServiceHealth.FAILED
+        return ObjHealth.OK if ok else ObjHealth.FAILED
 
     return [
         HAState(fid=create_process_fid(int(t['Service']['ID'])),

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -217,39 +217,42 @@ class HaLinkMessagePromise:
         return 'HaLinkMessagePromise' + str(self._ids)
 
 
-class ServiceHealth(Enum):
+class ObjHealth(Enum):
     FAILED = (0, HaNoteStruct.M0_NC_FAILED)
     OK = (1, HaNoteStruct.M0_NC_ONLINE)
     UNKNOWN = (2, HaNoteStruct.M0_NC_UNKNOWN)
     OFFLINE = (3, HaNoteStruct.M0_NC_TRANSIENT)
     STOPPED = (4, HaNoteStruct.M0_NC_TRANSIENT)
+    REPAIR = (5, HaNoteStruct.M0_NC_REPAIR)
+    REPAIRED = (6, HaNoteStruct.M0_NC_REPAIRED)
+    REBALANCE = (7, HaNoteStruct.M0_NC_REBALANCE)
 
     def __repr__(self):
         """Return human-readable constant name (useful in log output)."""
         return self.name
 
     @staticmethod
-    def from_ha_note_state(state: int) -> 'ServiceHealth':
+    def from_ha_note_state(state: int) -> 'ObjHealth':
         """
         Converts the int constant from HaNoteStruct into the corresponding
-        ServiceHealth.
+        ObjHealth.
         """
-        for i in list(ServiceHealth):
+        for i in list(ObjHealth):
             (_, note) = i.value
             if note == state:
                 return i
-        return ServiceHealth.UNKNOWN
+        return ObjHealth.UNKNOWN
 
     def to_ha_note_status(self) -> int:
         """
-        Converts the given ServiceHealth to the most suitable HaNoteStruct
+        Converts the given ObjHealth to the most suitable HaNoteStruct
         status.
         """
         ha_note: int = self.value[1]
         return ha_note
 
 
-HAState = NamedTuple('HAState', [('fid', Fid), ('status', ServiceHealth)])
+HAState = NamedTuple('HAState', [('fid', Fid), ('status', ObjHealth)])
 
 
 class m0HaProcessEvent(IntEnum):
@@ -275,10 +278,10 @@ class m0HaProcessEvent(IntEnum):
 
     def event_to_svchealth(self):
         m0ProcessEvToSvcHealth = {
-            m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTING: ServiceHealth.OK,
-            m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED: ServiceHealth.OK,
-            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING: ServiceHealth.FAILED,
-            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED: ServiceHealth.FAILED}
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTING: ObjHealth.OK,
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED: ObjHealth.OK,
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING: ObjHealth.FAILED,
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED: ObjHealth.FAILED}
         return m0ProcessEvToSvcHealth[self]
 
 

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -37,7 +37,7 @@ from urllib3.exceptions import HTTPError
 from hax.common import HaxGlobalState
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.types import (ConfHaProcess, Fid, FsStatsWithTime,
-                       ObjT, ServiceHealth, Profile, m0HaProcessEvent,
+                       ObjT, ObjHealth, Profile, m0HaProcessEvent,
                        m0HaProcessType, KeyDelete, HaNoteStruct,
                        m0HaObjState)
 
@@ -65,8 +65,8 @@ MotrConsulProcStatus = NamedTuple('MotrConsulProcStatus', [(
                                         ('consul_motr_proc_status', str)])
 
 MotrProcStatusLocalRemote = NamedTuple('MotrProcStatusLocalRemote', [(
-                                'motr_proc_status_local', ServiceHealth),
-                                ('motr_proc_status_remote', ServiceHealth)])
+                                'motr_proc_status_local', ObjHealth),
+                                ('motr_proc_status_remote', ObjHealth)])
 
 
 def mkServiceData(service: Dict[str, Any]) -> ServiceData:
@@ -497,7 +497,7 @@ class ConsulUtil:
     @supports_consul_cache
     def get_m0d_statuses(self,
                          kv_cache=None
-                         ) -> List[Tuple[ServiceData, ServiceHealth]]:
+                         ) -> List[Tuple[ServiceData, ObjHealth]]:
         """
         Return the list of all Motr service statuses according to Consul
         watchers. The following services are considered: ios, confd.
@@ -696,8 +696,8 @@ class ConsulUtil:
             pfid = create_process_fid(fidk)
         proc_node = self.get_process_node(pfid, kv_cache=kv_cache)
         if (self.get_service_health(proc_node, pfid.key, kv_cache=kv_cache) in
-                (ServiceHealth.OK, ServiceHealth.UNKNOWN,
-                 ServiceHealth.OFFLINE)):
+                (ObjHealth.OK, ObjHealth.UNKNOWN,
+                 ObjHealth.OFFLINE)):
             return HaNoteStruct.M0_NC_ONLINE
         else:
             return HaNoteStruct.M0_NC_FAILED
@@ -1058,19 +1058,19 @@ class ConsulUtil:
                 return Fid.parse(encl_fid)
         return None
 
-    def get_device_ha_state(self, status: ServiceHealth) -> str:
+    def get_device_ha_state(self, status: ObjHealth) -> str:
 
         device_ha_state_map = {
-            ServiceHealth.UNKNOWN: m0HaObjState.M0_NC_UNKNOWN,
-            ServiceHealth.OK: m0HaObjState.M0_NC_ONLINE,
-            ServiceHealth.OFFLINE: m0HaObjState.M0_NC_TRANSIENT,
-            ServiceHealth.FAILED: m0HaObjState.M0_NC_FAILED}
+            ObjHealth.UNKNOWN: m0HaObjState.M0_NC_UNKNOWN,
+            ObjHealth.OK: m0HaObjState.M0_NC_ONLINE,
+            ObjHealth.OFFLINE: m0HaObjState.M0_NC_TRANSIENT,
+            ObjHealth.FAILED: m0HaObjState.M0_NC_FAILED}
         return device_ha_state_map[status].name
 
     @repeat_if_fails()
     def set_node_state(self,
                        node_fid: Fid,
-                       status: ServiceHealth,
+                       status: ObjHealth,
                        kv_cache=None) -> None:
         # Example,
         # {
@@ -1095,7 +1095,7 @@ class ConsulUtil:
     @repeat_if_fails()
     def set_encl_state(self,
                        encl_fid: Fid,
-                       status: ServiceHealth,
+                       status: ObjHealth,
                        kv_cache=None) -> None:
         # Example,
         # {
@@ -1121,7 +1121,7 @@ class ConsulUtil:
     @repeat_if_fails()
     def get_ctrl_state_updates(self,
                                ctrl_fid: Fid,
-                               status: ServiceHealth,
+                               status: ObjHealth,
                                kv_cache=None) -> List[PutKV]:
         # Example,
         # {
@@ -1258,13 +1258,16 @@ class ConsulUtil:
     @supports_consul_cache
     def update_drive_state(self,
                            drive_fids: List[Fid],
-                           status: ServiceHealth,
+                           status: ObjHealth,
                            device_event=True,
                            kv_cache=None) -> None:
         device_state_map = {
-            ServiceHealth.OK: 'online',
-            ServiceHealth.FAILED: 'failed',
-            ServiceHealth.OFFLINE: 'offline',
+            ObjHealth.OK: 'online',
+            ObjHealth.FAILED: 'failed',
+            ObjHealth.OFFLINE: 'offline',
+            ObjHealth.REPAIR: 'repairing',
+            ObjHealth.REPAIRED: 'repaired',
+            ObjHealth.REBALANCE: 'rebalancing'
         }
         updates: List[PutKV] = []
         for drive in drive_fids:
@@ -1391,26 +1394,18 @@ class ConsulUtil:
         # We extract the sdev fid as follows,
         # e.g. node_name=ssc-vm-c-0553.colo.seagate.com
         #      drive=/dev/vdf
-        # 1. m0conf/nodes/ssc-vm-c-0553.colo.seagate.com/processes/41/
-        #     services/ios:43
-        # 2. Create ioservice motr fid
-        # 3. fetch consul kv for ios fid,
+        # 1. fetch consul kv for m0conf/nodes recursively,
         #    m0conf/nodes/0x6e00000000000001:0x20/processes/
         #    0x7200000000000001:0x29/services/0x7300000000000001:0x2b/
         #    sdevs/0x6400000000000001:0x2c:
         #    {"path": "/dev/vdf", "state": "M0_NC_UNKNOWN"}
-        # 4. find drive name in the json value and extract sdev fid from the
+        # 2. shortlist the keys having string `sdevs` in them
+        # 3. find drive name in the json value and extract sdev fid from the
         #    key 0x6400000000000001:0x2c
-        # 5. Create sdev fid from sdev fid key.
-        process_items = self.kv.kv_get(f'm0conf/nodes/{node_name}/processes',
-                                       recurse=True)
-        for x in process_items:
-            if '/ios' in x['Key']:
-                fidk_ios = x['Value']
-        ios_fid = create_service_fid(int(fidk_ios))
+        # 4. Create sdev fid from sdev fid key.
         sdev_items = self.kv.kv_get('m0conf/nodes', recurse=True)
         for x in sdev_items:
-            if f'/{ios_fid}/' in x['Key']:
+            if '/sdevs/' in x['Key']:
                 if json.loads(x['Value'])['path'] == drive:
                     # Using constant index 8 for the sdev fid.
                     # Fix this by changing the Consul schema to have
@@ -1477,15 +1472,15 @@ class ConsulUtil:
     # don't report failure if it has completed successfully.
     @uses_consul_cache
     def _check_process_status_node_failure(self, proc_id: int,
-                                           kv_cache=None) -> ServiceHealth:
+                                           kv_cache=None) -> ObjHealth:
         pfid = create_process_fid(proc_id)
         cns_status = self.get_process_status(pfid,
                                              kv_cache=kv_cache)
         if (cns_status.proc_type in
                 (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name,
                  'Unknown')):
-            return ServiceHealth.OFFLINE
-        return ServiceHealth.FAILED
+            return ObjHealth.OFFLINE
+        return ObjHealth.FAILED
 
     # It is tricky to report a correct service status due to various
     # failure conditions. Consul notification can be delayed, the
@@ -1498,7 +1493,7 @@ class ConsulUtil:
     # 3. If systemd status for the motr process is 'failed', corresponding
     #    Consul watcher notifies 'failed'
     # 4. Based on the Consul notification, we also check node status, if
-    #    node status is not 'passing', function returns ServiceHealth.FAILED.
+    #    node status is not 'passing', function returns ObjHealth.FAILED.
     # 5. If node status is 'passing' or 'warning', function checks the motr
     #    status in Consul KV and reports as follows,
     #    Service status      Consul KV                   result
@@ -1516,7 +1511,7 @@ class ConsulUtil:
     def get_service_health(self,
                            node: str,
                            svc_id: int,
-                           kv_cache=None) -> ServiceHealth:
+                           kv_cache=None) -> ObjHealth:
         """
         Returns current status of a Consul service identified by the given
         svc_id for a given node.
@@ -1532,35 +1527,35 @@ class ConsulUtil:
 
         svc_to_motr_status_map = {
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STARTING'):
-            local_remote_health_ret(ServiceHealth.OFFLINE,
-                                    ServiceHealth.OK),
+            local_remote_health_ret(ObjHealth.OFFLINE,
+                                    ObjHealth.OK),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STOPPING'):
-            local_remote_health_ret(ServiceHealth.OFFLINE,
-                                    ServiceHealth.UNKNOWN),
+            local_remote_health_ret(ObjHealth.OFFLINE,
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STARTED'):
-            local_remote_health_ret(ServiceHealth.OK,
-                                    ServiceHealth.OK),
+            local_remote_health_ret(ObjHealth.OK,
+                                    ObjHealth.OK),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STOPPED'):
-            local_remote_health_ret(ServiceHealth.OFFLINE,
-                                    ServiceHealth.UNKNOWN),
+            local_remote_health_ret(ObjHealth.OFFLINE,
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('passing', 'Unknown'):
-            local_remote_health_ret(ServiceHealth.UNKNOWN,
-                                    ServiceHealth.UNKNOWN),
+            local_remote_health_ret(ObjHealth.UNKNOWN,
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('warning', 'M0_CONF_HA_PROCESS_STOPPING'):
-            local_remote_health_ret(ServiceHealth.OFFLINE,
-                                    ServiceHealth.STOPPED),
+            local_remote_health_ret(ObjHealth.OFFLINE,
+                                    ObjHealth.STOPPED),
             cur_consul_status('warning', 'M0_CONF_HA_PROCESS_STARTED'):
-            local_remote_health_ret(ServiceHealth.OFFLINE,
-                                    ServiceHealth.FAILED),
+            local_remote_health_ret(ObjHealth.OFFLINE,
+                                    ObjHealth.FAILED),
             cur_consul_status('warning', 'M0_CONF_HA_PROCESS_STOPPED'):
-            local_remote_health_ret(ServiceHealth.STOPPED,
-                                    ServiceHealth.STOPPED),
+            local_remote_health_ret(ObjHealth.STOPPED,
+                                    ObjHealth.STOPPED),
             cur_consul_status('warning', 'M0_CONF_HA_PROCESS_STARTING'):
-            local_remote_health_ret(ServiceHealth.OFFLINE,
-                                    ServiceHealth.OFFLINE),
+            local_remote_health_ret(ObjHealth.OFFLINE,
+                                    ObjHealth.OFFLINE),
             cur_consul_status('warning', 'Unknown'):
-            local_remote_health_ret(ServiceHealth.UNKNOWN,
-                                    ServiceHealth.UNKNOWN)}
+            local_remote_health_ret(ObjHealth.UNKNOWN,
+                                    ObjHealth.UNKNOWN)}
         try:
             node_data: List[Dict[str, Any]] = self.get_node_health_details(
                 node, kv_cache=kv_cache)
@@ -1572,7 +1567,7 @@ class ConsulUtil:
                     node, kv_cache=kv_cache)):
                 return self._check_process_status_node_failure(
                            svc_id, kv_cache=kv_cache)
-            status = ServiceHealth.UNKNOWN
+            status = ObjHealth.UNKNOWN
             for item in node_data:
                 if item['ServiceID'] == str(svc_id):
                     pfid = create_process_fid(svc_id)
@@ -1583,12 +1578,12 @@ class ConsulUtil:
                         if (cns_status.proc_type in
                             (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name,
                              'Unknown')):
-                            return ServiceHealth.OFFLINE
+                            return ObjHealth.OFFLINE
                         elif (cns_status.proc_status !=
                               'M0_CONF_HA_PROCESS_STOPPED'):
-                            return ServiceHealth.OFFLINE
+                            return ObjHealth.OFFLINE
                         else:
-                            return ServiceHealth.FAILED
+                            return ObjHealth.FAILED
 
                     svc_health = svc_to_motr_status_map[MotrConsulProcStatus(
                                          item['Status'],
@@ -1601,11 +1596,11 @@ class ConsulUtil:
                         status = svc_health.motr_proc_status_local
                     else:
                         status = svc_health.motr_proc_status_remote
-                    if (status != ServiceHealth.OK and
+                    if (status != ObjHealth.OK and
                             cns_status.proc_type in (
                             m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name,
                             'Unknown')):
-                        status = ServiceHealth.OFFLINE
+                        status = ObjHealth.OFFLINE
 
                     # This situation is not expected but we handle
                     # the same. Hax may end up here if the process has stopped
@@ -1614,8 +1609,8 @@ class ConsulUtil:
                     # and will report OFFLINE for that process.
                     if (item['Status'] == 'warning' and
                             cns_status.proc_status == 'Unknown' and
-                            status == ServiceHealth.UNKNOWN):
-                        status = ServiceHealth.OFFLINE
+                            status == ObjHealth.UNKNOWN):
+                        status = ObjHealth.OFFLINE
 
                     return status
         except (ConsulException, HTTPError, RequestException) as e:
@@ -1723,7 +1718,7 @@ class ConsulUtil:
         statuses = self.get_m0d_statuses()
         LOG.debug('The following statuses received: %s', statuses)
         # started = ['M0_CONF_HA_PROCESS_STARTED' == v[1] for v in statuses]
-        started = [ServiceHealth.OK == v[1] for v in statuses]
+        started = [ObjHealth.OK == v[1] for v in statuses]
         return started
 
     @repeat_if_fails()
@@ -1741,12 +1736,12 @@ class ConsulUtil:
         LOG.debug('The following statuses received: %s', statuses)
         # stopping = [v[1] in ('M0_CONF_HA_PROCESS_STOPPING',
         #                      'M0_CONF_HA_PROCESS_STOPPED') for v in statuses]
-        stopping = [v[1] in (ServiceHealth.OFFLINE,
-                             ServiceHealth.STOPPED) for v in statuses]
+        stopping = [v[1] in (ObjHealth.OFFLINE,
+                             ObjHealth.STOPPED) for v in statuses]
         return all(stopping)
 
-    def get_process_current_status(self, status_reported: ServiceHealth,
-                                   proc_fid: Fid) -> ServiceHealth:
+    def get_process_current_status(self, status_reported: ObjHealth,
+                                   proc_fid: Fid) -> ObjHealth:
         status_current = status_reported
         # Reconfirm the process status only if the reported status is FAILED.
         node = self.get_process_node(proc_fid)
@@ -1756,17 +1751,17 @@ class ConsulUtil:
                  node, proc_fid, status_current)
         return status_current
 
-    def svcHealthToM0Status(self, svc_health: ServiceHealth):
+    def svcHealthToM0Status(self, svc_health: ObjHealth):
         svcHealthToM0status: dict = {
-            ServiceHealth.OK: m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
-            ServiceHealth.FAILED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
-            ServiceHealth.UNKNOWN: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
-            ServiceHealth.STOPPED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED
+            ObjHealth.OK: m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
+            ObjHealth.FAILED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
+            ObjHealth.UNKNOWN: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
+            ObjHealth.STOPPED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED
         }
         return svcHealthToM0status[svc_health]
 
     def service_health_to_m0dstatus_update(self, proc_fid: Fid,
-                                           svc_health: ServiceHealth):
+                                           svc_health: ObjHealth):
         ev = ConfHaProcess(chp_event=self.svcHealthToM0Status(svc_health),
                            chp_type=int(
                                 m0HaProcessType.M0_CONF_HA_PROCESS_M0D),
@@ -1783,15 +1778,15 @@ class ConsulUtil:
     @repeat_if_fails()
     def set_process_state(self,
                           process_fid: Fid,
-                          state: ServiceHealth) -> None:
+                          state: ObjHealth) -> None:
         LOG.debug('Setting process=%s in KV with state=%s',
                   process_fid, state)
         process_state_map = {
-            ServiceHealth.OK: 'online',
-            ServiceHealth.FAILED: 'failed',
-            ServiceHealth.OFFLINE: 'offline',
-            ServiceHealth.UNKNOWN: 'unknown',
-            ServiceHealth.STOPPED: 'stopped',
+            ObjHealth.OK: 'online',
+            ObjHealth.FAILED: 'failed',
+            ObjHealth.OFFLINE: 'offline',
+            ObjHealth.UNKNOWN: 'unknown',
+            ObjHealth.STOPPED: 'stopped',
         }
 
         # Example key is as follows

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -31,7 +31,7 @@ from hax.motr import Motr, WorkPlanner
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI
 from hax.types import (Fid, FidStruct, HaNote, HaNoteStruct, HAState, Profile,
-                       ServiceHealth, Uint128)
+                       ObjHealth, Uint128)
 from hax.util import (create_process_fid, create_profile_fid, create_drive_fid,
                       dump_json)
 
@@ -439,7 +439,7 @@ def test_get_nvec_replies_something(
 
     patch(consul_util.catalog, 'get_services', side_effect=my_services)
     patch(consul_util, 'get_node_health_status', return_value='passing')
-    patch(consul_util, 'get_service_health', return_value=ServiceHealth.OK)
+    patch(consul_util, 'get_service_health', return_value=ObjHealth.OK)
 
     msg = HaNvecGetEvent(
         hax_msg=12,
@@ -641,7 +641,7 @@ def test_broadcast_node_failure(mocker, motr, consul_util):
                         return_value=Fid(0x6500000000000001, 0x4))
 
     motr.broadcast_ha_states([
-        HAState(fid=Fid(0x7200000000000001, 0x15), status=ServiceHealth.FAILED)
+        HAState(fid=Fid(0x7200000000000001, 0x15), status=ObjHealth.FAILED)
     ])
 
     traces = motr._ffi.traces
@@ -814,7 +814,7 @@ def test_mkfs_process_stopped_no_disk_marked_offline(mocker, motr,
                         return_value='endpoint')
 
     motr.broadcast_ha_states([
-        HAState(fid=Fid(0x7200000000000001, 0x15), status=ServiceHealth.FAILED)
+        HAState(fid=Fid(0x7200000000000001, 0x15), status=ObjHealth.FAILED)
     ])
 
     assert not consul_util.update_drive_state.called, \
@@ -844,7 +844,7 @@ def test_nonmkfs_process_stop_causes_drive_offline(mocker, motr, consul_util):
                         return_value=Fid(0x6500000000000001, 0x4))
 
     motr.broadcast_ha_states([
-        HAState(fid=Fid(0x7200000000000001, 0x15), status=ServiceHealth.FAILED)
+        HAState(fid=Fid(0x7200000000000001, 0x15), status=ObjHealth.FAILED)
     ])
 
     assert consul_util.update_drive_state.called, \
@@ -998,7 +998,7 @@ def test_broadcast_io_service_failure(mocker, planner, motr, consumer,
                         return_value=Fid(0x6500000000000001, 0x4))
 
     motr.broadcast_ha_states([
-        HAState(fid=Fid(0x7200000000000001, 0x15), status=ServiceHealth.FAILED)
+        HAState(fid=Fid(0x7200000000000001, 0x15), status=ObjHealth.FAILED)
     ])
 
     traces = motr._ffi.traces
@@ -1184,7 +1184,7 @@ def test_broadcast_more_than_1024_objects(mocker, planner, motr, consumer,
                         return_value=_generate_sub_disks())
 
     motr.broadcast_ha_states([
-        HAState(fid=Fid(0x7200000000000001, 0x15), status=ServiceHealth.FAILED)
+        HAState(fid=Fid(0x7200000000000001, 0x15), status=ObjHealth.FAILED)
     ])
 
     traces = motr._ffi.traces

--- a/hax/test/integration/test_server.py
+++ b/hax/test/integration/test_server.py
@@ -28,7 +28,7 @@ from hax.message import BroadcastHAStates, StobId, StobIoqError
 from hax.motr import WorkPlanner
 from hax.motr.delivery import DeliveryHerald
 from hax.server import ServerRunner
-from hax.types import Fid, HAState, MessageId, ServiceHealth
+from hax.types import Fid, HAState, MessageId, ObjHealth
 from hax.util import dump_json
 
 
@@ -79,11 +79,11 @@ async def test_hello_works(hax_client):
     assert text == "I'm alive! Sincerely, HaX"
 
 
-@pytest.mark.parametrize('status,health', [('passing', ServiceHealth.OK),
-                                           ('warning', ServiceHealth.FAILED),
-                                           ('critical', ServiceHealth.FAILED)])
+@pytest.mark.parametrize('status,health', [('passing', ObjHealth.OK),
+                                           ('warning', ObjHealth.FAILED),
+                                           ('critical', ObjHealth.FAILED)])
 async def test_service_health_broadcast(hax_client, planner, status: str,
-                                        health: ServiceHealth):
+                                        health: ObjHealth):
     service_health = [{
         'Node': {
             'Node': 'localhost',
@@ -170,7 +170,7 @@ async def test_bq_stob_message_type_recognized(hax_client, planner, herald,
     assert resp.status == 200
     planner.add_command.assert_called_once_with(
         ContainsStates(
-            [HAState(fid=Fid(0x1, 0x4), status=ServiceHealth.FAILED)]))
+            [HAState(fid=Fid(0x1, 0x4), status=ObjHealth.FAILED)]))
 
 
 async def test_bq_stob_message_deserialized(hax_client, planner, herald,
@@ -223,4 +223,4 @@ async def test_bq_stob_message_deserialized(hax_client, planner, herald,
     assert resp.status == 200
     planner.add_command.assert_called_once_with(
         ContainsStates(
-            [HAState(fid=Fid(0x103, 0x204), status=ServiceHealth.FAILED)]))
+            [HAState(fid=Fid(0x103, 0x204), status=ObjHealth.FAILED)]))

--- a/hax/test/test_types.py
+++ b/hax/test/test_types.py
@@ -16,24 +16,29 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 import pytest
-from hax.types import HaNoteStruct, ServiceHealth
+from hax.types import HaNoteStruct, ObjHealth
 
 h = HaNoteStruct
-s = ServiceHealth
+o = ObjHealth
 
 
-@pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, s.OK),
-                                            (h.M0_NC_FAILED, s.FAILED),
-                                            (h.M0_NC_TRANSIENT, s.OFFLINE),
-                                            (h.M0_NC_UNKNOWN, s.UNKNOWN)])
-def test_service_health_to_ha_note(ha_note: int, health: ServiceHealth):
+@pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, o.OK),
+                                            (h.M0_NC_FAILED, o.FAILED),
+                                            (h.M0_NC_TRANSIENT, o.OFFLINE),
+                                            (h.M0_NC_UNKNOWN, o.UNKNOWN),
+                                            (h.M0_NC_REPAIR, o.REPAIR),
+                                            (h.M0_NC_REPAIRED, o.REPAIRED),
+                                            (h.M0_NC_REBALANCE, o.REBALANCE)])
+def test_obj_health_to_ha_note(ha_note: int, health: ObjHealth):
     assert ha_note == health.to_ha_note_status()
 
 
-@pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, s.OK),
-                                            (h.M0_NC_FAILED, s.FAILED),
-                                            (h.M0_NC_TRANSIENT, s.OFFLINE),
-                                            (h.M0_NC_UNKNOWN, s.UNKNOWN),
-                                            (h.M0_NC_REPAIRED, s.UNKNOWN)])
-def test_ha_note_to_service_health_works(ha_note: int, health: ServiceHealth):
-    assert ServiceHealth.from_ha_note_state(ha_note) == health
+@pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, o.OK),
+                                            (h.M0_NC_FAILED, o.FAILED),
+                                            (h.M0_NC_TRANSIENT, o.OFFLINE),
+                                            (h.M0_NC_UNKNOWN, o.UNKNOWN),
+                                            (h.M0_NC_REPAIR, o.REPAIR),
+                                            (h.M0_NC_REPAIRED, o.REPAIRED),
+                                            (h.M0_NC_REBALANCE, o.REBALANCE)])
+def test_ha_note_to_obj_health_works(ha_note: int, health: ObjHealth):
+    assert ObjHealth.from_ha_note_state(ha_note) == health

--- a/utils/hare-drive-state
+++ b/utils/hare-drive-state
@@ -38,8 +38,10 @@ Options:
                           "node" : "ssc-vm-c-0553.colo.seagate.com",
                           "source_type" : "drive",
                           "device" : "/dev/vdb"
-                          "state" : "FAILED",
+                          "state" : "failed",
                         }
+                        supported states: online, failed, offline,
+                                          repairing, repaired, rebalancing
   -h, --help            Show this help and exit.
 EOF
 }


### PR DESCRIPTION
hctl drive-state-set command is used to explicitly transition
motr storage drive objects. Presently the command fails to
apply sns drive state changes due to wrongly parsing the consul
kv to fetch sdev fid corresponding to the drive.

Solution:
- Update consul kv parsing to fetch sdev fid corresponding to the
drive.
- Handle SNS state transitions as well.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>