### PR TITLE
CORTX-29018: hax: handle ha states from motr

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -72,6 +72,15 @@ class HaNvecGetEvent(BaseMessage):
 
 
 @dataclass
+class HaNvecSetEvent(BaseMessage):
+    hax_msg: int
+    nvec: List[HaNote]
+
+    def __repr__(self):
+        return f'HaNvecSetEvent(<{len(self.nvec)} items>)'
+
+
+@dataclass
 class SnsOperation(BaseMessage):
     fid: Fid
 

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -481,6 +481,18 @@ class Motr:
                                    HaNoteStruct.M0_NC_ONLINE}:
                 bcast_ss.append(HAState(fid, obj_health))
 
+            # In case of failed repair, roll back to failed state.
+            elif n.note.no_state == HaNoteStruct.M0_NC_REPAIR:
+                obj_health = ObjHealth.from_ha_note_state(
+                                       HaNoteStruct.M0_NC_FAILED)
+                bcast_ss.append(HAState(fid, obj_health))
+
+            # In case of failed rebalance, roll back to repaired state.
+            elif n.note.no_state == HaNoteStruct.M0_NC_REBALANCE:
+                obj_health = ObjHealth.from_ha_note_state(
+                                       HaNoteStruct.M0_NC_REPAIRED)
+                bcast_ss.append(HAState(fid, obj_health))
+
         LOG.debug('got ha_states %s', ha_states)
         if bcast_ss:
             self.broadcast_ha_states(bcast_ss)

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -270,7 +270,12 @@ static void handle_nvec(const struct hax_msg *hm)
 
 	*hmsg = *hm;
 	PyObject *l = nvec_to_list(ha_notes, nr_notes);
-	PyObject_CallMethod(hc0->hc_handler, "ha_nvec_get", "(KO)", hmsg, l);
+	if (hm_nvec->hmnv_type == M0_HA_NVEC_GET)
+		PyObject_CallMethod(hc0->hc_handler, "ha_nvec_get", "(KO)", hmsg, l);
+	else if (hm_nvec->hmnv_type == M0_HA_NVEC_SET)
+		PyObject_CallMethod(hc0->hc_handler, "ha_nvec_set", "(KO)", hmsg, l);
+	else
+		M0_IMPOSSIBLE("invalid M0_HA_NVEC_type");
 
 	Py_DECREF(l);
 	PyGILState_Release(gstate);

--- a/hax/hax/motr/planner.py
+++ b/hax/hax/motr/planner.py
@@ -24,7 +24,8 @@ from typing import Callable, Deque, Dict, Optional, Set, Tuple, Type
 
 from hax.log import TRACE
 from hax.message import (AnyEntrypointRequest, BaseMessage, BroadcastHAStates,
-                         Die, HaNvecGetEvent, ProcessEvent, SnsOperation)
+                         Die, HaNvecGetEvent, HaNvecSetEvent, ProcessEvent,
+                         SnsOperation)
 from hax.motr.util import LinkedList
 from hax.types import Fid
 
@@ -314,6 +315,10 @@ class WorkPlanner:
             # HaNvecGetEvent can be done in parallel to any other commands.
             # No need to form the new group for it.
             return False
+        if isinstance(cmd, HaNvecSetEvent):
+            # HaNvecSetEvent can be done in parallel to any other commands.
+            # No need to form the new group for it.
+            return False
         if isinstance(cmd, AnyEntrypointRequest):
             # Entrypoint requests can be processed in parallel to other
             # requests are they are per processes. In a situation where
@@ -363,6 +368,7 @@ class WorkPlanner:
 
         if (isinstance(cmd, AnyEntrypointRequest)
                 or isinstance(cmd, HaNvecGetEvent)
+                or isinstance(cmd, HaNvecSetEvent)
                 or isinstance(cmd, ProcessEvent)):
             # Entrypoint and Die will always be added to the CURRENT group
             # (the one being currently active), so they can be executed at


### PR DESCRIPTION
Currently, M0_HA_NVEC_SET states from Motr are handled similarly to M0_HA_NVEC_GET, which is wrong and contradicts the design. For example, when the disk is repaired, the REPAIRED ha notification from Motr would not be handled.

Solution: add handling of M0_HA_NVEC_SET from Motr. For now, only M0_NC_REPAIRED and M0_NC_ONLINE are handled, which is sufficient for SNS repair/rebalance. More states can be added later.

References:
- https://jts.seagate.com/browse/CORTX-29018

How to test:
1) write some data
2) fail some disk: `hctl drive-state --json $(jq --null-input --compact-output '{ node: "centos8", source_type: "drive", device: "/dev/loop1", state: "failed" }')`
3) set its status to repairing state: `hctl drive-state --json $(jq --null-input --compact-output '{ node: "centos8", source_type: "drive", device: "/dev/loop1", state: "repair" }')`
4) start repair: `hctl repair start`
5) wait until repair completes, check with `hctl status -d`: the disk should become `repaired`
6) set it to rebalancing state: `hctl drive-state --json $(jq --null-input --compact-output '{ node: "centos8", source_type: "drive", device: "/dev/loop1", state: "rebalance" }')`
7) start rebalance: `hctl rebalance start`
8) the drive should become `online`.