### PR TITLE
CORTX-27237: Collect bytecount data from Motr and store in consul

### DIFF
--- a/hax/hax/bytecount.py
+++ b/hax/hax/bytecount.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,21 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-import datetime
 import logging
 from threading import Event
-
+from typing import List, Tuple
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
-from hax.types import FsStatsWithTime, StoppableThread
+from hax.types import ByteCountStats, Fid, ObjHealth, StoppableThread
 from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
 
 
-class FsStatsUpdater(StoppableThread):
+class ByteCountUpdater(StoppableThread):
     def __init__(self, motr: Motr, consul_util: ConsulUtil, interval_sec=5):
         super().__init__(target=self._execute,
-                         name='fs-stats-updater',
+                         name='byte-count-updater',
                          args=(motr, ))
         self.stopped = False
         self.consul = consul_util
@@ -46,30 +45,31 @@ class FsStatsUpdater(StoppableThread):
     @log_exception
     def _execute(self, motr: Motr):
         try:
-            LOG.info('filesystem stats updater thread has started')
+            LOG.info('byte-count updater thread has started')
             while not self.stopped:
                 if not self.consul.am_i_rc():
                     wait_for_event(self.event, self.interval_sec)
                     continue
-                if (not motr.is_spiel_ready() or (
-                        not all(self.consul.ensure_ioservices_running()))):
+                if not motr.is_spiel_ready():
                     wait_for_event(self.event, self.interval_sec)
                     continue
-                stats = motr.get_filesystem_stats()
-                if not stats:
-                    continue
-                LOG.debug('FS stats are as follows: %s', stats)
-                now_time = datetime.datetime.now()
-                data = FsStatsWithTime(stats=stats,
-                                       timestamp=now_time.timestamp(),
-                                       date=now_time.isoformat())
-                try:
-                    self.consul.update_fs_stats(data)
-                except HAConsistencyException:
-                    LOG.debug('Failed to update Consul KV '
-                              'due to an intermittent error. The '
-                              'error is swallowed since new attempts '
-                              'will be made timely')
+                processes: List[Tuple[Fid, ObjHealth]] = \
+                    self.consul.get_proc_fids_with_status(['ios'])
+                for ios, status in processes:
+                    if status == ObjHealth.OK:
+                        byte_count: ByteCountStats = motr.get_proc_bytecount(
+                            ios)
+                        LOG.debug('Received bytecount: %s', byte_count)
+                        if not byte_count:
+                            continue
+                        try:
+                            self.consul.update_pver_bc(byte_count)
+                        except HAConsistencyException:
+                            LOG.debug('Failed to update Consul KV '
+                                      'due to an intermittent error. The '
+                                      'error is swallowed since new attempts '
+                                      'will be made timely')
+
                 wait_for_event(self.event, self.interval_sec)
         except InterruptedException:
             # No op. _sleep() has interrupted before the timeout exceeded:
@@ -79,4 +79,4 @@ class FsStatsUpdater(StoppableThread):
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:
-            LOG.debug('filesystem stats updater thread exited')
+            LOG.debug('byte-count updater thread exited')

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -22,6 +22,7 @@ import logging
 import re
 import signal
 from typing import List, NamedTuple
+from hax.bytecount import ByteCountUpdater
 
 import inject
 
@@ -62,6 +63,11 @@ def _run_qconsumer_thread(planner: WorkPlanner, motr: Motr,
 def _run_stats_updater_thread(motr: Motr,
                               consul_util: ConsulUtil) -> StoppableThread:
     return _run_thread(FsStatsUpdater(motr, consul_util, interval_sec=30))
+
+
+def _run_bc_updater_thread(motr: Motr,
+                           consul_util: ConsulUtil) -> StoppableThread:
+    return _run_thread(ByteCountUpdater(motr, consul_util, interval_sec=30))
 
 
 @repeat_if_fails()
@@ -180,6 +186,7 @@ def main():
         rconfc_starter = _run_rconfc_starter_thread(motr, consul_util=util)
 
         stats_updater = _run_stats_updater_thread(motr, consul_util=util)
+        bc_updater = _run_bc_updater_thread(motr, consul_util=util)
         event_poller = _run_thread(create_ha_thread(planner, util))
         # [KN] This is a blocking call. It will work until the program is
         # terminated by signal
@@ -189,7 +196,8 @@ def main():
                               consul_util=util,
                               hax_state=state)
         server.run(threads_to_wait=[
-            *consumer_threads, stats_updater, rconfc_starter, event_poller
+            *consumer_threads, stats_updater, bc_updater, rconfc_starter,
+            event_poller
         ])
     except Exception:
         LOG.exception('Exiting due to an exception')

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -32,7 +32,7 @@ from hax.motr.planner import WorkPlanner
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
                        MessageId, ObjT, Profile, PverState, ReprebStatus,
-                       ServiceHealth, m0HaProcessEvent, m0HaProcessType)
+                       ObjHealth, m0HaProcessEvent, m0HaProcessType)
 from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
 
 LOG = logging.getLogger('hax')

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -36,7 +36,7 @@ from urllib3.exceptions import HTTPError
 
 from hax.common import HaxGlobalState
 from hax.exception import HAConsistencyException, InterruptedException
-from hax.types import (ConfHaProcess, Fid, FsStatsWithTime,
+from hax.types import (ByteCountStats, ConfHaProcess, Fid, FsStatsWithTime,
                        ObjT, ObjHealth, Profile, m0HaProcessEvent,
                        m0HaProcessType, KeyDelete, HaNoteStruct,
                        m0HaObjState)
@@ -487,6 +487,13 @@ class ConsulUtil:
             raise HAConsistencyException('Failed to communicate to'
                                          ' Consul Agent') from e
 
+    def am_i_rc(self) -> Any:
+        # The call is already marked with @repeat_if_fails
+        leader = self.get_leader_node()
+        # The call doesn't communicate via Consul REST API
+        this_node = self.get_local_nodename()
+        return leader == this_node
+
     def get_svc_status(self, srv_fid: Fid, kv_cache=None) -> str:
         try:
             return self.get_process_status(srv_fid,
@@ -496,16 +503,18 @@ class ConsulUtil:
 
     @supports_consul_cache
     def get_m0d_statuses(self,
+                         motr_services=None,
                          kv_cache=None
                          ) -> List[Tuple[ServiceData, ObjHealth]]:
         """
         Return the list of all Motr service statuses according to Consul
-        watchers. The following services are considered: ios, confd.
+        watchers.The following services are considered [default]: ios, confd.
         """
-        m0d_services = set(['ios', 'confd'])
+        if not motr_services:
+            motr_services = set(['ios', 'confd'])
         result = []
         for service_name in self.catalog.get_service_names():
-            if service_name not in m0d_services:
+            if service_name not in motr_services:
                 continue
             data = self.get_service_data_by_name(service_name)
             LOG.debug('svc data: %s', data)
@@ -524,6 +533,18 @@ class ConsulUtil:
 
     def get_confd_list(self) -> List[ServiceData]:
         return self.get_service_data_by_name('confd')
+
+    def get_proc_fids_with_status(self,
+                                  proc_names: List[str]
+                                  ) -> List[Tuple[Fid, ObjHealth]]:
+        """
+        Fetches all the process fids and their statuses across the cluster
+        for a given process name.
+        """
+        statuses = self.get_m0d_statuses(proc_names)
+        LOG.debug('The following statuses received for %s: %s',
+                  proc_names, statuses)
+        return [(item.fid, status) for item, status in statuses]
 
     @uses_consul_cache
     def get_services_by_parent_process(self,
@@ -1238,6 +1259,24 @@ class ConsulUtil:
         # all the cases
         data_str = simplejson.dumps(stats_data)
         self.kv.kv_put('stats/filesystem', data_str)
+
+    def update_pver_bc(self, data: ByteCountStats) -> None:
+        """
+        Updates bytecount stats per pool versions for all pvers
+        under the ios service in consul kv.
+        Example: key= ioservices/0x7200000000000001:0xf/pvers/
+                      0x7600000000000001:0x8/users/1
+        value = {"bc":4096, "object_cnt":1}
+        """
+        ios_fid = data.proc_fid
+        for pver in data.pvers:
+            value = json.dumps({'bc': pver.byte_count,
+                                'object_cnt': pver.object_count})
+
+            key = f'ioservices/{ios_fid}/pvers/{pver.pver_fid}/' \
+                f'users/{pver.user_id}'
+            LOG.debug('Setting bytecount stats in KV: %s:%s', key, value)
+            self.kv.kv_put(key, value)
 
     @repeat_if_fails()
     def update_process_status(self, event: ConfHaProcess) -> None:


### PR DESCRIPTION
Currently, we have motr apis to fetch the bytecount from motr land.
We need to use these apis and update the byte count of pool versions
in Consul in regular intervals.

Solution:
- Created a separate bytecount updater thread similar to fsStatsUpdater
  which updates bytecount information at regular intervals and stores
  it consul KV.


Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>