### PR TITLE
ha: node name not considered while fetching sdev fid

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -17,7 +17,7 @@
 #
 
 import logging
-from typing import List
+from typing import List, Any
 
 from hax.message import (BroadcastHAStates, Die, EntrypointRequest,
                          FirstEntrypointRequest, HaNvecGetEvent, ProcessEvent,
@@ -121,6 +121,7 @@ class ConsumerThread(StoppableThread):
                     state.status, state.fid)
                 proc_status_remote = self.consul.get_process_status(
                                          state.fid)
+                proc_status: Any = None
                 # MKFS states are upated by the node corresponding to a
                 # given process. So we ignore notifications for mkfs
                 # processes.
@@ -175,13 +176,14 @@ class ConsumerThread(StoppableThread):
                                 m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED)
                     else:
                         continue
-                    self.consul.update_process_status_local(
-                        ConfHaProcess(chp_event=proc_status,
-                                      chp_type=proc_type,
-                                      chp_pid=0,
-                                      fid=state.fid))
-                    new_ha_states.append(
-                        HAState(fid=state.fid, status=current_status))
+                    if proc_status is not None:
+                        self.consul.update_process_status_local(
+                            ConfHaProcess(chp_event=proc_status,
+                                          chp_type=proc_type,
+                                          chp_pid=0,
+                                          fid=state.fid))
+                        new_ha_states.append(
+                            HAState(fid=state.fid, status=current_status))
             else:
                 new_ha_states.append(state)
         return new_ha_states

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1425,9 +1425,11 @@ class ConsulUtil:
         #    key 0x6400000000000001:0x2c
         # 4. Create sdev fid from sdev fid key.
         # sdev_items = self.kv.kv_get('m0conf/nodes', recurse=True)
+        node_fid = self.get_node_fid(node_name)
         sdev_items = self.get_all_nodes()
         for x in sdev_items:
-            if '/sdevs/' in x['Key']:
+            if (f'm0conf/nodes/{node_fid}' in x['Key'] and
+                    '/sdevs/' in x['Key']):
                 if json.loads(x['Value'])['path'] == drive:
                     # Using constant index 8 for the sdev fid.
                     # Fix this by changing the Consul schema to have


### PR DESCRIPTION
While transitioning a drive state using `hctl drive-state` command, hax
maps the drive name to its corresponding motr fid. While doing this the
corresponding node name is not considered to fetch the drive fid
on a given node.

Solution:
Consider node name while parsing KV to extract the drive fid for a given
node.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>