### PR TITLE
nvec: report M0_NC_TRANSIENT for unknown status

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -242,7 +242,7 @@ class HaLinkMessagePromise:
 class ObjHealth(Enum):
     FAILED = (0, HaNoteStruct.M0_NC_FAILED)
     OK = (1, HaNoteStruct.M0_NC_ONLINE)
-    UNKNOWN = (2, HaNoteStruct.M0_NC_UNKNOWN)
+    UNKNOWN = (2, HaNoteStruct.M0_NC_TRANSIENT)
     OFFLINE = (3, HaNoteStruct.M0_NC_TRANSIENT)
     STOPPED = (4, HaNoteStruct.M0_NC_TRANSIENT)
     REPAIR = (5, HaNoteStruct.M0_NC_REPAIR)

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -710,11 +710,7 @@ class ConsulUtil:
         proc_node = self.get_process_node(pfid, kv_cache=kv_cache)
         proc_status: ObjHealth = self.get_service_health(proc_node, pfid.key,
                                                          kv_cache=kv_cache)
-        obj_state = proc_status.to_ha_note_status()
-        if obj_state == HaNoteStruct.M0_NC_UNKNOWN:
-            return HaNoteStruct.M0_NC_ONLINE
-        else:
-            return obj_state
+        return proc_status.to_ha_note_status()
 
     @staticmethod
     def get_process_keys(node_items: List[Any], fidk: int) -> List[Any]:

--- a/hax/test/test_types.py
+++ b/hax/test/test_types.py
@@ -25,17 +25,20 @@ o = ObjHealth
 @pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, o.OK),
                                             (h.M0_NC_FAILED, o.FAILED),
                                             (h.M0_NC_TRANSIENT, o.OFFLINE),
-                                            (h.M0_NC_UNKNOWN, o.UNKNOWN),
+                                            (h.M0_NC_UNKNOWN, o.OFFLINE),
                                             (h.M0_NC_REPAIR, o.REPAIR),
                                             (h.M0_NC_REPAIRED, o.REPAIRED),
                                             (h.M0_NC_REBALANCE, o.REBALANCE)])
 def test_obj_health_to_ha_note(ha_note: int, health: ObjHealth):
-    assert ha_note == health.to_ha_note_status()
+    if ha_note == h.M0_NC_UNKNOWN:
+        assert health.to_ha_note_status() == h.M0_NC_TRANSIENT
+    else:
+        assert ha_note == health.to_ha_note_status()
 
 
 @pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, o.OK),
                                             (h.M0_NC_FAILED, o.FAILED),
-                                            (h.M0_NC_TRANSIENT, o.OFFLINE),
+                                            (h.M0_NC_TRANSIENT, o.UNKNOWN),
                                             (h.M0_NC_UNKNOWN, o.UNKNOWN),
                                             (h.M0_NC_REPAIR, o.REPAIR),
                                             (h.M0_NC_REPAIRED, o.REPAIRED),


### PR DESCRIPTION
Hare reports a process as M0_NC_ONLINE by default even if the process
has not started.

Solution:
Report M0_NC_TRANSIENT if process has not started yet.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>