### PR TITLE
CORTX-27238: Categorise bytecount based on pool version state

### DIFF
--- a/hax/hax/bytecount.py
+++ b/hax/hax/bytecount.py
@@ -18,10 +18,11 @@
 
 import logging
 from threading import Event
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
-from hax.types import ByteCountStats, Fid, ObjHealth, StoppableThread
+from hax.types import (ByteCountStats, Fid, ObjHealth, PverState,
+                       StoppableThread)
 from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
@@ -42,6 +43,28 @@ class ByteCountUpdater(StoppableThread):
         self.stopped = True
         self.event.set()
 
+    def _get_pver_with_pver_status(self,
+                                   motr: Motr) -> Optional[
+                                       Dict[str, PverState]]:
+        '''
+        Getting a dictionary value of pver and it's state like below example:
+        Ex: {'0x7600000000000001:0x8': PverState.M0_CPS_CRITICAL,
+             '0x7600000000000001:0x9': PverState.M0_CPS_HEALTHY
+            }
+        Pver data is stored in consul kv in format
+        key = ioservices/0x7200000000000001:0x20/pvers/
+              0x7600000000000001:0x6/users/1
+        value = {"bc": 4096, "object_cnt": 1}
+        '''
+        iosservice_items = self.consul.kv.kv_get('ioservices/', recurse=True)
+        pver_items = {}
+        if iosservice_items:
+            for k in iosservice_items:
+                p_ver = k['Key'].split('/')[3]
+                pver_items[p_ver] = motr.get_pver_status(Fid.parse(p_ver))
+            LOG.debug('Received pool version and status: %s', pver_items)
+        return pver_items
+
     @log_exception
     def _execute(self, motr: Motr):
         try:
@@ -55,6 +78,8 @@ class ByteCountUpdater(StoppableThread):
                     continue
                 processes: List[Tuple[Fid, ObjHealth]] = \
                     self.consul.get_proc_fids_with_status(['ios'])
+                if not processes:
+                    continue
                 for ios, status in processes:
                     if status == ObjHealth.OK:
                         byte_count: ByteCountStats = motr.get_proc_bytecount(
@@ -71,6 +96,11 @@ class ByteCountUpdater(StoppableThread):
                                       'will be made timely')
 
                 wait_for_event(self.event, self.interval_sec)
+
+                pver_items = self._get_pver_with_pver_status(motr)
+                if not pver_items:
+                    continue
+                self.consul.update_bc_for_dg_category(pver_items)
         except InterruptedException:
             # No op. _sleep() has interrupted before the timeout exceeded:
             # the application is shutting down.

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -29,7 +29,7 @@
 #include "fid/fid.h"		/* M0_FID_TINIT */
 #include "ha/halon/interface.h" /* m0_halon_interface */
 #include "spiel/spiel.h"	/* m0_spiel, m0_spiel_filesystem_stats_fetch */
-#include "conf/pvers.h"
+#include "conf/pvers.h"		 /* m0_conf_pver_info, m0_conf_pver_state */
 #include "module/instance.h"
 #include "lib/assert.h"   /* M0_ASSERT */
 #include "lib/memory.h"   /* M0_ALLOC_ARR */
@@ -222,21 +222,21 @@ PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
 
 	struct m0_proc_counter count_stats;
 	int rc;
-	// call the motr api
+	/* call the motr api */
 	Py_BEGIN_ALLOW_THREADS rc =
 	    m0_spiel_proc_counters_fetch(spiel, proc_fid, &count_stats);
 	Py_END_ALLOW_THREADS if (rc != 0)
 	{
 		PyGILState_Release(gstate);
-		// This returns None python object (which is a singleton)
-		// properly with respect to reference counters.
+		/* This returns None python object (which is a singleton)
+		   properly with respect to reference counters. */
 		Py_RETURN_NONE;
 	}
 
 	PyObject *hax_mod = getModule("hax.types");
 	PyObject *py_fid = toFid(&count_stats.pc_proc_fid);
 	int len = count_stats.pc_cnt;
-	// Fetch all byte count stats per pver.
+	/* Fetch all byte count stats per pver. */
 	PyObject *list = PyList_New(len);
 	int i;
 	for (i = 0; i < len; ++i) {
@@ -271,29 +271,28 @@ int m0_ha_pver_status(unsigned long long ctx,
 {
 	PyGILState_STATE gstate;
 	gstate = PyGILState_Ensure();
-	// TODO use motr spiel API for fetching pver_status.
-	/*
+
 	struct hax_context *hc = (struct hax_context *)ctx;
 	struct m0_halon_interface *hi = hc->hc_hi;
 	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
-	struct m0_confc *confc = spiel->spl_core.spc_confc;
+
 	struct m0_conf_pver_info pver_info;
 
 	int rc;
-	// call the motr api
+	/* call the motr api */
 	Py_BEGIN_ALLOW_THREADS rc =
-	    m0_conf_pver_status(pver_fid, confc, &pver_info);
+	    m0_spiel_conf_pver_status(spiel, pver_fid, &pver_info);
 	Py_END_ALLOW_THREADS if (rc != 0)
 	{
 		PyGILState_Release(gstate);
-		// This returns error code.
+		/* This returns error code. */
 		return M0_ERR(rc);
 	}
 	M0_LOG(M0_INFO, "FID:"FID_F", Status:%d",
 		FID_P(&pver_info.cpi_fid), pver_info.cpi_state);
-	enum m0_conf_pver_state status  = pver_info.cpi_state;*/
+	enum m0_conf_pver_state status  = pver_info.cpi_state;
 	PyGILState_Release(gstate);
-	return 2;
+	return status;
 }
 
 static void handle_failvec(const struct hax_msg *hm)

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -37,7 +37,7 @@ from urllib3.exceptions import HTTPError
 from hax.common import HaxGlobalState
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FsStatsWithTime,
-                       ObjT, ObjHealth, Profile, m0HaProcessEvent,
+                       ObjT, ObjHealth, Profile, PverState, m0HaProcessEvent,
                        m0HaProcessType, KeyDelete, HaNoteStruct,
                        m0HaObjState)
 
@@ -1277,6 +1277,40 @@ class ConsulUtil:
                 f'users/{pver.user_id}'
             LOG.debug('Setting bytecount stats in KV: %s:%s', key, value)
             self.kv.kv_put(key, value)
+
+    def update_bc_for_dg_category(self,
+                                  pver_items: Dict[str, PverState]) -> None:
+        '''
+        This function will update bytecount for subsequent dg state/category
+        which will reflect on cluster status.
+        Bytecount data is stored in consul KV in key:value format
+        ioservices/0x7200000000000001:0x20/pvers/0x7600000000000001:0x6/users/1
+        value = {"bc": 4096, "object_cnt": 1}
+        '''
+        pool_ver = self.kv.kv_get('ioservices/', recurse=True)
+        pver_state_map = {
+            PverState.M0_CPS_HEALTHY: 'healthy_byte_count',
+            PverState.M0_CPS_DEGRADED: 'degraded_byte_count',
+            PverState.M0_CPS_CRITICAL: 'critical_byte_count',
+            PverState.M0_CPS_DAMAGED: 'damaged_byte_count'
+        }
+        # Calculate total bytecount per pver and store it based on its status.
+        data: Dict[PverState, int] = {}
+        for pver, status in pver_items.items():
+            total_bc = 0
+            for pool in pool_ver:
+                if pver in pool['Key']:
+                    total_bc += json.loads(pool['Value'].decode())['bc']
+            LOG.debug('pool version : %s  total_bytecount : %s  Status : %s',
+                      pver, total_bc, pver_state_map[status])
+            if status in data:
+                data[status] += total_bc
+            else:
+                data[status] = total_bc
+        # Populate the consul kv with total bytecount based on state.
+        for state in pver_state_map:
+            self.kv.kv_put(f'bytecount/{pver_state_map[state]}',
+                           json.dumps(data.get(state, 0)))
 
     @repeat_if_fails()
     def update_process_status(self, event: ConfHaProcess) -> None:


### PR DESCRIPTION
```
Based on pool version state for each pool version, it would require to
calculate degraded, critical and healthy bytecounts.

1. _get_pver_with_pver_status() in bytecount.py
   Getting a dictionary value of pver and it's state like below
        Ex: {'0x7600000000000001:0x8': PverState.M0_CPS_CRITICAL,
             '0x7600000000000001:0x9': PverState.M0_CPS_HEALTHY
            }

2. update_bc_for_dg_category in util.py
   which will update aggreagate bytecount value for each pool on consul.
   This function will update bytecount for subsequent dg state/category
   which must reflect on cluster status.
```

Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>