### PR TITLE
readme: hare architecture document link is missing from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,5 +337,6 @@ Solution: install cortx-py-utils RPM and retry.
 ## See also
 
 * [Hare RFCs](rfc/README.md)
+* [Hare Architecture](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/192020649/Hare+Architecture)
 * [Hare wiki](https://github.com/Seagate/cortx-hare/wiki)
 * [QSG_Test_History](Testing_Verification_History.md)


### PR DESCRIPTION
Solution:
Add https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/192020649/Hare+Architecture
to Hare README.md document.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>

-----
[View rendered README.md](https://github.com/mssawant/cortx-hare-1/blob/readme-update/README.md)