### PR TITLE
Problem: Mini prov test cases failing on rgw branch

### DIFF
--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -885,6 +885,8 @@ class TestCDF(unittest.TestCase):
                 },
                 'node>MACH_ID>hostname':
                 'myhost',
+                'cortx>hare>hax>endpoints':
+                ['tcp://myhost:22001'],
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>components':
@@ -996,12 +998,15 @@ class TestCDF(unittest.TestCase):
                 'StorageSet-1',
                 'cluster>storage_set[0]>nodes':
                 ['srvnode_1', 'srvnode_2'],
+                'cortx>hare>hax>endpoints':
+                ['tcp://srvnode-1.data.private:22001',
+                 'tcp://srvnode-2.data.private:22001'],
                 'node>MACH_ID>hostname':
                 'myhost',
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
-                    'srvnode-1.data.private',
+                'srvnode-1.data.private',
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
                  {'name': 'other'}],
@@ -1018,7 +1023,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_2_ID>type':                'storage_node',
                 'cortx>motr>interface_type':                'tcp',
                 'node>MACH_2_ID>network>data>private_fqdn':
-                    'srvnode-2.data.private',
+                'srvnode-2.data.private',
                 'node>MACH_2_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
                  {'name': 'other'}],
@@ -1144,6 +1149,8 @@ class TestCDF(unittest.TestCase):
                 ['/dev/meta1'],
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
+                'cortx>hare>hax>endpoints':
+                ['tcp://myhost:22001'],
                 'cortx>s3>service_instances':
                 1,
                 'cortx>motr>interface_type':


### PR DESCRIPTION
Solution:
Fixed mini-provisioning test cases

**Test:**
```
(.py3venv) [root@ssc-vm-g2-rhev4-2221 miniprov]# python ./setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing hare_mp.egg-info/PKG-INFO
writing dependency_links to hare_mp.egg-info/dependency_links.txt
writing entry points to hare_mp.egg-info/entry_points.txt
writing requirements to hare_mp.egg-info/requires.txt
writing top-level names to hare_mp.egg-info/top_level.txt
reading manifest file 'hare_mp.egg-info/SOURCES.txt'
writing manifest file 'hare_mp.egg-info/SOURCES.txt'
running build_ext
test_empty_source_results_empty (test.test_systemd.TestHaxUnitTrasform) ... ok
test_not_everything_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_restart_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_invalid_machine_id (test.test_validator.TestValidator) ... ok
test_is_cluster_first_node (test.test_validator.TestValidator) ... ok
test_allowed_failure_generation (test.test_cdf.TestCDF) ... ok
test_both_dix_and_sns_pools_can_exist (test.test_cdf.TestCDF) ... ok
test_disk_refs_can_be_empty (test.test_cdf.TestCDF) ... ok
test_dix_pool_uses_metadata_devices (test.test_cdf.TestCDF) ... ok
test_iface_type_can_be_null (test.test_cdf.TestCDF) ... ok
test_invalid_storage_set_configuration_rejected (test.test_cdf.TestCDF)
This test case checks whether exception will be raise if total ... ok
test_it_works (test.test_cdf.TestCDF) ... ok
test_md_pool_ignored (test.test_cdf.TestCDF) ... ok
test_metadata_is_hardcoded (test.test_cdf.TestCDF) ... ok
test_multiple_nodes_supported (test.test_cdf.TestCDF) ... ok
test_provided_values_respected (test.test_cdf.TestCDF) ... ok
test_template_sane (test.test_cdf.TestCDF) ... ok
test_disks_empty (test.test_cdf.TestTypes) ... ok
test_m0clients (test.test_cdf.TestTypes) ... ok
test_m0server_with_disks (test.test_cdf.TestTypes) ... ok
test_maybe_none (test.test_cdf.TestTypes) ... ok
test_pooldesc_empty (test.test_cdf.TestTypes) ... ok
test_protocol (test.test_cdf.TestTypes) ... ok

----------------------------------------------------------------------
Ran 23 tests in 0.399s

OK
```