### PR TITLE
consul: hare consul version range is obsolete

### DIFF
--- a/hare.spec
+++ b/hare.spec
@@ -49,7 +49,7 @@ BuildRequires: python3-pip
 BuildRequires: python3-setuptools
 %endif
 
-Requires: consul >= 1.7.0, consul < 1.10.0
+Requires: consul >= 1.9.0, consul < 1.12.0
 %if %{rhel} < 8
 Requires: puppet-agent >= 6.13.0
 %else


### PR DESCRIPTION
In latest container deployments, consul servers are deployed with
version 1.10.0 while clients are still on 1.9.1 and the latest released
version is 1.11.4.
```
[root@cortx-data-headless-svc-ssc-vm-g3-rhev4-2107 /]# consul members
Node                                            Address              Status  Type    Build   Protocol  DC   Segment
consul-server-0                                 172.18.167.20:8301   alive   server  1.10.0  2         dc1  <all>
consul-server-1                                 172.18.31.90:8301    alive   server  1.10.0  2         dc1  <all>
consul-server-2                                 172.18.164.149:8301  alive   server  1.10.0  2         dc1  <all>
cortx-data-headless-svc-ssc-vm-g3-rhev4-2107    172.18.120.211:8301  alive   client  1.9.1   2         dc1  <default>
cortx-data-headless-svc-ssc-vm-g3-rhev4-2184    172.18.31.92:8301    alive   client  1.9.1   2         dc1  <default>
cortx-data-headless-svc-ssc-vm-g3-rhev4-2198    172.18.167.22:8301   alive   client  1.9.1   2         dc1  <default>
```

Solution:
Bump up the required Consul version range to 1.9.0 - 1.12.0.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>