### PR TITLE
CORTX-28881 Hare needs to stop using 'cortx>common>setup_type' as it is not available anymore

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2272,7 +2272,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('bytecount/degraded_byte_count', 0),
         ('bytecount/critical_byte_count', 0),
         ('bytecount/damaged_byte_count', 0),
-        ('m0_client_types', cluster.m0_client_types),
+        ('m0_client_types', json.dumps(cluster.m0_client_types)),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node
                                                   and node.machine_id)],

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -189,8 +189,8 @@ nodes:
           data: [ <str> ]   # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
                             # Empty list means no IO service.
     m0_clients:
-        s3: <int>     # number of S3 servers to start
-        other: <int>  # max quantity of other Motr clients this host may have
+        - name: <str>      # name of the motr client to start(e.g. s3, rgw)
+          instances: <int> # number of client instances to start
 pools:
   - name: <str>
     type: sns|dix|md   # optional, defaults to "sns";
@@ -499,8 +499,13 @@ Make sure the value of data_iface in the CDF is correct.""")
                 f'Node {name}: The same disk is used by several IO services')
         total_nr_disks += len(disks)
 
+        nr_clients = 0
+        if 'm0_clients' in node and node['m0_clients'] is not None:
+            for client in node['m0_clients']:
+                nr_clients += client['instances']
+
         _assert(
-            nr_confds + node['m0_clients']['s3'] + node['m0_clients']['other']
+            nr_confds + nr_clients
             > 0, f'Node {name}: At least one Motr server or '
             'client is required')
 
@@ -1048,13 +1053,15 @@ class ConfProcess(ToDhall):
 
     def __init__(self, nr_cpu: int, memsize_MB: int,
                  endpoint,
-                 services: List[Oid], meta_data: str = None):
+                 services: List[Oid], meta_data: str = None,
+                 proc_name: str = None):
         _assert(nr_cpu > 0, 'nr_cpu must be positive')
         self.nr_cpu = nr_cpu
         _assert(memsize_MB > 0, 'memsize_MB must be positive')
         self.memsize_MB = memsize_MB
         self.endpoint = endpoint
         self.meta_data = meta_data
+        self.proc_name = proc_name
         _assert(all(x.type is ObjT.service for x in services),
                 'All services must be of ObjT.service type')
         self.services = services
@@ -1083,7 +1090,8 @@ class ConfProcess(ToDhall):
               node_desc: Dict[str, Any],
               proc_t: ProcT,
               proc_desc: Dict[str, Any] = None,
-              ctrl: Optional[Oid] = None) -> Oid:
+              ctrl: Optional[Oid] = None,
+              proc_name: str = None) -> Oid:
         _assert(parent.type is ObjT.node,
                 f'Parent must be ObjT.node but {parent.type} was given')
         if ctrl is not None:
@@ -1114,7 +1122,8 @@ class ConfProcess(ToDhall):
                               memsize_MB=facts['_memsize_MB'],
                               endpoint=ep,
                               meta_data=meta_data,
-                              services=[])
+                              services=[],
+                              proc_name=proc_name)
         m0conf[parent].processes.append(proc_id)
 
         for stype in service_types(proc_t, proc_desc):
@@ -2129,7 +2138,8 @@ ConsulAgent = NamedTuple('ConsulAgent', [('node_name', str), ('ipaddr', str)])
 Cluster = NamedTuple('Cluster', [('m0conf', Dict[Oid, Any]),
                                  ('consul_servers', List[ConsulAgent]),
                                  ('consul_clients', List[ConsulAgent]),
-                                 ('m0_clients', Dict[Oid, Oid])])
+                                 ('m0_clients', Dict[Oid, Oid]),
+                                 ('m0_client_types', List[str])])
 
 
 def generate_consul_agents(cluster: Cluster) -> str:
@@ -2237,12 +2247,11 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                                         meta_data=proc.meta_data)
                 # Add Motr clients to consul kv
                 if proc_id in cluster.m0_clients:
-                    proc_ep = m0conf[proc_id].endpoint
                     yield ConsulService(node_name=node.name,
                                         proc_id=proc_id,
                                         ep=proc.endpoint,
                                         svc_id=cluster.m0_clients[proc_id],
-                                        stype=proc_ep.portalgroup.name,
+                                        stype=m0conf[proc_id].proc_name,
                                         meta_data=None)
 
     def sns_pools() -> List[Oid]:
@@ -2263,6 +2272,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('bytecount/degraded_byte_count', 0),
         ('bytecount/critical_byte_count', 0),
         ('bytecount/damaged_byte_count', 0),
+        ('m0_client_types', cluster.m0_client_types),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node
                                                   and node.machine_id)],
@@ -2467,7 +2477,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
 
 def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     cluster = Cluster(m0conf={}, consul_servers=[], consul_clients=[],
-                      m0_clients={})
+                      m0_clients={}, m0_client_types=[])
     conf = cluster.m0conf
     root_id = ConfRoot.build(conf)
     # XXX Move all the logic into ConfRoot.build?
@@ -2507,15 +2517,15 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                                # XXX use 'mgmt_iface' for consul?
                                ipaddr=ipaddr))
 
-        for client_t, proc_t in [('s3', ProcT.m0_client_s3),
-                                 ('other', ProcT.m0_client_other)]:
-            for _ in range(node['m0_clients'][client_t]):
-                proc_id = ConfProcess.build(conf, node_id, node, proc_t)
-                cluster.m0_clients[proc_id] = new_oid(ObjT.service)
-                if client_t == 'other':
-                    if node['hostname'] not in other_clients:
-                        other_clients[node['hostname']] = []
-                    other_clients[node['hostname']].append((node_id, proc_id))
+        if 'm0_clients' in node and node['m0_clients'] is not None:
+            for client in node['m0_clients']:
+                for _ in range(client['instances']):
+                    proc_id = ConfProcess.build(conf, node_id,
+                                                node, ProcT.m0_client_other,
+                                                proc_name=client['name'])
+                    cluster.m0_clients[proc_id] = new_oid(ObjT.service)
+                    if client['name'] not in cluster.m0_client_types:
+                        cluster.m0_client_types.append(client['name'])
 
     check_drive_multiple_references(conf, cluster_desc)
 

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -45,6 +45,7 @@
 , ClusterDesc  = ./types/ClusterDesc.dhall
 , NodeDesc     = ./types/NodeDesc.dhall
 , M0ServerDesc = ./types/M0ServerDesc.dhall
+, M0ClientDesc = ./types/M0ClientDesc.dhall
 , Disk         = ./types/IODisk.dhall
 , PoolDesc     = ./types/PoolDesc.dhall
 , DiskRef      = ./types/DiskRef.dhall

--- a/cfgen/dhall/types/M0ClientDesc.dhall
+++ b/cfgen/dhall/types/M0ClientDesc.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cfgen/dhall/types/M0ClientDesc.dhall
+++ b/cfgen/dhall/types/M0ClientDesc.dhall
@@ -18,14 +18,7 @@
 
 -}
 
-{ hostname : Text
-, machine_id : Optional Text
-, processorcount: Optional Natural
-, memorysize_mb: Optional Double
-, data_iface : Text
-, data_iface_ip_addr : Optional Text
-, data_iface_type : Optional ./Protocol.dhall
-, transport_type : Text
-, m0_servers : Optional (List ./M0ServerDesc.dhall)
-, m0_clients : Optional (List ./M0ClientDesc.dhall)
+-- motr client definition
+{ name : Text
+, instances : Natural
 }

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -21,9 +21,9 @@ nodes:
             - path: /dev/loop7
             - path: /dev/loop8
             - path: /dev/loop9
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -29,9 +29,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu3
     data_iface: eth1
     transport_type: libfab
@@ -50,9 +50,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/sde
             - path: /dev/sdf
             - path: /dev/sdg
-    m0_clients:
-        s3: 0           # number of S3 servers to start
-        other: 2        # max quantity of other Motr clients this node may have
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: pod-c2
     data_iface: eth1_c2
     data_iface_type: o2ib
@@ -34,9 +34,9 @@ nodes:
             - path: /dev/sdi
             - path: /dev/sdj
             - path: /dev/sdk
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathd
             - path: /dev/disk/by-id/dm-name-mpathe
             - path: /dev/disk/by-id/dm-name-mpathf
-    m0_clients:
-      s3: 11
-      other: 3
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: srvnode-2
     data_iface: enp175s0f1_c2
     data_iface_type: o2ib
@@ -38,9 +38,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathj
             - path: /dev/disk/by-id/dm-name-mpathk
             - path: /dev/disk/by-id/dm-name-mpathl
-    m0_clients:
-      s3: 11
-      other: 3
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: tier1-nvme
     disk_refs:

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -25,9 +25,9 @@ nodes:
             - path: /dev/loop8 
             - path: /dev/loop9 
           meta_data: null
-    m0_clients:
-      s3: 0         # number of S3 servers to start
-      other: 2      # max quantity of other Motr clients this host may have
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 create_aux: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -92,10 +92,7 @@ in
                 }
             }
           ]
-      , m0_clients =
-          { s3 = 0
-          , other = 2
-          }
+      , m0_clients = None (List { name : Text, instances : Natural })
       }
     ]
 , pools =

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -2,7 +2,7 @@ import os.path as P
 import subprocess as S
 from dataclasses import dataclass
 from string import Template
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 from math import floor, ceil
 import pkg_resources
 
@@ -11,7 +11,7 @@ from hare_mp.store import ValueProvider
 from hare_mp.types import (ClusterDesc, DiskRef, DList, Maybe, NodeDesc,
                            PoolDesc, PoolType, ProfileDesc, Protocol, Text,
                            M0ServerDesc, DisksDesc, AllowedFailures, Layout,
-                           FdmiFilterDesc)
+                           FdmiFilterDesc, M0ClientDesc)
 from hare_mp.utils import func_log, func_enter, func_leave, Utils
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
@@ -66,15 +66,18 @@ class CdfGenerator:
         # Skipping for controller and HA pod
         machines = conf.get_machine_ids_for_service(
             Const.SERVICE_MOTR_IO.value)
+        # Get all the pods which runs the client components
+        client_machines = []
+        for client in conf.get_motr_clients():
+            name = str(client.get('name'))
+            client_machines.extend(conf.get_machine_ids_for_component(name))
 
-        s3_machines = conf.get_machine_ids_for_service(
-            Const.SERVICE_S3_SERVER.value)
-        # Avoid adding duplicate machine ids if s3 and data node
+        # Avoid adding duplicate machine ids if client and data node
         # are the same. We do not use list(set()) mechanism as it
         # changes the order and since this code is executed on all
         # the nodes in-parallel, the configuration generated on
         # every node must follow the same order to maintain consistency.
-        for machine in s3_machines:
+        for machine in client_machines:
             if machine not in machines:
                 machines.append(machine)
 
@@ -349,6 +352,24 @@ class CdfGenerator:
         length = 1
         return length
 
+    def _get_node_clients(self, machine_id: str) -> Iterator[M0ClientDesc]:
+        """
+        For all the motr clients present in the cluster return only those
+        clients that are present in the components list for the given
+        node>{machine_id} according to the ConfStore.
+
+        cortx>motr>clients=[rgw, other]
+        node>{machine_id}>components=[motr, other]
+
+        return 'other' only.
+        """
+        for client in self.provider.get_motr_clients():
+            name = str(client.get('name'))
+            if self.utils.is_component(machine_id, name):
+                yield M0ClientDesc(
+                    name=Text(name),
+                    instances=int(str(client.get('num_instances'))))
+
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
 
@@ -356,16 +377,7 @@ class CdfGenerator:
         # node>{machine-id}>name
         iface = self._get_iface(machine_id)
         servers = None
-        no_m0clients = 0
-        nr_s3_instances = 0
         if(self.utils.is_motr_component(machine_id)):
-            try:
-                # cortx>motr>client_instances
-                no_m0clients = int(store.get(
-                    'cortx>motr>client_instances',
-                    allow_null=True))
-            except TypeError:
-                no_m0clients = 2
             # Currently, there is 1 m0d per cvg.
             # We will create 1 IO service entry in CDF per cvg.
             # An IO service entry will use data  and metadat devices
@@ -393,8 +405,12 @@ class CdfGenerator:
                     meta_data=Maybe(None, 'Text')),
                 runs_confd=Maybe(True, 'Bool')))
 
-        if (self.utils.is_s3_component(machine_id)):
-            nr_s3_instances = int(store.get('cortx>s3>service_instances'))
+        # adding clients
+        clients = DList([
+            client
+            for client in self._get_node_clients(machine_id)
+        ], 'List M0ClientDesc')
+        m0_clients = clients if clients else None
 
         node_facts = self.utils.get_node_facts()
         return NodeDesc(
@@ -407,10 +423,5 @@ class CdfGenerator:
             data_iface_type=Maybe(self._get_iface_type(machine_id), 'P'),
             transport_type=Text(self.utils.get_transport_type()),
             m0_servers=Maybe(servers, 'List M0ServerDesc'),
-            #
-            # [KN] This is a hotfix for singlenode deployment
-            # TODO in the future the value must be taken from a correct
-            # ConfStore key (it doesn't exist now).
-            # cortx>s3>service_instances
-            s3_instances=nr_s3_instances,
-            client_instances=no_m0clients)
+            m0_clients=Maybe(m0_clients, 'List M0ClientDesc')
+        )

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -21,6 +21,11 @@ let M0ServerDesc =
       , io_disks : IODisks
       }
 
+let M0ClientDesc =
+      { name : Text
+      , instances : Natural
+      }
+
 let NodeInfo =
       { hostname : Text
       , machine_id : Optional Text
@@ -31,8 +36,7 @@ let NodeInfo =
       , data_iface_type : Optional T.Protocol
       , transport_type : Text
       , m0_servers : Optional (List M0ServerDesc)
-      , s3_instances : Natural
-      , client_instances : Natural
+      , m0_clients : Optional (List M0ClientDesc)
       }
 
 let AllowedFailures =
@@ -77,7 +81,7 @@ let toNodeDesc
           , data_iface = n.data_iface
           , data_iface_type = n.data_iface_type
           , transport_type = n.transport_type
-          , m0_clients = { other = n.client_instances, s3 = n.s3_instances }
+          , m0_clients = n.m0_clients
           , m0_servers = n.m0_servers
           }
 

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -292,7 +292,8 @@ def post_install(args):
     checkRpm('consul')
     checkRpm('cortx-hare')
     checkRpm('cortx-py-utils')
-    checkRpm('cortx-s3server')
+    # we need to check for 'rgw' rpm
+    # checkRpm('cortx-s3server')
 
     if args.report_unavailable_features:
         unsupported_feature(args.config[0])

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -180,32 +180,6 @@ def logrotate_generic(url: str):
 
 
 @func_log(func_enter, func_leave)
-def logrotate(url: str):
-    ''' This function is kept incase needed in future.
-        This function configures logrotate based on
-        'setup_type' key from confstore
-    '''
-    try:
-        server_type = get_server_type(url)
-        logging.info('Server type (%s)', server_type)
-
-        if server_type != 'unknown':
-            with open(f'/opt/seagate/cortx/hare/conf/logrotate/{server_type}',
-                      'r') as f:
-                content = f.read()
-
-            log_dir = get_log_dir(url)
-            content = content.replace('TMP_LOG_PATH',
-                                      log_dir)
-
-            with open('/etc/logrotate.d/hare', 'w') as f:
-                f.write(content)
-
-    except Exception as error:
-        logging.error('Cannot configure logrotate for hare (%s)', error)
-
-
-@func_log(func_enter, func_leave)
 def unsupported_feature(url: str):
     try:
         features_unavailable = []
@@ -726,10 +700,6 @@ def generate_support_bundle(args):
         cmd.append(log_dir)
         cmd.append('-c')
         cmd.append(conf_dir)
-
-        provider = ConfStoreProvider(url)
-        if provider.get('cortx>common>setup_type') == 'K8':
-            cmd.append('--no-systemd')
 
         execute(cmd)
     except Exception as error:

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -891,8 +891,15 @@ def generate_config(url: str, path_to_cdf: str) -> None:
            '--log-dir', get_log_dir(url),
            '--log-file', LOG_FILE,
            '--uuid', provider.get_machine_id()]
-    execute(cmd, env={'PYTHONPATH': python_path, 'PATH': path,
-                      'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
+
+    locale_info = execute(['locale', '-a'])
+    env = {'PYTHONPATH': python_path, 'PATH': path}
+
+    if 'en_US.utf-8' in locale_info or 'en_US.utf8' in locale_info:
+        env.update({'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
+
+    execute(cmd, env)
+
     utils.copy_conf_files(conf_dir)
     utils.copy_consul_files(conf_dir, mode='client')
     utils.import_kv(conf_dir)

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -85,9 +85,9 @@ class Text:
 
 
 @dataclass(repr=False)
-class M0Clients(DhallTuple):
-    s3: int
-    other: int
+class M0ClientDesc(DhallTuple):
+    name: Text
+    instances: int
 
 
 @dataclass(repr=False)
@@ -120,8 +120,7 @@ class NodeDesc(DhallTuple):
     data_iface_type: Maybe[Protocol]
     transport_type: Text
     m0_servers: Maybe[DList[M0ServerDesc]]
-    s3_instances: int
-    client_instances: int
+    m0_clients: Maybe[DList[M0ClientDesc]]
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -239,7 +239,7 @@ class Utils:
                     m0_client_types = item_data['value']
                     break
 
-        for client_type in m0_client_types:
+        for client_type in json.loads(m0_client_types):
             src = f'{conf_dir_path}/sysconfig/{client_type}/{node_name}'
             dest = f'{global_config_path}/{client_type}/sysconfig/{machine_id}'
             os.makedirs(dest, exist_ok=True)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -152,35 +152,25 @@ class Utils:
     def is_motr_component(self, machine_id: str) -> bool:
         """
         Returns True if motr component is present in the components list
-        for the given node>{machine_id} according to the
-        ConfStore (ValueProvider).
+        for the given node>{machine_id}.
         """
-        comp_names = self.provider.get(f'node>{machine_id}>'
-                                       f'components')
-        for component in comp_names:
-            if(component.get('name') == Const.COMPONENT_MOTR.value):
-                rc = True
-                break
-            else:
-                rc = False
-        return rc
+        return self.is_component(machine_id, Const.COMPONENT_MOTR.value)
 
     @func_log(func_enter, func_leave)
-    def is_s3_component(self, machine_id: str) -> bool:
+    def is_component(self, machine_id: str, name: str) -> bool:
         """
-        Returns True if s3 component is present in the components list
-        for the given node>{machine_id} according to the
+        Returns True if the given component is present in the components
+        list for the given node>{machine_id} according to the
         ConfStore (ValueProvider).
         """
         comp_names = self.provider.get(f'node>{machine_id}>'
                                        f'components')
+        found = False
         for component in comp_names:
-            if(component.get('name') == Const.COMPONENT_S3.value):
-                rc = True
+            if(component.get('name') == name):
+                found = True
                 break
-            else:
-                rc = False
-        return rc
+        return found
 
     @func_log(func_enter, func_leave)
     def save_drives_info(self):

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -29,7 +29,7 @@ import pkg_resources
 
 from hare_mp.cdf import CdfGenerator
 from hare_mp.store import ConfStoreProvider, ValueProvider
-from hare_mp.types import (DisksDesc, Disk, DList, M0Clients, M0ServerDesc, Maybe,
+from hare_mp.types import (DisksDesc, Disk, DList, M0ClientDesc, M0ServerDesc, Maybe,
                            MissingKeyError, PoolDesc, PoolType, Protocol, Text,
                            AllowedFailures, Layout)
 from hare_mp.utils import Utils
@@ -38,8 +38,8 @@ from hax.util import KVAdapter
 
 class TestTypes(unittest.TestCase):
     def test_m0clients(self):
-        val = M0Clients(s3=5, other=2)
-        self.assertEqual('{ s3 = 5, other = 2 }', str(val))
+        val = M0ClientDesc(name='other', instances=2)
+        self.assertEqual('{ name = other, instances = 2 }', str(val))
 
     def test_protocol(self):
         self.assertEqual('P.tcp', str(Protocol.tcp))
@@ -111,6 +111,7 @@ class TestCDF(unittest.TestCase):
 
             store.get_machine_id = Mock(return_value='1114a50a6bf6f9c93ebd3c49d07d3fd4')
             store.get_machine_ids_for_service = Mock(return_value=['1114a50a6bf6f9c93ebd3c49d07d3fd4'])
+            store.get_motr_clients = Mock(return_value=[])
             utils = Utils(store)
             kv = KVAdapter()
             def my_get(key: str, recurse: bool = False):
@@ -234,6 +235,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -307,7 +309,8 @@ class TestCDF(unittest.TestCase):
                 'node': {'MACH_ID': {'cluster_id': 'CLUSTER_ID'}},
                 'node>MACH_ID>cluster_id': 'CLUSTER_ID',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_ID>storage>cvg_count': 2,
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
@@ -323,13 +326,16 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'cortx>motr>client_instances':                2,
             }
             return data.get(value)
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=
+                                      [{'name': 'other',
+                                        'num_instances' : 2}])
+        store.get_machine_ids_for_component = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -375,8 +381,11 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
-        self.assertEqual(1, ret[0].s3_instances)
-        self.assertEqual(2, ret[0].client_instances)
+        clients = ret[0].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
 
 
         cdf = CdfGenerator(provider=store)
@@ -586,6 +595,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         cdf._get_m0d_per_cvg = Mock(return_value=1)
         utils = Utils(store)
@@ -908,6 +918,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -992,7 +1003,8 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1'],
                 'node>MACH_ID>storage>cvg':
@@ -1008,7 +1020,8 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_2_ID>network>data>private_fqdn':
                     'srvnode-2.data.private',
                 'node>MACH_2_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_2_ID>network>data>private_interfaces':
                 ['eth1'],
                 'cortx>motr>transport_type':
@@ -1029,6 +1042,11 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID',
                                                                'MACH_2_ID'])
+        store.get_motr_clients = Mock(return_value=
+                                [{'name': 'other',
+                                'num_instances' : 2}])
+        store.get_machine_ids_for_component = Mock(return_value=['MACH_ID',
+                                                                 'MACH_2_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -1077,13 +1095,19 @@ class TestCDF(unittest.TestCase):
         self.assertIn(Text('srvnode-1.data.private'),
                       [ret[0].hostname, ret[1].hostname])
         self.assertEqual(Text('eth1'), ret[0].data_iface)
-        self.assertEqual(1, ret[0].s3_instances)
-        self.assertEqual(2, ret[0].client_instances)
+        clients = ret[0].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
         self.assertIn(Text('srvnode-2.data.private'),
                       [ret[0].hostname, ret[1].hostname])
         self.assertEqual(Text('eth1'), ret[1].data_iface)
-        self.assertEqual(1, ret[1].s3_instances)
-        self.assertEqual(2, ret[1].client_instances)
+        clients = ret[1].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
         self.assertEqual('Some (P.tcp)', str(ret[0].data_iface_type))
         self.assertEqual('Some (P.tcp)', str(ret[1].data_iface_type))
 
@@ -1136,6 +1160,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         utils = Utils(store)
         kv = KVAdapter()

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -33,7 +33,7 @@ The required parameter is one of the following:
 
   --phase 1 - start Motr confd servers
   --phase 2 - start Motr IO servers
-  --phase 3 - start S3 servers
+  --phase 3 - start Motr client services
 
 Options:
   --mkfs-only   Do m0mkfs only (CAUTION: wipes Motr data).
@@ -118,7 +118,7 @@ EOF
     die "'motr-kernel' systemd service is not installed"
 fi
 
-. update-consul-conf --dry-run --xprt $xprt # import CONFD_IDs, IOS_IDs, S3_IDs, id2fid()
+. update-consul-conf --dry-run --xprt $xprt # import CONFD_IDs, IOS_IDs, MOTR_CLIENT_IDS, id2fid()
 
 sysconfig_dir='/etc/sysconfig'
 [ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -187,8 +187,8 @@ case $phase in
        IDs=$IOS_IDs
        ;;
     phase3)
-       proc='s3server@'
-       IDs=$S3_IDs
+       proc=
+       IDs=$MOTR_CLIENT_IDS
        ;;
     *)
        die 'Impossible happened'
@@ -217,11 +217,18 @@ wait_m0mkfs_done() {
 }
 
 for id in $IDs; do
-    fid=$(id2fid $id)
+    if [[ $phase == 'phase3' ]]; then
+        proc="$(echo $id| cut -d':' -f 1| tr -d '"' )@"
+        fid=$(id2fid $(echo $id| cut -d':' -f 2))
+    else
+        fid=$(id2fid $id)
+    fi
+
     if [[ $do_mkfs ]]; then
         sudo systemctl start motr-mkfs@$fid
         wait_m0mkfs_done $id
     fi
+
 
     if [[ $do_mkfs != 'mkfs-only' ]]; then
         sudo systemctl start $proc$fid

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -495,10 +495,10 @@ bootstrap_nodes phase1
 # Start ioservices
 bootstrap_nodes phase2
 
-. update-consul-conf --server --dry-run --xprt $xprt # import S3_IDs
-if [[ -n $S3_IDs ]]; then
-    # Now the 3rd phase (s3servers).
-    say 'Starting S3 servers (phase3)...'
+. update-consul-conf --server --dry-run --xprt $xprt # import MOTR_CLIENT_IDS
+if [[ -n $MOTR_CLIENT_IDS ]]; then
+    # Now the 3rd phase (motr clients).
+    say 'Starting motr clients...'
     bootstrap-node --phase phase3 --xprt $xprt &
     pids=($!)
 

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -30,7 +30,8 @@ from hax.types import ObjT
 
 from utils import get_node_name
 
-Process = NamedTuple('Process', [('name', str), ('fid', str)])
+Process = NamedTuple('Process', [('name', str), ('fid', str), ('ep', str)])
+KeyData = NamedTuple('KeyData', [('key_path', str), ('ep', str)])
 
 
 class Node:
@@ -38,8 +39,8 @@ class Node:
         self.name = name
         self.svcs: List[Process] = []
 
-    def add_service(self, svc: str, fid: str) -> None:
-        self.svcs.append(Process(svc, fid))
+    def add_service(self, svc: str, fid: str, ep: str) -> None:
+        self.svcs.append(Process(svc, fid, ep))
 
     def get_service(self, service: str) -> Optional[List[Process]]:
         # Returns list of services matching the given service
@@ -79,23 +80,39 @@ def node_names(data: List) -> List[str]:
     return nodes
 
 
-def get_keys_for_processes(data: List, client_types: List) -> List[str]:
+def get_keys_for_processes(data: List, client_types: List) -> List[KeyData]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/services/<svc_type>'
     # entries from the file.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md)
 
-    service_names = 'confd|ios'
+    service_names = 'confd|ios|ha'
 
     for client_type in client_types:
         service_names += '|' + client_type
 
     regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
                        '/(' + service_names + ')+$')
-    keys = []
+    keys: List[KeyData] = []
     for key in data:
         match_result = re.match(regex, key['key'])
         if not match_result:
             continue
-        keys.append(match_result.group(0))
+
+        # Key e.g. m0conf/nodes/localhost/processes/43/services/rgw
+        parts = key['key'].split('/')
+        process_fidk = parts[-3]
+
+        # key e.g. m0conf/nodes/localhost/processes/43/
+        #                         endpoint:inet:tcp:192.168.59.148@5001
+        regex_ep = re.compile(
+            f'^m0conf\\/.*\\/processes\\/{process_fidk}\\/endpoint')
+
+        for epdata in data:
+            result = re.match(regex_ep, epdata['key'])
+            if not result:
+                continue
+
+            keys.append(KeyData(match_result.group(0), epdata['value']))
+            break
     if not keys:
         raise RuntimeError(
             'No ioservice, confd, or any motr client found in the cluster')
@@ -103,10 +120,10 @@ def get_keys_for_processes(data: List, client_types: List) -> List[str]:
 
 
 def add_service_to_node(nodes: List[Node], node_name: str, svc_name: str,
-                        fid: str) -> None:
+                        fid: str, ep: str) -> None:
     for node in nodes:
         if node.name == node_name:
-            node.add_service(svc_name, fid)
+            node.add_service(svc_name, fid, ep)
 
 
 def get_service_for_node(nodes: List[Node], node_name: str,
@@ -130,10 +147,12 @@ def get_service_for_node(nodes: List[Node], node_name: str,
     return None
 
 
-def process_all_keys(keys: List,
+def process_all_keys(keys: List[KeyData],
                      nodes: List[Node],
                      client_types: List) -> None:
-    names = {'confd': 'confd', 'ios': 'ioservice'}
+    names = {'confd': 'confd',
+             'ios': 'ioservice',
+             'ha': 'hax'}
 
     for client_type in client_types:
         names[client_type] = client_type
@@ -141,12 +160,13 @@ def process_all_keys(keys: List,
     for key in keys:
         # key looks like
         # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
-        parts = key.split('/')
+        parts = key.key_path.split('/')
         svc_type = parts[-1]
         node_name = parts[2]
         process_fidk = parts[-3]
         add_service_to_node(nodes, node_name, names[svc_type],
-                            to_fid(ObjT.PROCESS.value, int(process_fidk)))
+                            to_fid(ObjT.PROCESS.value, int(process_fidk)),
+                            key.ep)
 
     for node in nodes:
         if not node.svcs:

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -174,7 +174,7 @@ def get_nodes_for_cluster(path: str) -> List[Node]:
     client_types = []
     for key in file_data:
         if key['key'] == 'm0_client_types':
-            client_types = key['value']
+            client_types = json.loads(key['value'])
             break
 
     keys = get_keys_for_processes(file_data, client_types)

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -17,7 +17,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-# :help: Fetch the fids for motr services (m0d and s3server)
+# :help: Fetch the fids for motr services (m0d and other clients)
 
 import argparse
 import json
@@ -79,12 +79,17 @@ def node_names(data: List) -> List[str]:
     return nodes
 
 
-def get_keys_for_processes(data: List) -> List[str]:
+def get_keys_for_processes(data: List, client_types: List) -> List[str]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/services/<svc_type>'
     # entries from the file.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md)
-    regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
-                       '/(confd|ios|m0_client_s3)+$')
 
+    service_names = 'confd|ios'
+
+    for client_type in client_types:
+        service_names += '|' + client_type
+
+    regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
+                       '/(' + service_names + ')+$')
     keys = []
     for key in data:
         match_result = re.match(regex, key['key'])
@@ -93,7 +98,7 @@ def get_keys_for_processes(data: List) -> List[str]:
         keys.append(match_result.group(0))
     if not keys:
         raise RuntimeError(
-            'No ioservice, confd, or s3servers found in the cluster')
+            'No ioservice, confd, or any motr client found in the cluster')
     return keys
 
 
@@ -125,8 +130,14 @@ def get_service_for_node(nodes: List[Node], node_name: str,
     return None
 
 
-def process_all_keys(keys: List, nodes: List[Node]) -> None:
-    names = {'confd': 'confd', 'ios': 'ioservice', 'm0_client_s3': 's3server'}
+def process_all_keys(keys: List,
+                     nodes: List[Node],
+                     client_types: List) -> None:
+    names = {'confd': 'confd', 'ios': 'ioservice'}
+
+    for client_type in client_types:
+        names[client_type] = client_type
+
     for key in keys:
         # key looks like
         # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
@@ -140,7 +151,7 @@ def process_all_keys(keys: List, nodes: List[Node]) -> None:
     for node in nodes:
         if not node.svcs:
             raise RuntimeError(
-                'No ioservice, confd, or s3servers found on the '
+                'No ioservice, confd, or any motr client found on the '
                 f'node {node.name}')
 
 
@@ -160,21 +171,28 @@ def get_nodes_for_cluster(path: str) -> List[Node]:
     if not nodes:
         raise RuntimeError('No nodes configured in the cluster')
 
-    keys = get_keys_for_processes(file_data)
-    process_all_keys(keys, nodes)
+    client_types = []
+    for key in file_data:
+        if key['key'] == 'm0_client_types':
+            client_types = key['value']
+            break
+
+    keys = get_keys_for_processes(file_data, client_types)
+    process_all_keys(keys, nodes, client_types)
     return nodes
 
 
 def parse_opts(argv):
     p = argparse.ArgumentParser(
-        description='Fetches the fids for motr services (m0d and s3server) '
+        description='Fetches the fids for motr services (m0d and clients) '
         'in cluster or node.',
         usage='%(prog)s [OPTION]')
 
     p.add_argument('--service',
                    '-s',
                    help='service name. - Returns fid for given service. '
-                   'List of services- "confd", "ioservice", "s3server". '
+                   'List of services- "confd", "ioservice", other '
+                   'client type. '
                    'Default: Returns the fids for all the services.',
                    type=str,
                    action='store')

--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -43,8 +43,6 @@ Positional arguments:
                         config files are present.
   -l                    The directory where the Hare related log files
                         are present.
-  --no-systemd          When set, systemd facilities will not be used to
-                        generate the logs
 
 Options:
   -h, --help   Show this help and exit.
@@ -55,10 +53,9 @@ bundle_id=$HOSTNAME
 dest_dir=$DEFAULT_DEST_DIR
 log_dir=$DEFAULT_LOG_DIR
 conf_dir=$DEFAULT_CONF_DIR
-use_systemd=true
 
 TEMP=$(getopt --options hm:b:t:c:l: \
-              --longoptions help,systemd-disabled,no-systemd \
+              --longoptions help,systemd-disabled \
               --name "$PROG" -- "$@" || true)
 
 eval set -- "$TEMP"
@@ -69,7 +66,6 @@ while true; do
         -t)                   dest_dir=$2; shift 2 ;;
         -c)                   conf_dir=$2; shift 2 ;;
         -l)                   log_dir=$2; shift 2 ;;
-        --no-systemd)         use_systemd=false; shift ;;
         --)                   shift; break ;;
         *)                    echo 'getopt: internal error...'; exit 1 ;;
     esac
@@ -124,17 +120,15 @@ cd "$dest_dir/hare/$HOSTNAME"
 exec 5>&2
 exec 2> >(tee _reportbug.stderr >&2)
 
-if $use_systemd; then
-    systemd_journal
+systemd_journal
 
-    sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
-         > syslog-pacemaker.json || true
+sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
+     > syslog-pacemaker.json || true
 
-    sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
-         > systemctl-status.txt || true
-else
-    running_process_list
-fi
+sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
+     > systemctl-status.txt || true
+
+running_process_list
 
 # cluster status
 sudo timeout --kill-after 30 15 hctl status \

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -177,9 +177,20 @@ def processes(cns: Consul, consul_util: ConsulUtil,
     node_health = consul_util.get_node_health_status(node_name)
     process_states = get_node_process_states(cns, node_name)
     process_list = get_node_processes(cns, node_name)
+
+    names = {
+        'confd': 'confd',
+        'ha': 'hax',
+        'ios': 'ioservice',
+        'm0_client_s3': 's3server'
+    }
+    m0_client_types = kv_item(cns, 'm0_client_types')
+    for client_type in json.loads(m0_client_types['Value']):
+        names[client_type] = client_type
+
     return [
         Process(
-            name=proc_id2name(cns, process_list, k),
+            name=proc_id2name(names, process_list, k),
             fid=Fid(0x7200000000000001, k),
             ep=(proc_id2endpoint(process_list, k) or '**ERROR**'),
             status=process_status(node_health, process_states,
@@ -235,19 +246,9 @@ def proc_id2endpoint(process_list: List[Dict[str, Any]],
     return None
 
 
-def proc_id2name(cns: Consul,
+def proc_id2name(names: Dict[str, str],
                  processes: List[Dict[str, Any]],
                  proc_id: int) -> str:
-    names = {
-        'confd': 'confd',
-        'ha': 'hax',
-        'ios': 'ioservice',
-        'm0_client_s3': 's3server'
-    }
-    m0_client_types = kv_item(cns, 'm0_client_types')
-    for client_type in json.loads(m0_client_types['Value']):
-        names[client_type] = client_type
-
     regex = re.compile(
         f'^m0conf\\/.*\\/processes\\/{proc_id}\\/services\\/(.+)$')
     process_found = False

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -179,7 +179,7 @@ def processes(cns: Consul, consul_util: ConsulUtil,
     process_list = get_node_processes(cns, node_name)
     return [
         Process(
-            name=proc_id2name(process_list, k),
+            name=proc_id2name(cns, process_list, k),
             fid=Fid(0x7200000000000001, k),
             ep=(proc_id2endpoint(process_list, k) or '**ERROR**'),
             status=process_status(node_health, process_states,
@@ -235,13 +235,19 @@ def proc_id2endpoint(process_list: List[Dict[str, Any]],
     return None
 
 
-def proc_id2name(processes: List[Dict[str, Any]], proc_id: int) -> str:
+def proc_id2name(cns: Consul,
+                 processes: List[Dict[str, Any]],
+                 proc_id: int) -> str:
     names = {
         'confd': 'confd',
         'ha': 'hax',
         'ios': 'ioservice',
         'm0_client_s3': 's3server'
     }
+    m0_client_types = kv_item(cns, 'm0_client_types')
+    for client_type in json.loads(m0_client_types['Value']):
+        names[client_type] = client_type
+
     regex = re.compile(
         f'^m0conf\\/.*\\/processes\\/{proc_id}\\/services\\/(.+)$')
     process_found = False

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -186,6 +186,14 @@ get_service_host() {
     echo ${1##*:}
 }
 
+get_motr_client_types() {
+
+    local cmd="jq '.[] | select(.key==\"m0_client_types\") |
+                  .value' $kv_file"
+
+    eval $cmd || true
+}
+
 install_motr_conf() {
     local motr_conf_file=$1
     if $custom_config; then
@@ -195,12 +203,12 @@ install_motr_conf() {
     fi
 }
 
-install_s3_conf() {
-    local s3_conf_file=$1
+install_motr_client_conf() {
+    local motr_client_conf_file=$1
     if $custom_config; then
-        sudo install $s3_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
+        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
     else
-        sudo install $s3_conf_file $sysconfig_dir/
+        sudo install $motr_client_conf_file $sysconfig_dir/
     fi
 }
 
@@ -238,7 +246,19 @@ Please verify that the host name matches the one stored in the Consul KV.
 }
 CONFD_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/confd"')
 IOS_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/ios"')
-S3_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/m0_client_s3"')
+
+MOTR_CLIENT_TYPES=$(get_motr_client_types)
+MOTR_CLIENT_TYPES=$(echo $MOTR_CLIENT_TYPES  | cut -d "[" -f2 | cut -d "]" -f1)
+
+MOTR_CLIENT_IDS=
+for motr_client_type in $MOTR_CLIENT_TYPES; do
+    motr_client_type=$(echo $motr_client_type | tr -d ',')
+    ids=$(get_service_ids_from_kv_file "grep -iw \"services\/$motr_client_type\"")
+    for client_id in $ids; do
+        MOTR_CLIENT_IDS+="${motr_client_type}:${client_id} "
+    done
+done
+
 HAX_EP=$(get_service_ep_from_kv_file $HAX_ID)
 
 if $dry_run; then
@@ -366,15 +386,16 @@ EOF
     install_motr_conf /tmp/m0d-$fid
 }
 
-append_s3_svc() {
+append_motr_client_svc() {
     local id=$1
     local fid=$(id2fid $id)
     local ep=$(get_service_ep_from_kv_file $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
     local host=$(get_service_host $addr)
-    local s3port=$2
-    local s3svc='s3server'@$fid
+    local client_port=$2
+    local motr_client_type=$(echo $3 | tr -d '"')
+    local svc=$motr_client_type@$fid
     SVCS_CONF+="${SVCS_CONF:+,}{
       \"id\": \"$id\",
       \"name\": \"s3service\",
@@ -387,7 +408,7 @@ append_s3_svc() {
       \"checks\": [
           {
             \"args\": [ \"/opt/seagate/cortx/hare/libexec/check-service\",
-                        \"--svc\", \"$s3svc\", \"--port\", \"$port\",
+                        \"--svc\", \"$svc\", \"--port\", \"$port\",
                         \"--host\", \"$host\",
                         \"--conf-dir\", \"$conf_dir\" ],
             \"interval\": \"1s\",
@@ -397,14 +418,14 @@ append_s3_svc() {
     }"
     local first_profile_fid=$(get_profile_from_kv_file)
     [[ -n $first_profile_fid ]]  # assert
-    cat <<EOF | sudo tee /tmp/s3server-$fid > /dev/null
+    cat <<EOF | sudo tee /tmp/$motr_client_type-$fid > /dev/null
 MOTR_PROFILE_FID=$first_profile_fid
-MOTR_S3SERVER_EP='$ep'
+MOTR_${motr_client_type^^}_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
-MOTR_S3SERVER_PORT=$s3port
+MOTR_${motr_client_type^^}_PORT=$client_port
 EOF
-    install_s3_conf /tmp/s3server-$fid
+    install_motr_client_conf /tmp/$motr_client_type-$fid
 }
 
 for id in $HAX_ID; do
@@ -419,10 +440,13 @@ for id in $IOS_IDs; do
     append_ios_svc $id
 done
 
-s3port=28071
-for id in $S3_IDs; do
-    append_s3_svc $id $s3port
-    ((s3port++))
+client_port=28071
+
+for id in $MOTR_CLIENT_IDS; do
+    proc=$(echo $id| cut -d':' -f 1)
+    client_id=$(echo $id| cut -d':' -f 2)
+    append_motr_client_svc $client_id $client_port $proc
+    ((client_port++))
 done
 
 tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -428,10 +428,10 @@ append_motr_client_svc() {
     [[ -n $first_profile_fid ]]  # assert
     cat <<EOF | sudo tee /tmp/$motr_client_type-$fid > /dev/null
 MOTR_PROFILE_FID=$first_profile_fid
-MOTR_${motr_client_type^^}_EP='$ep'
+MOTR_CLIENT_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
-MOTR_${motr_client_type^^}_PORT=$client_port
+MOTR_CLIENT_PORT=$client_port
 EOF
     install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -187,9 +187,8 @@ get_service_host() {
 }
 
 get_motr_client_types() {
-
-    local cmd="jq '.[] | select(.key==\"m0_client_types\") |
-                  .value' $kv_file"
+    local cmd="jq -r '.[] | select(.key==\"m0_client_types\") |
+                  .value' $kv_file | jq -r '.[]'"
 
     eval $cmd || true
 }
@@ -249,11 +248,9 @@ CONFD_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/confd"')
 IOS_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/ios"')
 
 MOTR_CLIENT_TYPES=$(get_motr_client_types)
-MOTR_CLIENT_TYPES=$(echo $MOTR_CLIENT_TYPES  | cut -d "[" -f2 | cut -d "]" -f1)
 
 MOTR_CLIENT_IDS=
 for motr_client_type in $MOTR_CLIENT_TYPES; do
-    motr_client_type=$(echo $motr_client_type | tr -d ',')
     ids=$(get_service_ids_from_kv_file "grep -iw \"services\/$motr_client_type\"")
     for client_id in $ids; do
         MOTR_CLIENT_IDS+="${motr_client_type}:${client_id} "

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -223,6 +223,10 @@ create_client_conf_dir() {
 }
 
 if $custom_config ; then
+    create_motr_conf_dir
+fi
+
+if $custom_config ; then
     [ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
 else
     [ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -264,7 +268,6 @@ fi
 # --------------------------------------------------------------------
 
 if $custom_config ; then
-    create_motr_conf_dir
     for motr_client_type in $MOTR_CLIENT_TYPES; do
         motr_client_type=$(echo $motr_client_type | tr -d ',' | tr -d '"')
         create_client_conf_dir $motr_client_type

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -205,8 +205,9 @@ install_motr_conf() {
 
 install_motr_client_conf() {
     local motr_client_conf_file=$1
+    local motr_client_type=$2
     if $custom_config; then
-        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
+        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/$motr_client_type/$(get_node_name)/
     else
         sudo install $motr_client_conf_file $sysconfig_dir/
     fi
@@ -216,14 +217,10 @@ create_motr_conf_dir() {
     mkdir -p $conf_dir/$sysconfig_dir/motr/$(get_node_name)
 }
 
-create_s3_conf_dir() {
-    mkdir -p $conf_dir/$sysconfig_dir/s3/$(get_node_name)
+create_client_conf_dir() {
+    local motr_client_type=$1
+    mkdir -p $conf_dir/$sysconfig_dir/$motr_client_type/$(get_node_name)
 }
-
-if $custom_config ; then
-    create_motr_conf_dir
-    create_s3_conf_dir
-fi
 
 if $custom_config ; then
     [ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -265,6 +262,14 @@ if $dry_run; then
     return 0  # we must not `exit`, because the script is sourced
 fi
 # --------------------------------------------------------------------
+
+if $custom_config ; then
+    create_motr_conf_dir
+    for motr_client_type in $MOTR_CLIENT_TYPES; do
+        motr_client_type=$(echo $motr_client_type | tr -d ',' | tr -d '"')
+        create_client_conf_dir $motr_client_type
+    done
+fi
 
 mkdir -p $conf_dir/consul-server-conf/
 mkdir -p $conf_dir/consul-client-conf/
@@ -425,7 +430,7 @@ MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 MOTR_${motr_client_type^^}_PORT=$client_port
 EOF
-    install_motr_client_conf /tmp/$motr_client_type-$fid
+    install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }
 
 for id in $HAX_ID; do


### PR DESCRIPTION
**Solution**: Removed reference to above key during support bundle generation

**Test:**
**LC**
```
[root@cortx-server-headless-svc-ssc-vm-g4-rhev4-0635 cortx-server-headless-svc-ssc-vm-g4-rhev4-0635]# ls -l
total 20
-rw-r--r-- 1 root root 3218 Feb 18 12:27 _reportbug.stderr
drwxr-xr-x 4 root root 4096 Feb 18 12:27 etc
-rw-r--r-- 1 root root 1106 Feb 18 12:27 hctl-status.txt
-rw-r--r-- 1 root root 2260 Feb 18 12:27 processes.txt
-rw-r--r-- 1 root root    0 Feb 18 12:27 syslog-pacemaker.json
-rw-r--r-- 1 root root    0 Feb 18 12:27 systemctl-status.txt
drwxr-xr-x 3 root root 4096 Feb 18 12:27 var
```

**LR**
```
[root@ssc-vm-g2-rhev4-2221 ssc-vm-g2-rhev4-2221.colo.seagate.com]# ls -l
total 165536
drwxr-xr-x 3 root root      4096 Feb 18 06:42 etc
-rw-r--r-- 1 root root      1030 Feb 18 06:42 hctl-status.txt
-rw-r--r-- 1 root root     29477 Feb 18 06:42 processes.txt
-rw-r--r-- 1 root root      2164 Feb 18 06:42 _reportbug.stderr
-rw-r--r-- 1 root root         0 Feb 18 06:42 syslog-pacemaker.json
-rw-r--r-- 1 root root     17624 Feb 18 06:42 systemctl-status.txt
-rw-r--r-- 1 root root 169438842 Feb 18 06:42 systemd-journal_0
drwxr-xr-x 4 root root      4096 Feb 18 06:42 var
```