### PR TITLE
CORTX-29223: hax: unset locale causes hctl commands to fail

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -24,6 +24,9 @@ import signal
 from typing import List, NamedTuple
 
 import inject
+import locale
+import codecs
+import os
 
 from hax.common import HaxGlobalState, di_configuration
 from hax.filestats import FsStatsUpdater
@@ -116,10 +119,20 @@ def _run_rconfc_starter_thread(motr: Motr,
     return rconfc_starter
 
 
+def set_locale():
+    try:
+        if codecs.lookup('UTF-8').name == 'utf-8':
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+            os.environ["LANG"] = "en_US.utf-8"
+    except Exception:
+        LOG.exception('Error setting locale ')
+
+
 def main():
     # Note: no logging must happen before this call.
     # Otherwise the log configuration will not apply.
     setup_logging()
+    set_locale()
     inject.configure(di_configuration)
 
     state = inject.instance(HaxGlobalState)

--- a/hctl
+++ b/hctl
@@ -122,6 +122,13 @@ is_systemd_enabled() {
    fi
 }
 
+locale_set() {
+    if [[ `locale -a | grep "en_US.utf8"` ]]; then
+        export LANG="en_US.UTF-8"
+        export LC_ALL="en_US.UTF-8"
+    fi
+}
+
 # process commands
 case $cmd in
     help) usage; exit ;;
@@ -133,6 +140,7 @@ case $cmd in
         PATH="$HARE_BASE_DIR/libexec:$PATH"
         PATH="$HARE_BASE_DIR/bin:$PATH"
         export PATH
+        locale_set
 
         # TODO: python3.6 version can be different
         PYTHONPATH="$HARE_BASE_DIR/lib/python3.6/site-packages"
@@ -154,6 +162,7 @@ case $cmd in
         PATH="$HARE_BASE_DIR/libexec:$PATH"
         PATH="$HARE_BASE_DIR/bin:$PATH"
         export PATH
+        locale_set
 
         # TODO: python3.6 version can be different
         PYTHONPATH="$HARE_BASE_DIR/lib/python3.6/site-packages"

--- a/utils/proto-rc
+++ b/utils/proto-rc
@@ -88,7 +88,8 @@ check4signal() {
 
 # Simple log helper to output to stderr and syslog
 log() {
-    logger --tag "hare/${0##*/}" --stderr "$*"
+    # logger --tag "hare/${0##*/}" --stderr "$*"
+    echo -n "$*" >> $LOGFILE
 }
 
 # Users can use this function to set timeouts.


### PR DESCRIPTION
```
2022-02-24 18:38:19 hare/proto-rc: 11016: Process epoch: eq/11: {"message_type": "device-state-set", "payload": {"node": "cortx-data-headless-svc-ssc-vm-g2-rhev4-1475", "source_type": "drive", "device": "/dev/sdg", "state": "failed"}}
2022-02-24 18:38:19 hare/proto-rc: HARE_RC_EVENT_TYPE: device-state-set, HARE_RC_EVENT_PAYLOAD: {
2022-02-24 18:38:19   "node": "cortx-data-headless-svc-ssc-vm-g2-rhev4-1475",
2022-02-24 18:38:19   "source_type": "drive",
2022-02-24 18:38:19   "device": "/dev/sdg",
2022-02-24 18:38:19   "state": "failed"
2022-02-24 18:38:19 }
2022-02-24 18:38:19 2022-02-24 18:38:19,560 [DEBUG] Bound <class 'hax.common.HaxGlobalState'> to an instance <hax.common.HaxGlobalState object at 0x7f07a6f95128>
2022-02-24 18:38:19 2022-02-24 18:38:19,560 [DEBUG] Created and configured an injector, config=<function di_configuration at 0x7f07ac16e488>
2022-02-24 18:38:19 2022-02-24 18:38:19,569 [ERROR] Exiting with failure
2022-02-24 18:38:19 Traceback (most recent call last):
2022-02-24 18:38:19   File "/opt/seagate/cortx/hare/lib64/python3.6/site-packages/hax/queue/cli.py", line 56, in main
2022-02-24 18:38:19     obj={})
2022-02-24 18:38:19   File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/click/core.py", line 1137, in __call__
2022-02-24 18:38:19     return self.main(*args, **kwargs)
2022-02-24 18:38:19   File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/click/core.py", line 1043, in main
2022-02-24 18:38:19     _verify_python_env()
2022-02-24 18:38:19   File "/opt/seagate/cortx/hare/lib/python3.6/site-packages/click/_unicodefun.py", line 100, in _verify_python_env
2022-02-24 18:38:19     raise RuntimeError("\n\n".join(extra))
2022-02-24 18:38:19 RuntimeError: Click will abort further execution because Python was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/unicode-support/ for mitigation steps.
2022-02-24 18:38:19
2022-02-24 18:38:19 This system lists some UTF-8 supporting locales that you can pick from. The following suitable locales were discovered: en_AG.utf8, en_AU.utf8, en_BW.utf8, en_CA.utf8, en_DK.utf8, en_GB.utf8, en_HK.utf8, en_IE.utf8, en_IN.utf8, en_NG.utf8, en_NZ.utf8, en_PH.utf8, en_SG.utf8, en_US.utf8, en_ZA.utf8, en_ZM.utf8, en_ZW.utf8
```

Solution:
- export LANG and LC_ALL variables set to en_US.utf8
- set locale explicitly from hax