### PR TITLE
CORTX-29101 : hctl: devices states are not maintained on re-bootstrap

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -352,9 +352,10 @@ fi
 say 'Starting Consul server on this node...'
 
 # $join_ip is our bind_ip address
-mk-consul-env --mode server --bind $join_ip $join_peers_opt \
-              --extra-options '-ui -bootstrap-expect 1'
-
+if [[ $opt_mkfs ]]; then
+    mk-consul-env --mode server --bind $join_ip $join_peers_opt \
+                  --extra-options '-ui -bootstrap-expect 1'
+fi
 sudo systemctl start hare-consul-agent
 
 # Wait for Consul's internal leader to be ready.
@@ -371,24 +372,30 @@ while ! grep -q 'leader *= *true' <<< "$(consul info 2>/dev/null)"; do
 done
 echo ' OK'
 
-say 'Importing configuration into the KV store...'
-jq '[.[] | {key, value: (.value | @base64)}]' < $conf_dir/consul-kv.json |
-    consul kv import - > /dev/null
-echo ' OK'
+if [[ $opt_mkfs ]]; then
+    say 'Importing configuration into the KV store...'
+    jq '[.[] | {key, value: (.value | @base64)}]' < $conf_dir/consul-kv.json |
+        consul kv import - > /dev/null
+    echo ' OK'
+fi
 
 say 'Starting Consul on other nodes...'
 pids=()
 while read node bind_ip; do
-    ssh_error_info "$node" "PATH=$PATH $(which mk-consul-env) \
-                          --mode server --bind $bind_ip --join $join_ip &&
-               sudo systemctl start hare-consul-agent" &
+    if [[ $opt_mkfs ]]; then
+        ssh_error_info "$node" "PATH=$PATH $(which mk-consul-env) \
+                          --mode server --bind $bind_ip --join $join_ip" &
+    fi
+    ssh_error_info sudo "$node" "systemctl start hare-consul-agent" &
     pids+=($!)
 done < <(get_server_nodes | grep -vw $(node-name) || true)
 
 while read node bind_ip; do
-    ssh_error_info "$node" "PATH=$PATH $(which mk-consul-env) \
-                          --mode client --bind $bind_ip --join $join_ip &&
-               sudo systemctl start hare-consul-agent" &
+    if [[ $opt_mkfs ]]; then
+        ssh_error_info "$node" "PATH=$PATH $(which mk-consul-env) \
+                              --mode client --bind $bind_ip --join $join_ip" &
+    fi
+    ssh_error_info "$node" "sudo systemctl start hare-consul-agent" &
     pids+=($!)
 done < <(get_client_nodes)
 wait4 ${pids[@]-}
@@ -417,17 +424,21 @@ while (( $(get_ready_agents_nr) != $agents_nr )); do
 done
 echo 'Consul ready on all nodes'
 
-say 'Updating Consul configuraton from the KV store...'
-update-consul-conf --server --xprt $xprt &
-pid=($!)
-wait4 ${pid[@]}
+if [[ $opt_mkfs ]]; then
+    say 'Updating Consul configuraton from the KV store...'
+    update-consul-conf --server --xprt $xprt &
+    pid=($!)
+    wait4 ${pid[@]}
+fi
 
 pids=
 
 while read node _; do
     scp -qr /var/lib/hare/consul-kv.json $node:/var/lib/hare/
-    ssh_error_info "$node" "PATH=$PATH $(which update-consul-conf)" --server --xprt $xprt &
-    pids+=($!)
+    if [[ $opt_mkfs ]]; then
+        ssh_error_info "$node" "PATH=$PATH $(which update-consul-conf)" --server --xprt $xprt &
+        pids+=($!)
+    fi
 done < <(get_all_nodes | grep -vw $(node-name) || true)
 wait4 ${pids[@]}
 echo ' OK'


### PR DESCRIPTION
After initial bootstrap with mkfs, any changes to the devices is not
maintained if the cluster is re-bootstrapped without mkfs option.

Solution:
Regenerate consul configuration and environment only if mkfs options is
specified.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>