### PR TITLE
Rebase main with rgw

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2315,7 +2315,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('bytecount/degraded_byte_count', 0),
         ('bytecount/critical_byte_count', 0),
         ('bytecount/damaged_byte_count', 0),
-        ('m0_client_types', cluster.m0_client_types),
+        ('m0_client_types', json.dumps(cluster.m0_client_types)),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node
                                                   and node.machine_id)],

--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -189,8 +189,8 @@ nodes:
           data: [ <str> ]   # e.g. [ "/dev/loop0", "/dev/loop1", "/dev/loop2" ]
                             # Empty list means no IO service.
     m0_clients:
-        s3: <int>     # number of S3 servers to start
-        other: <int>  # max quantity of other Motr clients this host may have
+        - name: <str>      # name of the motr client to start(e.g. s3, rgw)
+          instances: <int> # number of client instances to start
 pools:
   - name: <str>
     type: sns|dix|md   # optional, defaults to "sns";
@@ -511,8 +511,13 @@ Make sure the value of data_iface in the CDF is correct.""")
                 f'Node {name}: The same disk is used by several IO services')
         total_nr_disks += len(disks)
 
+        nr_clients = 0
+        if 'm0_clients' in node and node['m0_clients'] is not None:
+            for client in node['m0_clients']:
+                nr_clients += client['instances']
+
         _assert(
-            nr_confds + node['m0_clients']['s3'] + node['m0_clients']['other']
+            nr_confds + nr_clients
             > 0, f'Node {name}: At least one Motr server or '
             'client is required')
 
@@ -1082,13 +1087,15 @@ class ConfProcess(ToDhall):
 
     def __init__(self, nr_cpu: int, memsize_MB: int,
                  endpoint,
-                 services: List[Oid], meta_data: str = None):
+                 services: List[Oid], meta_data: str = None,
+                 proc_name: str = None):
         _assert(nr_cpu > 0, 'nr_cpu must be positive')
         self.nr_cpu = nr_cpu
         _assert(memsize_MB > 0, 'memsize_MB must be positive')
         self.memsize_MB = memsize_MB
         self.endpoint = endpoint
         self.meta_data = meta_data
+        self.proc_name = proc_name
         _assert(all(x.type is ObjT.service for x in services),
                 'All services must be of ObjT.service type')
         self.services = services
@@ -1118,7 +1125,8 @@ class ConfProcess(ToDhall):
               node_desc: Dict[str, Any],
               proc_t: ProcT,
               proc_desc: Dict[str, Any] = None,
-              ctrl: Optional[Oid] = None) -> Oid:
+              ctrl: Optional[Oid] = None,
+              proc_name: str = None) -> Oid:
         _assert(parent.type is ObjT.node,
                 f'Parent must be ObjT.node but {parent.type} was given')
         if ctrl is not None:
@@ -1150,7 +1158,8 @@ class ConfProcess(ToDhall):
                               memsize_MB=facts['_memsize_MB'],
                               endpoint=ep,
                               meta_data=meta_data,
-                              services=[])
+                              services=[],
+                              proc_name=proc_name)
         m0conf[parent].processes.append(proc_id)
 
         for stype in service_types(proc_t, proc_desc):
@@ -2172,7 +2181,8 @@ ConsulAgent = NamedTuple('ConsulAgent', [('node_name', str), ('ipaddr', str)])
 Cluster = NamedTuple('Cluster', [('m0conf', Dict[Oid, Any]),
                                  ('consul_servers', List[ConsulAgent]),
                                  ('consul_clients', List[ConsulAgent]),
-                                 ('m0_clients', Dict[Oid, Oid])])
+                                 ('m0_clients', Dict[Oid, Oid]),
+                                 ('m0_client_types', List[str])])
 
 
 def generate_consul_agents(cluster: Cluster) -> str:
@@ -2280,12 +2290,11 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                                         meta_data=proc.meta_data)
                 # Add Motr clients to consul kv
                 if proc_id in cluster.m0_clients:
-                    proc_ep = m0conf[proc_id].endpoint
                     yield ConsulService(node_name=node.name,
                                         proc_id=proc_id,
                                         ep=proc.endpoint,
                                         svc_id=cluster.m0_clients[proc_id],
-                                        stype=proc_ep.portalgroup.name,
+                                        stype=m0conf[proc_id].proc_name,
                                         meta_data=None)
 
     def sns_pools() -> List[Oid]:
@@ -2306,6 +2315,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('bytecount/degraded_byte_count', 0),
         ('bytecount/critical_byte_count', 0),
         ('bytecount/damaged_byte_count', 0),
+        ('m0_client_types', cluster.m0_client_types),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node
                                                   and node.machine_id)],
@@ -2510,7 +2520,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
 
 def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     cluster = Cluster(m0conf={}, consul_servers=[], consul_clients=[],
-                      m0_clients={})
+                      m0_clients={}, m0_client_types=[])
     conf = cluster.m0conf
     root_id = ConfRoot.build(conf)
     # XXX Move all the logic into ConfRoot.build?
@@ -2574,16 +2584,15 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                                # XXX use 'mgmt_iface' for consul?
                                ipaddr=ipaddr))
 
-        for client_t, proc_t in [('s3', ProcT.m0_client_s3),
-                                 ('other', ProcT.m0_client_other)]:
-            for _ in range(node['m0_clients'][client_t]):
-                proc_id = ConfProcess.build(conf, node_id, portalgroup, node,
-                                            proc_t)
-                cluster.m0_clients[proc_id] = new_oid(ObjT.service)
-                if client_t == 'other':
-                    if node['hostname'] not in other_clients:
-                        other_clients[node['hostname']] = []
-                    other_clients[node['hostname']].append((node_id, proc_id))
+        if 'm0_clients' in node and node['m0_clients'] is not None:
+            for client in node['m0_clients']:
+                for _ in range(client['instances']):
+                    proc_id = ConfProcess.build(conf, node_id, portalgroup,
+                                                node, ProcT.m0_client_other,
+                                                proc_name=client['name'])
+                    cluster.m0_clients[proc_id] = new_oid(ObjT.service)
+                    if client['name'] not in cluster.m0_client_types:
+                        cluster.m0_client_types.append(client['name'])
 
     # Motr requires all the data devices together in-order to map a data object
     # to its corresponding device and further to its ioservice. Motr maintains

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -45,6 +45,7 @@
 , ClusterDesc  = ./types/ClusterDesc.dhall
 , NodeDesc     = ./types/NodeDesc.dhall
 , M0ServerDesc = ./types/M0ServerDesc.dhall
+, M0ClientDesc = ./types/M0ClientDesc.dhall
 , Disk         = ./types/IODisk.dhall
 , PoolDesc     = ./types/PoolDesc.dhall
 , DiskRef      = ./types/DiskRef.dhall

--- a/cfgen/dhall/types/M0ClientDesc.dhall
+++ b/cfgen/dhall/types/M0ClientDesc.dhall
@@ -1,5 +1,5 @@
 {-
-  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cfgen/dhall/types/M0ClientDesc.dhall
+++ b/cfgen/dhall/types/M0ClientDesc.dhall
@@ -18,14 +18,7 @@
 
 -}
 
-{ hostname : Text
-, machine_id : Optional Text
-, processorcount: Optional Natural
-, memorysize_mb: Optional Double
-, data_iface : Text
-, data_iface_ip_addr : Optional Text
-, data_iface_type : Optional ./Protocol.dhall
-, transport_type : Text
-, m0_servers : Optional (List ./M0ServerDesc.dhall)
-, m0_clients : Optional (List ./M0ClientDesc.dhall)
+-- motr client definition
+{ name : Text
+, instances : Natural
 }

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -21,9 +21,9 @@ nodes:
             - path: /dev/loop7
             - path: /dev/loop8
             - path: /dev/loop9
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -29,9 +29,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: ssu3
     data_iface: eth1
     transport_type: libfab
@@ -50,9 +50,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/sde
             - path: /dev/sdf
             - path: /dev/sdg
-    m0_clients:
-        s3: 0           # number of S3 servers to start
-        other: 2        # max quantity of other Motr clients this node may have
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: pod-c2
     data_iface: eth1_c2
     data_iface_type: o2ib
@@ -34,9 +34,9 @@ nodes:
             - path: /dev/sdi
             - path: /dev/sdj
             - path: /dev/sdk
-    m0_clients:
-        s3: 0
-        other: 2
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathd
             - path: /dev/disk/by-id/dm-name-mpathe
             - path: /dev/disk/by-id/dm-name-mpathf
-    m0_clients:
-      s3: 11
-      other: 3
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
   - hostname: srvnode-2
     data_iface: enp175s0f1_c2
     data_iface_type: o2ib
@@ -38,9 +38,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathj
             - path: /dev/disk/by-id/dm-name-mpathk
             - path: /dev/disk/by-id/dm-name-mpathl
-    m0_clients:
-      s3: 11
-      other: 3
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 pools:
   - name: tier1-nvme
     disk_refs:

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -25,9 +25,9 @@ nodes:
             - path: /dev/loop8 
             - path: /dev/loop9 
           meta_data: null
-    m0_clients:
-      s3: 0         # number of S3 servers to start
-      other: 2      # max quantity of other Motr clients this host may have
+    m0_clients: null
+     # - name: other   # name of the motr client
+     #   instances: 2   # Number of instances, this host will run
 create_aux: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -92,10 +92,7 @@ in
                 }
             }
           ]
-      , m0_clients =
-          { s3 = 0
-          , other = 2
-          }
+      , m0_clients = None (List { name : Text, instances : Natural })
       }
     ]
 , pools =

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -2,7 +2,7 @@ import os.path as P
 import subprocess as S
 from dataclasses import dataclass
 from string import Template
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 from math import floor, ceil
 import pkg_resources
 from urllib.parse import urlparse
@@ -12,7 +12,7 @@ from hare_mp.store import ValueProvider
 from hare_mp.types import (ClusterDesc, DiskRef, DList, Maybe, NodeDesc,
                            PoolDesc, PoolType, ProfileDesc, Protocol, Text,
                            M0ServerDesc, DisksDesc, AllowedFailures, Layout,
-                           FdmiFilterDesc, NetworkPorts)
+                           FdmiFilterDesc, NetworkPorts, M0ClientDesc)
 from hare_mp.utils import func_log, func_enter, func_leave, Utils
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
@@ -67,15 +67,18 @@ class CdfGenerator:
         # Skipping for controller and HA pod
         machines = conf.get_machine_ids_for_service(
             Const.SERVICE_MOTR_IO.value)
+        # Get all the pods which runs the client components
+        client_machines = []
+        for client in conf.get_motr_clients():
+            name = str(client.get('name'))
+            client_machines.extend(conf.get_machine_ids_for_component(name))
 
-        s3_machines = conf.get_machine_ids_for_service(
-            Const.SERVICE_S3_SERVER.value)
-        # Avoid adding duplicate machine ids if s3 and data node
+        # Avoid adding duplicate machine ids if client and data node
         # are the same. We do not use list(set()) mechanism as it
         # changes the order and since this code is executed on all
         # the nodes in-parallel, the configuration generated on
         # every node must follow the same order to maintain consistency.
-        for machine in s3_machines:
+        for machine in client_machines:
             if machine not in machines:
                 machines.append(machine)
 
@@ -378,6 +381,24 @@ class CdfGenerator:
         length = 1
         return length
 
+    def _get_node_clients(self, machine_id: str) -> Iterator[M0ClientDesc]:
+        """
+        For all the motr clients present in the cluster return only those
+        clients that are present in the components list for the given
+        node>{machine_id} according to the ConfStore.
+
+        cortx>motr>clients=[rgw, other]
+        node>{machine_id}>components=[motr, other]
+
+        return 'other' only.
+        """
+        for client in self.provider.get_motr_clients():
+            name = str(client.get('name'))
+            if self.utils.is_component(machine_id, name):
+                yield M0ClientDesc(
+                    name=Text(name),
+                    instances=int(str(client.get('num_instances'))))
+
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
 
@@ -385,16 +406,7 @@ class CdfGenerator:
         # node>{machine-id}>name
         iface = self._get_iface(machine_id)
         servers = None
-        no_m0clients = 0
-        nr_s3_instances = 0
         if(self.utils.is_motr_component(machine_id)):
-            try:
-                # cortx>motr>client_instances
-                no_m0clients = int(store.get(
-                    'cortx>motr>client_instances',
-                    allow_null=True))
-            except TypeError:
-                no_m0clients = 2
             # Currently, there is 1 m0d per cvg.
             # We will create 1 IO service entry in CDF per cvg.
             # An IO service entry will use data  and metadat devices
@@ -422,8 +434,12 @@ class CdfGenerator:
                     meta_data=Maybe(None, 'Text')),
                 runs_confd=Maybe(True, 'Bool')))
 
-        if (self.utils.is_s3_component(machine_id)):
-            nr_s3_instances = int(store.get('cortx>s3>service_instances'))
+        # adding clients
+        clients = DList([
+            client
+            for client in self._get_node_clients(machine_id)
+        ], 'List M0ClientDesc')
+        m0_clients = clients if clients else None
 
         node_facts = self.utils.get_node_facts()
         return NodeDesc(
@@ -436,10 +452,5 @@ class CdfGenerator:
             data_iface_type=Maybe(self._get_iface_type(machine_id), 'P'),
             transport_type=Text(self.utils.get_transport_type()),
             m0_servers=Maybe(servers, 'List M0ServerDesc'),
-            #
-            # [KN] This is a hotfix for singlenode deployment
-            # TODO in the future the value must be taken from a correct
-            # ConfStore key (it doesn't exist now).
-            # cortx>s3>service_instances
-            s3_instances=nr_s3_instances,
-            client_instances=no_m0clients)
+            m0_clients=Maybe(m0_clients, 'List M0ClientDesc')
+        )

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -344,14 +344,34 @@ class CdfGenerator:
             return 'dummy'
         return ifaces[0]
 
-    # cortx>motr>interface_type
     def _get_iface_type(self, machine_id: str) -> Optional[Protocol]:
-        iface = self.provider.get(
-            'cortx>motr>interface_type',
+        endpoints = self.provider.get(
+            'cortx>hare>hax>endpoints',
             allow_null=True)
-        if iface is None:
+
+        if endpoints is None:
             return None
-        return Protocol[iface]
+
+        hostname = self.utils.get_hostname(machine_id)
+
+        proto = None
+        # Expected format '<protocol>://<hostname>:<port>'
+        # e.g. endpoints:
+        #      - tcp://data1-node1:22001  # For motr and Hax communication
+        #      - tcp://data1-node2:22001  # For motr and Hax communication
+        for e in endpoints:
+            key = e.split(':')
+
+            if key[0] == 'https':
+                continue
+
+            if key[1].split('/')[2] == hostname:
+                proto = key[0]
+                break
+
+        if proto is None:
+            return None
+        return Protocol[proto]
 
     # node>{machine -id}>storage>cvg[N]>devices>data
     def _get_data_devices(self, machine_id: str, cvg: int) -> DList[Text]:

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -21,6 +21,11 @@ let M0ServerDesc =
       , io_disks : IODisks
       }
 
+let M0ClientDesc =
+      { name : Text
+      , instances : Natural
+      }
+
 let NodeInfo =
       { hostname : Text
       , machine_id : Optional Text
@@ -31,8 +36,7 @@ let NodeInfo =
       , data_iface_type : Optional T.Protocol
       , transport_type : Text
       , m0_servers : Optional (List M0ServerDesc)
-      , s3_instances : Natural
-      , client_instances : Natural
+      , m0_clients : Optional (List M0ClientDesc)
       }
 
 let AllowedFailures =
@@ -78,7 +82,7 @@ let toNodeDesc
           , data_iface = n.data_iface
           , data_iface_type = n.data_iface_type
           , transport_type = n.transport_type
-          , m0_clients = { other = n.client_instances, s3 = n.s3_instances }
+          , m0_clients = n.m0_clients
           , m0_servers = n.m0_servers
           }
 

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -292,7 +292,8 @@ def post_install(args):
     checkRpm('consul')
     checkRpm('cortx-hare')
     checkRpm('cortx-py-utils')
-    checkRpm('cortx-s3server')
+    # we need to check for 'rgw' rpm
+    # checkRpm('cortx-s3server')
 
     if args.report_unavailable_features:
         unsupported_feature(args.config[0])

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -891,8 +891,15 @@ def generate_config(url: str, path_to_cdf: str) -> None:
            '--log-dir', get_log_dir(url),
            '--log-file', LOG_FILE,
            '--uuid', provider.get_machine_id()]
-    execute(cmd, env={'PYTHONPATH': python_path, 'PATH': path,
-                      'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
+
+    locale_info = execute(['locale', '-a'])
+    env = {'PYTHONPATH': python_path, 'PATH': path}
+
+    if 'en_US.utf-8' in locale_info or 'en_US.utf8' in locale_info:
+        env.update({'LC_ALL': "en_US.utf-8", 'LANG': "en_US.utf-8"})
+
+    execute(cmd, env)
+
     utils.copy_conf_files(conf_dir)
     utils.copy_consul_files(conf_dir, mode='client')
     utils.import_kv(conf_dir)

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -85,9 +85,9 @@ class Text:
 
 
 @dataclass(repr=False)
-class M0Clients(DhallTuple):
-    s3: int
-    other: int
+class M0ClientDesc(DhallTuple):
+    name: Text
+    instances: int
 
 
 @dataclass(repr=False)
@@ -120,8 +120,7 @@ class NodeDesc(DhallTuple):
     data_iface_type: Maybe[Protocol]
     transport_type: Text
     m0_servers: Maybe[DList[M0ServerDesc]]
-    s3_instances: int
-    client_instances: int
+    m0_clients: Maybe[DList[M0ClientDesc]]
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -239,7 +239,7 @@ class Utils:
                     m0_client_types = item_data['value']
                     break
 
-        for client_type in m0_client_types:
+        for client_type in json.loads(m0_client_types):
             src = f'{conf_dir_path}/sysconfig/{client_type}/{node_name}'
             dest = f'{global_config_path}/{client_type}/sysconfig/{machine_id}'
             os.makedirs(dest, exist_ok=True)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -152,35 +152,25 @@ class Utils:
     def is_motr_component(self, machine_id: str) -> bool:
         """
         Returns True if motr component is present in the components list
-        for the given node>{machine_id} according to the
-        ConfStore (ValueProvider).
+        for the given node>{machine_id}.
         """
-        comp_names = self.provider.get(f'node>{machine_id}>'
-                                       f'components')
-        for component in comp_names:
-            if(component.get('name') == Const.COMPONENT_MOTR.value):
-                rc = True
-                break
-            else:
-                rc = False
-        return rc
+        return self.is_component(machine_id, Const.COMPONENT_MOTR.value)
 
     @func_log(func_enter, func_leave)
-    def is_s3_component(self, machine_id: str) -> bool:
+    def is_component(self, machine_id: str, name: str) -> bool:
         """
-        Returns True if s3 component is present in the components list
-        for the given node>{machine_id} according to the
+        Returns True if the given component is present in the components
+        list for the given node>{machine_id} according to the
         ConfStore (ValueProvider).
         """
         comp_names = self.provider.get(f'node>{machine_id}>'
                                        f'components')
+        found = False
         for component in comp_names:
-            if(component.get('name') == Const.COMPONENT_S3.value):
-                rc = True
+            if(component.get('name') == name):
+                found = True
                 break
-            else:
-                rc = False
-        return rc
+        return found
 
     @func_log(func_enter, func_leave)
     def save_drives_info(self):

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -29,7 +29,7 @@ import pkg_resources
 
 from hare_mp.cdf import CdfGenerator
 from hare_mp.store import ConfStoreProvider, ValueProvider
-from hare_mp.types import (DisksDesc, Disk, DList, M0Clients, M0ServerDesc, Maybe,
+from hare_mp.types import (DisksDesc, Disk, DList, M0ClientDesc, M0ServerDesc, Maybe,
                            MissingKeyError, PoolDesc, PoolType, Protocol, Text,
                            AllowedFailures, Layout)
 from hare_mp.utils import Utils
@@ -38,8 +38,8 @@ from hax.util import KVAdapter
 
 class TestTypes(unittest.TestCase):
     def test_m0clients(self):
-        val = M0Clients(s3=5, other=2)
-        self.assertEqual('{ s3 = 5, other = 2 }', str(val))
+        val = M0ClientDesc(name='other', instances=2)
+        self.assertEqual('{ name = other, instances = 2 }', str(val))
 
     def test_protocol(self):
         self.assertEqual('P.tcp', str(Protocol.tcp))
@@ -111,6 +111,7 @@ class TestCDF(unittest.TestCase):
 
             store.get_machine_id = Mock(return_value='1114a50a6bf6f9c93ebd3c49d07d3fd4')
             store.get_machine_ids_for_service = Mock(return_value=['1114a50a6bf6f9c93ebd3c49d07d3fd4'])
+            store.get_motr_clients = Mock(return_value=[])
             utils = Utils(store)
             kv = KVAdapter()
             def my_get(key: str, recurse: bool = False):
@@ -234,6 +235,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -307,7 +309,8 @@ class TestCDF(unittest.TestCase):
                 'node': {'MACH_ID': {'cluster_id': 'CLUSTER_ID'}},
                 'node>MACH_ID>cluster_id': 'CLUSTER_ID',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_ID>storage>cvg_count': 2,
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
@@ -323,13 +326,16 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'cortx>motr>client_instances':                2,
             }
             return data.get(value)
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=
+                                      [{'name': 'other',
+                                        'num_instances' : 2}])
+        store.get_machine_ids_for_component = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -375,8 +381,11 @@ class TestCDF(unittest.TestCase):
         self.assertEqual(1, len(ret))
         self.assertEqual(Text('srvnode-1.data.private'), ret[0].hostname)
         self.assertEqual(Text('eth1'), ret[0].data_iface)
-        self.assertEqual(1, ret[0].s3_instances)
-        self.assertEqual(2, ret[0].client_instances)
+        clients = ret[0].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
 
 
         cdf = CdfGenerator(provider=store)
@@ -586,6 +595,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         cdf._get_m0d_per_cvg = Mock(return_value=1)
         utils = Utils(store)
@@ -908,6 +918,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -992,7 +1003,8 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1'],
                 'node>MACH_ID>storage>cvg':
@@ -1008,7 +1020,8 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_2_ID>network>data>private_fqdn':
                     'srvnode-2.data.private',
                 'node>MACH_2_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
+                 {'name': 'other'}],
                 'node>MACH_2_ID>network>data>private_interfaces':
                 ['eth1'],
                 'cortx>motr>transport_type':
@@ -1029,6 +1042,11 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID',
                                                                'MACH_2_ID'])
+        store.get_motr_clients = Mock(return_value=
+                                [{'name': 'other',
+                                'num_instances' : 2}])
+        store.get_machine_ids_for_component = Mock(return_value=['MACH_ID',
+                                                                 'MACH_2_ID'])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
@@ -1077,13 +1095,19 @@ class TestCDF(unittest.TestCase):
         self.assertIn(Text('srvnode-1.data.private'),
                       [ret[0].hostname, ret[1].hostname])
         self.assertEqual(Text('eth1'), ret[0].data_iface)
-        self.assertEqual(1, ret[0].s3_instances)
-        self.assertEqual(2, ret[0].client_instances)
+        clients = ret[0].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
         self.assertIn(Text('srvnode-2.data.private'),
                       [ret[0].hostname, ret[1].hostname])
         self.assertEqual(Text('eth1'), ret[1].data_iface)
-        self.assertEqual(1, ret[1].s3_instances)
-        self.assertEqual(2, ret[1].client_instances)
+        clients = ret[1].m0_clients.value.value
+        self.assertIsInstance(clients, list)
+        self.assertEqual(1, len(clients))
+        self.assertEqual(Text('other'), clients[0].name)
+        self.assertEqual(2, clients[0].instances)
         self.assertEqual('Some (P.tcp)', str(ret[0].data_iface_type))
         self.assertEqual('Some (P.tcp)', str(ret[1].data_iface_type))
 
@@ -1136,6 +1160,7 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
+        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         utils = Utils(store)
         kv = KVAdapter()

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -885,6 +885,8 @@ class TestCDF(unittest.TestCase):
                 },
                 'node>MACH_ID>hostname':
                 'myhost',
+                'cortx>hare>hax>endpoints':
+                ['tcp://myhost:22001'],
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>components':
@@ -996,12 +998,15 @@ class TestCDF(unittest.TestCase):
                 'StorageSet-1',
                 'cluster>storage_set[0]>nodes':
                 ['srvnode_1', 'srvnode_2'],
+                'cortx>hare>hax>endpoints':
+                ['tcp://srvnode-1.data.private:22001',
+                 'tcp://srvnode-2.data.private:22001'],
                 'node>MACH_ID>hostname':
                 'myhost',
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>network>data>private_fqdn':
-                    'srvnode-1.data.private',
+                'srvnode-1.data.private',
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
                  {'name': 'other'}],
@@ -1018,7 +1023,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_2_ID>type':                'storage_node',
                 'cortx>motr>interface_type':                'tcp',
                 'node>MACH_2_ID>network>data>private_fqdn':
-                    'srvnode-2.data.private',
+                'srvnode-2.data.private',
                 'node>MACH_2_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
                  {'name': 'other'}],
@@ -1144,6 +1149,8 @@ class TestCDF(unittest.TestCase):
                 ['/dev/meta1'],
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
+                'cortx>hare>hax>endpoints':
+                ['tcp://myhost:22001'],
                 'cortx>s3>service_instances':
                 1,
                 'cortx>motr>interface_type':

--- a/utils/bootstrap-node
+++ b/utils/bootstrap-node
@@ -33,7 +33,7 @@ The required parameter is one of the following:
 
   --phase 1 - start Motr confd servers
   --phase 2 - start Motr IO servers
-  --phase 3 - start S3 servers
+  --phase 3 - start Motr client services
 
 Options:
   --mkfs-only   Do m0mkfs only (CAUTION: wipes Motr data).
@@ -118,7 +118,7 @@ EOF
     die "'motr-kernel' systemd service is not installed"
 fi
 
-. update-consul-conf --dry-run --xprt $xprt # import CONFD_IDs, IOS_IDs, S3_IDs, id2fid()
+. update-consul-conf --dry-run --xprt $xprt # import CONFD_IDs, IOS_IDs, MOTR_CLIENT_IDS, id2fid()
 
 sysconfig_dir='/etc/sysconfig'
 [ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -187,8 +187,8 @@ case $phase in
        IDs=$IOS_IDs
        ;;
     phase3)
-       proc='s3server@'
-       IDs=$S3_IDs
+       proc=
+       IDs=$MOTR_CLIENT_IDS
        ;;
     *)
        die 'Impossible happened'
@@ -217,11 +217,18 @@ wait_m0mkfs_done() {
 }
 
 for id in $IDs; do
-    fid=$(id2fid $id)
+    if [[ $phase == 'phase3' ]]; then
+        proc="$(echo $id| cut -d':' -f 1| tr -d '"' )@"
+        fid=$(id2fid $(echo $id| cut -d':' -f 2))
+    else
+        fid=$(id2fid $id)
+    fi
+
     if [[ $do_mkfs ]]; then
         sudo systemctl start motr-mkfs@$fid
         wait_m0mkfs_done $id
     fi
+
 
     if [[ $do_mkfs != 'mkfs-only' ]]; then
         sudo systemctl start $proc$fid

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -510,10 +510,10 @@ bootstrap_nodes phase1
 # Start ioservices
 bootstrap_nodes phase2
 
-. update-consul-conf --server --dry-run --xprt $xprt # import S3_IDs
-if [[ -n $S3_IDs ]]; then
-    # Now the 3rd phase (s3servers).
-    say 'Starting S3 servers (phase3)...'
+. update-consul-conf --server --dry-run --xprt $xprt # import MOTR_CLIENT_IDS
+if [[ -n $MOTR_CLIENT_IDS ]]; then
+    # Now the 3rd phase (motr clients).
+    say 'Starting motr clients...'
     bootstrap-node --phase phase3 --xprt $xprt &
     pids=($!)
 

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -168,7 +168,7 @@ def get_nodes_for_cluster(path: str) -> List[Node]:
     client_types = []
     for key in file_data:
         if key['key'] == 'm0_client_types':
-            client_types = key['value']
+            client_types = json.loads(key['value'])
             break
 
     keys = get_keys_for_processes(file_data, client_types)

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -30,7 +30,8 @@ from hax.types import ObjT
 
 from utils import get_node_name
 
-Process = NamedTuple('Process', [('name', str), ('fid', str)])
+Process = NamedTuple('Process', [('name', str), ('fid', str), ('ep', str)])
+KeyData = NamedTuple('KeyData', [('key_path', str), ('ep', str)])
 
 
 class Node:
@@ -38,8 +39,8 @@ class Node:
         self.name = name
         self.svcs: List[Process] = []
 
-    def add_service(self, svc: str, fid: str) -> None:
-        self.svcs.append(Process(svc, fid))
+    def add_service(self, svc: str, fid: str, ep: str) -> None:
+        self.svcs.append(Process(svc, fid, ep))
 
     def get_service(self, service: str) -> Optional[List[Process]]:
         # Returns list of services matching the given service
@@ -79,33 +80,49 @@ def node_names(data: List) -> List[str]:
     return nodes
 
 
-def get_keys_for_processes(data: List, client_types: List) -> List[str]:
+def get_keys_for_processes(data: List, client_types: List) -> List[KeyData]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/services/<svc_type>'
     # entries from the file.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md)
 
-    service_names = 'confd|ios'
+    service_names = 'confd|ios|ha'
 
     for client_type in client_types:
         service_names += '|' + client_type
 
     regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
                        '/(' + service_names + ')+$')
-    keys = []
+    keys: List[KeyData] = []
     for key in data:
         match_result = re.match(regex, key['key'])
         if not match_result:
             continue
-        keys.append(match_result.group(0))
+
+        # Key e.g. m0conf/nodes/localhost/processes/43/services/rgw
+        parts = key['key'].split('/')
+        process_fidk = parts[-3]
+
+        # key e.g. m0conf/nodes/localhost/processes/43/
+        #                         endpoint:inet:tcp:192.168.59.148@5001
+        regex_ep = re.compile(
+            f'^m0conf\\/.*\\/processes\\/{process_fidk}\\/endpoint')
+
+        for epdata in data:
+            result = re.match(regex_ep, epdata['key'])
+            if not result:
+                continue
+
+            keys.append(KeyData(match_result.group(0), epdata['value']))
+            break
     if not keys:
         logging.error('No services found')
     return keys
 
 
 def add_service_to_node(nodes: List[Node], node_name: str, svc_name: str,
-                        fid: str) -> None:
+                        fid: str, ep: str) -> None:
     for node in nodes:
         if node.name == node_name:
-            node.add_service(svc_name, fid)
+            node.add_service(svc_name, fid, ep)
 
 
 def get_service_for_node(nodes: List[Node], node_name: str,
@@ -128,10 +145,12 @@ def get_service_for_node(nodes: List[Node], node_name: str,
     return None
 
 
-def process_all_keys(keys: List,
+def process_all_keys(keys: List[KeyData],
                      nodes: List[Node],
                      client_types: List) -> None:
-    names = {'confd': 'confd', 'ios': 'ioservice'}
+    names = {'confd': 'confd',
+             'ios': 'ioservice',
+             'ha': 'hax'}
 
     for client_type in client_types:
         names[client_type] = client_type
@@ -139,12 +158,14 @@ def process_all_keys(keys: List,
     for key in keys:
         # key looks like
         # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
-        parts = key.split('/')
+        parts = key.key_path.split('/')
         svc_type = parts[-1]
         node_name = parts[2]
         process_fidk = parts[-3]
         add_service_to_node(nodes, node_name, names[svc_type],
-                            to_fid(ObjT.PROCESS.value, int(process_fidk)))
+                            to_fid(ObjT.PROCESS.value, int(process_fidk)),
+                            key.ep)
+
     for node in nodes:
         if not node.svcs:
             logging.error(

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -23,30 +23,32 @@ import argparse
 import json
 import re
 import sys
-from typing import List, NamedTuple, Optional
+from typing import List, Optional, Dict, Any
 import logging
 import simplejson
 from hax.types import ObjT
 
 from utils import get_node_name
-
-Process = NamedTuple('Process', [('name', str), ('fid', str), ('ep', str)])
-KeyData = NamedTuple('KeyData', [('key_path', str), ('ep', str)])
+from helper.exec import Executor, Program
 
 
 class Node:
+    profile_fid: Optional[str] = None
+
     def __init__(self, name: str):
         self.name = name
-        self.svcs: List[Process] = []
+        self.svcs: List[Dict[str, str]] = []
+        self.ha_ep: Optional[str] = None
+        self.uuid: Optional[str] = None
 
-    def add_service(self, svc: str, fid: str, ep: str) -> None:
-        self.svcs.append(Process(svc, fid, ep))
+    def add_service(self, svc: Dict[str, Any]) -> None:
+        self.svcs.append(svc)
 
-    def get_service(self, service: str) -> Optional[List[Process]]:
+    def get_service(self, service: str) -> Optional[List[Dict[str, Any]]]:
         # Returns list of services matching the given service
-        services: List[Process] = []
+        services: List[Dict[str, Any]] = []
         for svc in self.svcs:
-            if svc.name == service:
+            if svc['name'] == service:
                 services.append(svc)
         if services:
             return services
@@ -65,7 +67,7 @@ def to_fid(container: int, key: int) -> str:
     return f'{container:#x}:{key:#x}'
 
 
-def node_names(data: List) -> List[str]:
+def node_names(data: List[Dict[str, str]]) -> List[str]:
     # Get entries from file
     # "key": "m0conf/nodes/<node_fid>",
     # "value": "{\"name\": \"<node name>\", \"state\": \"<HA state>\"}"
@@ -80,7 +82,7 @@ def node_names(data: List) -> List[str]:
     return nodes
 
 
-def get_keys_for_processes(data: List, client_types: List) -> List[KeyData]:
+def get_keys_for_processes(data: List, client_types: List) -> List[str]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/services/<svc_type>'
     # entries from the file.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md)
 
@@ -91,42 +93,124 @@ def get_keys_for_processes(data: List, client_types: List) -> List[KeyData]:
 
     regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
                        '/(' + service_names + ')+$')
-    keys: List[KeyData] = []
+    keys: List[str] = []
     for key in data:
         match_result = re.match(regex, key['key'])
         if not match_result:
             continue
 
-        # Key e.g. m0conf/nodes/localhost/processes/43/services/rgw
-        parts = key['key'].split('/')
-        process_fidk = parts[-3]
+        keys.append(match_result.group(0))
 
-        # key e.g. m0conf/nodes/localhost/processes/43/
-        #                         endpoint:inet:tcp:192.168.59.148@5001
-        regex_ep = re.compile(
-            f'^m0conf\\/.*\\/processes\\/{process_fidk}\\/endpoint')
-
-        for epdata in data:
-            result = re.match(regex_ep, epdata['key'])
-            if not result:
-                continue
-
-            keys.append(KeyData(match_result.group(0), epdata['value']))
-            break
     if not keys:
         logging.error('No services found')
     return keys
 
 
-def add_service_to_node(nodes: List[Node], node_name: str, svc_name: str,
-                        fid: str, ep: str) -> None:
+def get_ha_ep(data: List[Dict[str, str]], node_name: str) -> Optional[str]:
+    # Key e.g. 'm0conf/nodes/localhost/processes/6/services/ha'
+    regex = re.compile(f'^m0conf\\/nodes\\/{node_name}\\/processes\\/.*\\'
+                       '/services\\/ha')
+
+    for key in data:
+        match_result = re.match(regex, key['key'])
+        if not match_result:
+            continue
+        parts = key['key'].split('/')
+        ha_id = parts[4]
+        break
+
+    # Key e.g. 'm0conf/nodes/localhost/processes/6/endpoint'
+    regex = re.compile(f'^m0conf\\/nodes\\/{node_name}\\/processes\\'
+                       f'/{ha_id}\\/endpoint')
+
+    for key in data:
+        match_result = re.match(regex, key['key'])
+        if not match_result:
+            continue
+        return key['value']
+
+    return None
+
+
+def generate_node_uuid() -> str:
+    p = Program(['uuidgen', '--time'])
+    return Executor().run(p)
+
+
+def get_confd_svc(node: Node, data: List) -> Dict[str, Any]:
+    return {'ha_ep': node.ha_ep,
+            'conf_xc': '/etc/motr/confd.xc',
+            'uuid': node.uuid}
+
+
+def get_io_svc(fid: str, node: Node,
+               data: List) -> Dict[str, Any]:
+    svc: Dict[str, Any] = {}
+    svc = {'ha_ep': node.ha_ep,
+           'uuid': node.uuid}
+
+    metadata = get_ios_metadata(fid, node.name, data)
+    if metadata:
+        svc.update({'be_seg_path': metadata})
+
+    return svc
+
+
+def get_ios_metadata(fid: str,
+                     node_name: str,
+                     data: List[Dict[str, str]]) -> Optional[str]:
+    # Key e.g. '"key": "m0conf/nodes/localhost/processes/12/meta_data",
+    #           "value": "/dev/sda"'
+    regex = re.compile(f'^m0conf\\/nodes\\/{node_name}\\/processes\\/{fid}\\'
+                       '/meta_data')
+
+    for key in data:
+        match_result = re.match(regex, key['key'])
+        if not match_result:
+            continue
+        return key['value']
+    return None
+
+
+def get_profile_fid(data: List[Dict[str, str]]) -> Optional[str]:
+    # Key e.g. "m0conf/profiles/0x7000000000000001:0x59"
+    regex = re.compile('^m0conf\\/profiles\\/.*$')
+
+    for key in data:
+        match_result = re.match(regex, key['key'])
+        if not match_result:
+            continue
+        parts = key['key'].split('/')
+        return parts[2]
+    return None
+
+
+def get_motr_client_svc(node: Node, data: List) -> Dict[str, Any]:
+    return {'ha_ep': node.ha_ep,
+            'profile_fid': node.profile_fid}
+
+
+def add_service_to_node(nodes: List[Node], data: List, client_types: List,
+                        node_name: str, svc_name: str,
+                        process_fidk: str, ep: str) -> None:
+    fid = to_fid(ObjT.PROCESS.value, int(process_fidk))
     for node in nodes:
         if node.name == node_name:
-            node.add_service(svc_name, fid, ep)
+            svc: Dict[str, Any] = {}
+            svc.update({'name': svc_name, 'fid': fid, 'ep': ep})
+            if svc_name == 'confd':
+                svc.update(get_confd_svc(node, data))
+            elif svc_name == 'ioservice':
+                svc.update(get_io_svc(process_fidk, node, data))
+            elif svc_name in client_types:
+                svc.update(get_motr_client_svc(node, data))
+            node.add_service(svc)
 
 
-def get_service_for_node(nodes: List[Node], node_name: str,
-                         service: str, path: str) -> Optional[List[Process]]:
+def get_service_for_node(nodes: List[Node],
+                         node_name: str,
+                         service: str,
+                         path: str) -> Optional[List[Dict[str, Any]]]:
     # if node_name is not specified, then local node is used.
     if not node_name:
         node_name = get_node_name(path)
@@ -145,9 +229,10 @@ def get_service_for_node(nodes: List[Node], node_name: str,
     return None
 
 
-def process_all_keys(keys: List[KeyData],
+def process_all_keys(keys: List[str],
                      nodes: List[Node],
-                     client_types: List) -> None:
+                     client_types: List,
+                     data: List) -> None:
     names = {'confd': 'confd',
              'ios': 'ioservice',
              'ha': 'hax'}
@@ -158,13 +243,24 @@ def process_all_keys(keys: List[KeyData],
     for key in keys:
         # key looks like
         # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
-        parts = key.key_path.split('/')
+        parts = key.split('/')
         svc_type = parts[-1]
         node_name = parts[2]
         process_fidk = parts[-3]
-        add_service_to_node(nodes, node_name, names[svc_type],
-                            to_fid(ObjT.PROCESS.value, int(process_fidk)),
-                            key.ep)
+
+        regex_ep = re.compile(
+            f'^m0conf\\/.*\\/processes\\/{process_fidk}\\/endpoint')
+
+        for epdata in data:
+            result = re.match(regex_ep, epdata['key'])
+            if not result:
+                continue
+
+            ep = epdata['value']
+            break
+
+        add_service_to_node(nodes, data, client_types, node_name,
+                            names[svc_type], process_fidk, ep)
 
     for node in nodes:
         if not node.svcs:
@@ -173,15 +269,15 @@ def process_all_keys(keys: List[KeyData],
                 f'node {node.name}')
 
 
-def read_file(path: str):
+def read_file(path: str) -> List[Dict[str, str]]:
     filename = f'{path}/consul-kv.json'
     with open(filename) as consul_kv_file:
-        data = json.load(consul_kv_file)
+        data: List[Dict[str, str]] = json.load(consul_kv_file)
     return data
 
 
 def get_nodes_for_cluster(path: str) -> List[Node]:
-    file_data = read_file(path)
+    file_data: List[Dict[str, str]] = read_file(path)
     nodes: List[Node] = []
     for n in node_names(file_data):
         nodes.append(Node(n))
@@ -193,7 +289,13 @@ def get_nodes_for_cluster(path: str) -> List[Node]:
             break
 
     keys = get_keys_for_processes(file_data, client_types)
-    process_all_keys(keys, nodes, client_types)
+
+    Node.profile_fid = get_profile_fid(file_data)
+    for node in nodes:
+        node.ha_ep = get_ha_ep(file_data, node.name)
+        node.uuid = generate_node_uuid()
+
+    process_all_keys(keys, nodes, client_types, file_data)
     return nodes
 
 

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -17,7 +17,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-# :help: Fetch the fids for motr services (m0d and s3server)
+# :help: Fetch the fids for motr services (m0d and other clients)
 
 import argparse
 import json
@@ -79,12 +79,17 @@ def node_names(data: List) -> List[str]:
     return nodes
 
 
-def get_keys_for_processes(data: List) -> List[str]:
+def get_keys_for_processes(data: List, client_types: List) -> List[str]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/services/<svc_type>'
     # entries from the file.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md)
-    regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
-                       '/(confd|ios|m0_client_s3)+$')
 
+    service_names = 'confd|ios'
+
+    for client_type in client_types:
+        service_names += '|' + client_type
+
+    regex = re.compile('^m0conf\\/.*\\/processes\\/.*\\/services\\'
+                       '/(' + service_names + ')+$')
     keys = []
     for key in data:
         match_result = re.match(regex, key['key'])
@@ -123,8 +128,14 @@ def get_service_for_node(nodes: List[Node], node_name: str,
     return None
 
 
-def process_all_keys(keys: List, nodes: List[Node]) -> None:
-    names = {'confd': 'confd', 'ios': 'ioservice', 'm0_client_s3': 's3server'}
+def process_all_keys(keys: List,
+                     nodes: List[Node],
+                     client_types: List) -> None:
+    names = {'confd': 'confd', 'ios': 'ioservice'}
+
+    for client_type in client_types:
+        names[client_type] = client_type
+
     for key in keys:
         # key looks like
         # 'm0conf/nodes/<name>/processes/<process_fidk>/services/<svc_type>'
@@ -137,7 +148,7 @@ def process_all_keys(keys: List, nodes: List[Node]) -> None:
     for node in nodes:
         if not node.svcs:
             logging.error(
-                'No ioservice, confd, or s3servers found on the '
+                'No ioservice, confd, or any motr client found on the '
                 f'node {node.name}')
 
 
@@ -154,21 +165,28 @@ def get_nodes_for_cluster(path: str) -> List[Node]:
     for n in node_names(file_data):
         nodes.append(Node(n))
 
-    keys = get_keys_for_processes(file_data)
-    process_all_keys(keys, nodes)
+    client_types = []
+    for key in file_data:
+        if key['key'] == 'm0_client_types':
+            client_types = key['value']
+            break
+
+    keys = get_keys_for_processes(file_data, client_types)
+    process_all_keys(keys, nodes, client_types)
     return nodes
 
 
 def parse_opts(argv):
     p = argparse.ArgumentParser(
-        description='Fetches the fids for motr services (m0d and s3server) '
+        description='Fetches the fids for motr services (m0d and clients) '
         'in cluster or node.',
         usage='%(prog)s [OPTION]')
 
     p.add_argument('--service',
                    '-s',
                    help='service name. - Returns fid for given service. '
-                   'List of services- "confd", "ioservice", "s3server". '
+                   'List of services- "confd", "ioservice", other '
+                   'client type. '
                    'Default: Returns the fids for all the services.',
                    type=str,
                    action='store')

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -177,9 +177,20 @@ def processes(cns: Consul, consul_util: ConsulUtil,
     node_health = consul_util.get_node_health_status(node_name)
     process_states = get_node_process_states(cns, node_name)
     process_list = get_node_processes(cns, node_name)
+
+    names = {
+        'confd': 'confd',
+        'ha': 'hax',
+        'ios': 'ioservice',
+        'm0_client_s3': 's3server'
+    }
+    m0_client_types = kv_item(cns, 'm0_client_types')
+    for client_type in json.loads(m0_client_types['Value']):
+        names[client_type] = client_type
+
     return [
         Process(
-            name=proc_id2name(cns, process_list, k),
+            name=proc_id2name(names, process_list, k),
             fid=Fid(0x7200000000000001, k),
             ep=(proc_id2endpoint(process_list, k) or '**ERROR**'),
             status=process_status(node_health, process_states,
@@ -235,19 +246,9 @@ def proc_id2endpoint(process_list: List[Dict[str, Any]],
     return None
 
 
-def proc_id2name(cns: Consul,
+def proc_id2name(names: Dict[str, str],
                  processes: List[Dict[str, Any]],
                  proc_id: int) -> str:
-    names = {
-        'confd': 'confd',
-        'ha': 'hax',
-        'ios': 'ioservice',
-        'm0_client_s3': 's3server'
-    }
-    m0_client_types = kv_item(cns, 'm0_client_types')
-    for client_type in json.loads(m0_client_types['Value']):
-        names[client_type] = client_type
-
     regex = re.compile(
         f'^m0conf\\/.*\\/processes\\/{proc_id}\\/services\\/(.+)$')
     process_found = False

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -179,7 +179,7 @@ def processes(cns: Consul, consul_util: ConsulUtil,
     process_list = get_node_processes(cns, node_name)
     return [
         Process(
-            name=proc_id2name(process_list, k),
+            name=proc_id2name(cns, process_list, k),
             fid=Fid(0x7200000000000001, k),
             ep=(proc_id2endpoint(process_list, k) or '**ERROR**'),
             status=process_status(node_health, process_states,
@@ -235,13 +235,19 @@ def proc_id2endpoint(process_list: List[Dict[str, Any]],
     return None
 
 
-def proc_id2name(processes: List[Dict[str, Any]], proc_id: int) -> str:
+def proc_id2name(cns: Consul,
+                 processes: List[Dict[str, Any]],
+                 proc_id: int) -> str:
     names = {
         'confd': 'confd',
         'ha': 'hax',
         'ios': 'ioservice',
         'm0_client_s3': 's3server'
     }
+    m0_client_types = kv_item(cns, 'm0_client_types')
+    for client_type in json.loads(m0_client_types['Value']):
+        names[client_type] = client_type
+
     regex = re.compile(
         f'^m0conf\\/.*\\/processes\\/{proc_id}\\/services\\/(.+)$')
     process_found = False

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -186,6 +186,14 @@ get_service_host() {
     echo ${1##*:}
 }
 
+get_motr_client_types() {
+
+    local cmd="jq '.[] | select(.key==\"m0_client_types\") |
+                  .value' $kv_file"
+
+    eval $cmd || true
+}
+
 install_motr_conf() {
     local motr_conf_file=$1
     if $custom_config; then
@@ -195,12 +203,12 @@ install_motr_conf() {
     fi
 }
 
-install_s3_conf() {
-    local s3_conf_file=$1
+install_motr_client_conf() {
+    local motr_client_conf_file=$1
     if $custom_config; then
-        sudo install $s3_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
+        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
     else
-        sudo install $s3_conf_file $sysconfig_dir/
+        sudo install $motr_client_conf_file $sysconfig_dir/
     fi
 }
 
@@ -238,7 +246,19 @@ Please verify that the host name matches the one stored in the Consul KV.
 }
 CONFD_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/confd"')
 IOS_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/ios"')
-S3_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/m0_client_s3"')
+
+MOTR_CLIENT_TYPES=$(get_motr_client_types)
+MOTR_CLIENT_TYPES=$(echo $MOTR_CLIENT_TYPES  | cut -d "[" -f2 | cut -d "]" -f1)
+
+MOTR_CLIENT_IDS=
+for motr_client_type in $MOTR_CLIENT_TYPES; do
+    motr_client_type=$(echo $motr_client_type | tr -d ',')
+    ids=$(get_service_ids_from_kv_file "grep -iw \"services\/$motr_client_type\"")
+    for client_id in $ids; do
+        MOTR_CLIENT_IDS+="${motr_client_type}:${client_id} "
+    done
+done
+
 HAX_EP=$(get_service_ep_from_kv_file $HAX_ID)
 
 if $dry_run; then
@@ -366,15 +386,16 @@ EOF
     install_motr_conf /tmp/m0d-$fid
 }
 
-append_s3_svc() {
+append_motr_client_svc() {
     local id=$1
     local fid=$(id2fid $id)
     local ep=$(get_service_ep_from_kv_file $id)
     local addr=$(get_service_addr $ep)
     local port=$(get_service_port $ep)
     local host=$(get_service_host $addr)
-    local s3port=$2
-    local s3svc='s3server'@$fid
+    local client_port=$2
+    local motr_client_type=$(echo $3 | tr -d '"')
+    local svc=$motr_client_type@$fid
     SVCS_CONF+="${SVCS_CONF:+,}{
       \"id\": \"$id\",
       \"name\": \"s3service\",
@@ -387,7 +408,7 @@ append_s3_svc() {
       \"checks\": [
           {
             \"args\": [ \"/opt/seagate/cortx/hare/libexec/check-service\",
-                        \"--svc\", \"$s3svc\", \"--port\", \"$port\",
+                        \"--svc\", \"$svc\", \"--port\", \"$port\",
                         \"--host\", \"$host\",
                         \"--conf-dir\", \"$conf_dir\" ],
             \"interval\": \"1s\",
@@ -397,14 +418,14 @@ append_s3_svc() {
     }"
     local first_profile_fid=$(get_profile_from_kv_file)
     [[ -n $first_profile_fid ]]  # assert
-    cat <<EOF | sudo tee /tmp/s3server-$fid > /dev/null
+    cat <<EOF | sudo tee /tmp/$motr_client_type-$fid > /dev/null
 MOTR_PROFILE_FID=$first_profile_fid
-MOTR_S3SERVER_EP='$ep'
+MOTR_${motr_client_type^^}_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
-MOTR_S3SERVER_PORT=$s3port
+MOTR_${motr_client_type^^}_PORT=$client_port
 EOF
-    install_s3_conf /tmp/s3server-$fid
+    install_motr_client_conf /tmp/$motr_client_type-$fid
 }
 
 for id in $HAX_ID; do
@@ -419,10 +440,13 @@ for id in $IOS_IDs; do
     append_ios_svc $id
 done
 
-s3port=28071
-for id in $S3_IDs; do
-    append_s3_svc $id $s3port
-    ((s3port++))
+client_port=28071
+
+for id in $MOTR_CLIENT_IDS; do
+    proc=$(echo $id| cut -d':' -f 1)
+    client_id=$(echo $id| cut -d':' -f 2)
+    append_motr_client_svc $client_id $client_port $proc
+    ((client_port++))
 done
 
 tmpfile=$(mktemp /tmp/${CONF_FILE##*/}.XXXXXX)

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -428,10 +428,10 @@ append_motr_client_svc() {
     [[ -n $first_profile_fid ]]  # assert
     cat <<EOF | sudo tee /tmp/$motr_client_type-$fid > /dev/null
 MOTR_PROFILE_FID=$first_profile_fid
-MOTR_${motr_client_type^^}_EP='$ep'
+MOTR_CLIENT_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
-MOTR_${motr_client_type^^}_PORT=$client_port
+MOTR_CLIENT_PORT=$client_port
 EOF
     install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -187,9 +187,8 @@ get_service_host() {
 }
 
 get_motr_client_types() {
-
-    local cmd="jq '.[] | select(.key==\"m0_client_types\") |
-                  .value' $kv_file"
+    local cmd="jq -r '.[] | select(.key==\"m0_client_types\") |
+                  .value' $kv_file | jq -r '.[]'"
 
     eval $cmd || true
 }
@@ -249,11 +248,9 @@ CONFD_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/confd"')
 IOS_IDs=$(get_service_ids_from_kv_file 'grep -iw "services\/ios"')
 
 MOTR_CLIENT_TYPES=$(get_motr_client_types)
-MOTR_CLIENT_TYPES=$(echo $MOTR_CLIENT_TYPES  | cut -d "[" -f2 | cut -d "]" -f1)
 
 MOTR_CLIENT_IDS=
 for motr_client_type in $MOTR_CLIENT_TYPES; do
-    motr_client_type=$(echo $motr_client_type | tr -d ',')
     ids=$(get_service_ids_from_kv_file "grep -iw \"services\/$motr_client_type\"")
     for client_id in $ids; do
         MOTR_CLIENT_IDS+="${motr_client_type}:${client_id} "

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -223,6 +223,10 @@ create_client_conf_dir() {
 }
 
 if $custom_config ; then
+    create_motr_conf_dir
+fi
+
+if $custom_config ; then
     [ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
 else
     [ -d $sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -264,7 +268,6 @@ fi
 # --------------------------------------------------------------------
 
 if $custom_config ; then
-    create_motr_conf_dir
     for motr_client_type in $MOTR_CLIENT_TYPES; do
         motr_client_type=$(echo $motr_client_type | tr -d ',' | tr -d '"')
         create_client_conf_dir $motr_client_type

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -205,8 +205,9 @@ install_motr_conf() {
 
 install_motr_client_conf() {
     local motr_client_conf_file=$1
+    local motr_client_type=$2
     if $custom_config; then
-        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/s3/$(get_node_name)/
+        sudo install $motr_client_conf_file $conf_dir/$sysconfig_dir/$motr_client_type/$(get_node_name)/
     else
         sudo install $motr_client_conf_file $sysconfig_dir/
     fi
@@ -216,14 +217,10 @@ create_motr_conf_dir() {
     mkdir -p $conf_dir/$sysconfig_dir/motr/$(get_node_name)
 }
 
-create_s3_conf_dir() {
-    mkdir -p $conf_dir/$sysconfig_dir/s3/$(get_node_name)
+create_client_conf_dir() {
+    local motr_client_type=$1
+    mkdir -p $conf_dir/$sysconfig_dir/$motr_client_type/$(get_node_name)
 }
-
-if $custom_config ; then
-    create_motr_conf_dir
-    create_s3_conf_dir
-fi
 
 if $custom_config ; then
     [ -d $conf_dir/$sysconfig_dir ] || sysconfig_dir='/etc/default'
@@ -265,6 +262,14 @@ if $dry_run; then
     return 0  # we must not `exit`, because the script is sourced
 fi
 # --------------------------------------------------------------------
+
+if $custom_config ; then
+    create_motr_conf_dir
+    for motr_client_type in $MOTR_CLIENT_TYPES; do
+        motr_client_type=$(echo $motr_client_type | tr -d ',' | tr -d '"')
+        create_client_conf_dir $motr_client_type
+    done
+fi
 
 mkdir -p $conf_dir/consul-server-conf/
 mkdir -p $conf_dir/consul-client-conf/
@@ -425,7 +430,7 @@ MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
 MOTR_${motr_client_type^^}_PORT=$client_port
 EOF
-    install_motr_client_conf /tmp/$motr_client_type-$fid
+    install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }
 
 for id in $HAX_ID; do


### PR DESCRIPTION
**Test:**
Tested single node RGW deployment, it was successful
```
[root@cortx-data-headless-svc-ssc-vm-g4-rhev4-0635 /]# hctl status
Byte_count:
    critical_byte_count : 0
    damaged_byte_count : 0
    degraded_byte_count : 0
    healthy_byte_count : 0
Data pool:
    # fid name
    0x6f00000000000001:0x33 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x50 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-server-headless-svc-ssc-vm-g4-rhev4-0635
    [started]  hax        0x7200000000000001:0x29  inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  rgw        0x7200000000000001:0x2c  inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@21501
    cortx-data-headless-svc-ssc-vm-g4-rhev4-0635  (RC)
    [started]  hax        0x7200000000000001:0x7   inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  ioservice  0x7200000000000001:0xa   inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21001
    [started]  ioservice  0x7200000000000001:0x17  inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21002
    [started]  confd      0x7200000000000001:0x24  inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21003
```
