### PR TITLE
CORTX-25823: nvec reply does not contain process real status

### DIFF
--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -48,7 +48,7 @@ class FsStatsUpdater(StoppableThread):
         try:
             LOG.info('filesystem stats updater thread has started')
             while not self.stopped:
-                if not self._am_i_rc():
+                if not self.consul.am_i_rc():
                     wait_for_event(self.event, self.interval_sec)
                     continue
                 if (not motr.is_spiel_ready() or (
@@ -80,10 +80,3 @@ class FsStatsUpdater(StoppableThread):
             LOG.exception('Aborting due to an error')
         finally:
             LOG.debug('filesystem stats updater thread exited')
-
-    def _am_i_rc(self):
-        # The call is already marked with @repeat_if_fails
-        leader = self.consul.get_leader_node()
-        # The call doesn't communicate via Consul REST API
-        this_node = self.consul.get_local_nodename()
-        return leader == this_node

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -116,62 +116,72 @@ class ConsumerThread(StoppableThread):
                                ha_states: List[HAState]) -> List[HAState]:
         new_ha_states: List[HAState] = []
         for state in ha_states:
-            # We are only concerned with process statuses.
             if state.fid.container == ObjT.PROCESS.value:
                 current_status = self.consul.get_process_current_status(
                     state.status, state.fid)
-                if current_status == ObjHealth.OK:
-                    if (self.consul.get_process_local_status(
-                            state.fid) == 'M0_CONF_HA_PROCESS_STARTED'):
-                        continue
-                if current_status in (ObjHealth.FAILED,
-                                      ObjHealth.STOPPED):
-                    if (self.consul.get_process_local_status(
-                            state.fid) == 'M0_CONF_HA_PROCESS_STOPPED'):
-                        # Consul may report failure of a process multiple
-                        # times, so we don't want to send duplicate failure
-                        # notifications, it may cause delay in cleanup
-                        # activities.
-                        continue
-                # XXX:
-                # Sometime, there can be situation where Consul event is sent
-                # and can be delayed, where state reported by Consul for a
-                # given process can be in its past already, e.g. consul
-                # reported process failure but when hax received the event,
-                # process might have already restarted. In this case the event
-                # still needs to be handled. Also, it is possible that Consul
-                # reported failure but process status is not yet updated in
-                # Consul services catalog, in such a case the reported status
-                # can be true and cannot be just dropped. These scenarios must
-                # be re-visited.
-                if current_status not in (ObjHealth.UNKNOWN,
-                                          ObjHealth.OFFLINE):
-                    # We also need to account and report the failure of remote
-                    # Motr processes to this node's hax and motr processes.
-                    # When Consul reports a remote process failure, hax
-                    # confirms its current status from Consul KV and updates
-                    # the list of failed services and also adds it to the
-                    # broadcast list.
-                    proc_status_saved = self.consul.get_process_status(
-                                            state.fid)
-                    proc_type = m0HaProcessType.str_to_Enum(
-                        proc_status_saved.proc_type)
-                    if current_status != ObjHealth.OK:
+                proc_status_remote = self.consul.get_process_status(
+                                         state.fid)
+                # MKFS states are upated by the node corresponding to a
+                # given process. So we ignore notifications for mkfs
+                # processes.
+                if proc_status_remote.proc_type in (
+                        'Unknown',
+                        str(m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS)):
+                    continue
+                proc_type = m0HaProcessType.str_to_Enum(
+                     proc_status_remote.proc_type)
+                # Consul reports process failure, if that process died
+                # abruptly, its corresponding status might not have been
+                # persisted. Thus, its the RC's responsibility to update
+                # its status. So, we check the current status of the
+                # process and if the status was persisted, if not then RC
+                # will do it.
+                # Corressponding process ONLINE event will be updated when
+                # the process notifies so to Hare.
+                if (current_status == ObjHealth.OFFLINE and (
+                        proc_status_remote.proc_status !=
+                        'M0_CONF_HA_PROCESS_STOPPED')):
+                    if self.consul.am_i_rc():
                         proc_status = (
                             m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED)
-                    else:
+                        self.consul.update_process_status(
+                            ConfHaProcess(chp_event=proc_status,
+                                          chp_type=proc_type,
+                                          chp_pid=0,
+                                          fid=state.fid))
+                        new_ha_states.append(
+                            HAState(fid=state.fid, status=current_status))
+                    continue
+                if not self.consul.is_proc_local(state.fid):
+                    proc_status_local = self.consul.get_process_status_local(
+                                            state.fid)
+                    # Consul monitors a process every 1 second and this
+                    # notification is sent to every node. Thus to avoid
+                    # notifying about a process multiple times about the
+                    # same status every node maintains a local copy of the
+                    # remote process status, which is checked everytime a
+                    # consul notification is received and accordingly
+                    # the status is notified locally to all the local motr
+                    # processes.
+                    if (current_status == ObjHealth.OK and
+                            (proc_status_local.proc_status !=
+                             'M0_CONF_HA_PROCESS_STARTED')):
                         proc_status = (
                             m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED)
-
-                        LOG.debug('update process failure')
-                        self.consul.update_process_status(
-                            ConfHaProcess(
-                                chp_event=proc_status,
-                                chp_type=proc_type,
-                                chp_pid=0,
-                                fid=state.fid))
-                new_ha_states.append(
-                    HAState(fid=state.fid, status=current_status))
+                    elif current_status == ObjHealth.OFFLINE:
+                        if (proc_status_local.proc_status !=
+                                'M0_CONF_HA_PROCESS_STOPPED'):
+                            proc_status = (
+                                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED)
+                    else:
+                        continue
+                    self.consul.update_process_status_local(
+                        ConfHaProcess(chp_event=proc_status,
+                                      chp_type=proc_type,
+                                      chp_pid=0,
+                                      fid=state.fid))
+                    new_ha_states.append(
+                        HAState(fid=state.fid, status=current_status))
             else:
                 new_ha_states.append(state)
         return new_ha_states

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -298,9 +298,11 @@ class Motr:
                 else HaNoteStruct.M0_NC_FAILED
 
         def _update_process_tree(proc_fid: Fid, state: ObjHealth) -> bool:
-            return (st.status in (ObjHealth.FAILED, ObjHealth.OK) and
+            return (st.status in (ObjHealth.FAILED, ObjHealth.OK,
+                                  ObjHealth.OFFLINE) and
                     not self.consul_util.is_proc_client(st.fid) and
                     not broadcast_hax_only and
+                    not self._is_mkfs(proc_fid) and
                     proc_fid != hax_fid)
 
         hax_fid = self.consul_util.get_hax_fid()
@@ -342,8 +344,8 @@ class Motr:
                 # If both the above conditions are not true then we will just
                 # mark controller status
                 is_node_failed = self.is_node_failed(note, kv_cache=kv_cache)
-                if (st.status == ObjHealth.FAILED
-                        and is_node_failed):
+                if (st.status in (ObjHealth.FAILED, ObjHealth.OFFLINE) and
+                        is_node_failed):
                     notes += self.notify_node_status_by_process(
                         note, kv_cache=kv_cache)
                 elif (st.status == ObjHealth.OK

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -54,6 +54,26 @@ ObjT = Enum(
 ObjT.__doc__ = 'Motr conf object types and their m0_fid.f_container values'
 
 
+FidTypeToObjT = {
+    0x7200000000000001: ObjT.PROCESS,
+    0x7300000000000001: ObjT.SERVICE,
+    0x6400000000000001: ObjT.SDEV,
+    0x6b00000000000001: ObjT.DRIVE,
+    0x7000000000000001: ObjT.PROFILE,
+    0x6a00000000000001: ObjT.OBJV,
+    0x6e00000000000001: ObjT.NODE,
+    0x5300000000000001: ObjT.SITE,
+    0x6100000000000001: ObjT.RACK,
+    0x6500000000000001: ObjT.ENCLOSURE,
+    0x6300000000000001: ObjT.CONTROLLER,
+    0x7400000000000001: ObjT.ROOT,
+    0x6f00000000000001: ObjT.POOL,
+    0x7600000000000001: ObjT.PVER,
+    0x6c00000000000001: ObjT.FDMI_FILTER,
+    0x6700000000000001: ObjT.FDMI_FLT_GRP
+}
+
+
 class HaNoteStruct(c.Structure):
     # Constants for no_state field values as they are described in ha/note.h
 


### PR DESCRIPTION
Eventhough hare reports process failure (offline) the same is
not updated in consul kv. Thus, while preparing nvec reply,
correct status of the failed process is not reported.

Solution:
- notify offline(M0_NC_TRANSIENT) on process failure instead of
failed(M0_NC_FAILED).
- Update failure of a peer motr process in consul kv through Hare
recovery co-ordinator.
- Read the process status from consul kv.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>