### PR TITLE
CORTX-28823: consul client agent status is not updated

### DIFF
--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -1,5 +1,6 @@
 {
   "enable_local_script_checks": true,
+  "leave_on_terminate": true,
   "watches": [
     {
       "type": "service",


### PR DESCRIPTION
Problem:

If a consul client agent, started with hax process, is shutdown abruptly
and restarted within 7-10 seconds, consul is not able to detect the
failure and thus, does not evict the failed agent. Additionally, if
the corresponding node, when restarted, maintains the same name but
different ip address, consul thinks its the same agent but since the
corresponding ip address saved is different from the newly assigned
ipaddress, consul is not able to communicate with the restarted client
agent.

Solution:

Consul client agent must be configured with `leave_on_terminate` set
to `true`. This allows Consul to gracefully evict the consul agent
whenever the agent shuts down, thus updating its status in consul quorum.

Signed-off-by: Suvrat Joshi <suvrat.joshi@seagate.com>