### PR TITLE
Problem: premerge-test failing due to 'm0crate' failure

### DIFF
--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -21,9 +21,9 @@ nodes:
             - path: /dev/loop7
             - path: /dev/loop8
             - path: /dev/loop9
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -29,9 +29,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -14,9 +14,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
   - hostname: ssu2
     data_iface: eth1
     transport_type: libfab
@@ -32,9 +32,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
   - hostname: ssu3
     data_iface: eth1
     transport_type: libfab
@@ -50,9 +50,9 @@ nodes:
             - path: /dev/vde
             - path: /dev/vdf
             - path: /dev/vdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/sde
             - path: /dev/sdf
             - path: /dev/sdg
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
   - hostname: pod-c2
     data_iface: eth1_c2
     data_iface_type: o2ib
@@ -34,9 +34,9 @@ nodes:
             - path: /dev/sdi
             - path: /dev/sdj
             - path: /dev/sdk
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 pools:
   - name: the pool
     disk_refs:

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -17,9 +17,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathd
             - path: /dev/disk/by-id/dm-name-mpathe
             - path: /dev/disk/by-id/dm-name-mpathf
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
   - hostname: srvnode-2
     data_iface: enp175s0f1_c2
     data_iface_type: o2ib
@@ -38,9 +38,9 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathj
             - path: /dev/disk/by-id/dm-name-mpathk
             - path: /dev/disk/by-id/dm-name-mpathl
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 pools:
   - name: tier1-nvme
     disk_refs:

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -25,9 +25,9 @@ nodes:
             - path: /dev/loop8 
             - path: /dev/loop9 
           meta_data: null
-    m0_clients: null
-     # - name: other   # name of the motr client
-     #   instances: 2   # Number of instances, this host will run
+    m0_clients:
+      - name: m0_client_other  # name of the motr client
+        instances: 2   # Number of instances, this host will run
 create_aux: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -92,7 +92,7 @@ in
                 }
             }
           ]
-      , m0_clients = None (List { name : Text, instances : Natural })
+      , m0_clients = Some [ { name = "m0_client_other", instances = 2 } ]
       }
     ]
 , pools =

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -510,21 +510,6 @@ bootstrap_nodes phase1
 # Start ioservices
 bootstrap_nodes phase2
 
-. update-consul-conf --server --dry-run --xprt $xprt # import MOTR_CLIENT_IDS
-if [[ -n $MOTR_CLIENT_IDS ]]; then
-    # Now the 3rd phase (motr clients).
-    say 'Starting motr clients...'
-    bootstrap-node --phase phase3 --xprt $xprt &
-    pids=($!)
-
-    while read node _; do
-        ssh_error_info "$node" "PATH=$PATH $(which bootstrap-node) --phase phase3 --xprt $xprt" &
-        pids+=($!)
-    done < <(get_all_nodes | grep -vw $(node-name) || true)
-    wait4 ${pids[@]}
-    echo ' OK'
-fi
-
 say 'Checking health of services...'
 check_service() {
     local svc=$1
@@ -533,7 +518,7 @@ check_service() {
         fgrep -v '["passing"]' || true
 }
 count=1
-for svc in confd ios s3service; do
+for svc in confd ios; do
     svc_not_ready=$(check_service $svc)
     while [[ $svc_not_ready ]]; do
         if (( $count > 30 )); then

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -387,7 +387,7 @@ def show_text_status(cns: Consul, consul_util: ConsulUtil,
             echo(f'    {h} {leader_tag(cns, h)}')
             for p in processes(cns, consul_util, h):
                 fid: str = f'{p.fid}'
-                echo(f'    [{p.status}]  {p.name:<9}  {fid:<23}  {p.ep}')
+                echo(f'    [{p.status}]  {p.name:<18}  {fid:<30}  {p.ep}')
         if devices_requested:
             echo('Devices:')
             for h in node_names(cns):


### PR DESCRIPTION
**Solution:**
'm0crate-io-conf' expects atleast one client to be configured in CDF.
Modified code to include more client named 'm0_client_other' in
example CDFs
Also modified bootstrap script to skip client service startup

**Test:**
Tested bootstrap on LR setup
```
[root@ssc-vm-g2-rhev4-2221 cortx-hare]# hctl bootstrap --mkfs ~/CDF.yaml_backup
2022-03-03 05:06:36: Generating cluster configuration... OK
2022-03-03 05:06:38: Starting Consul server on this node............ OK
2022-03-03 05:06:48: Importing configuration into the KV store... OK
2022-03-03 05:06:48: Starting Consul on other nodes...Consul ready on all nodes
2022-03-03 05:06:48: Updating Consul configuraton from the KV store... OK
2022-03-03 05:06:50: Waiting for the RC Leader to get elected........... OK
2022-03-03 05:06:59: Starting Motr (phase1, mkfs)... OK
2022-03-03 05:07:08: Starting Motr (phase1, m0d)... OK
2022-03-03 05:07:11: Starting Motr (phase2, mkfs)... OK
2022-03-03 05:07:21: Starting Motr (phase2, m0d)... OK
2022-03-03 05:07:24: Checking health of services... OK

[root@ssc-vm-g2-rhev4-2221 cortx-hare]# hctl status
Byte_count:
    critical_byte_count : 0
    damaged_byte_count : 0
    degraded_byte_count : 0
    healthy_byte_count : 0
Data pool:
    # fid name
    0x6f00000000000001:0x31 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x4f 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax                 0x7200000000000001:0x6          inet:tcp:192.168.59.148@22001
    [started]  confd               0x7200000000000001:0x9          inet:tcp:192.168.59.148@21001
    [started]  ioservice           0x7200000000000001:0xc          inet:tcp:192.168.59.148@21002
    [unknown]  m0_client_other     0x7200000000000001:0x29         inet:tcp:192.168.59.148@21501
    [unknown]  m0_client_other     0x7200000000000001:0x2c         inet:tcp:192.168.59.148@21502
```

Also premerge test is passing now on this PR.

Tested single node deployment
```
[root@ssc-vm-g4-rhev4-0635 k8_cortx_cloud]# kubectl get pods
NAME                                                 READY   STATUS    RESTARTS   AGE
consul-client-fcswj                                  1/1     Running   0          20m
consul-server-0                                      1/1     Running   0          20m
cortx-control-6d6f99cdfd-qrkdl                       1/1     Running   0          19m
cortx-data-ssc-vm-g4-rhev4-0635-f5bc85fc9-wrt44      4/4     Running   0          18m
cortx-ha-6c6cdf6998-84jjk                            3/3     Running   0          16m
cortx-server-ssc-vm-g4-rhev4-0635-65c5f4465c-zgbmd   2/2     Running   0          17m
kafka-0                                              1/1     Running   0          19m
openldap-0                                           1/1     Running   0          20m
zookeeper-0                                          1/1     Running   0          20m
[root@ssc-vm-g4-rhev4-0635 k8_cortx_cloud]# kubectl exec -it cortx-server-ssc-vm-g4-rhev4-0635-65c5f4465c-zgbmd -c cortx-hax -- /bin/bash
[root@cortx-server-headless-svc-ssc-vm-g4-rhev4-0635 /]# hctl status
Byte_count:
    critical_byte_count : 0
    damaged_byte_count : 0
    degraded_byte_count : 0
    healthy_byte_count : 0
Data pool:
    # fid name
    0x6f00000000000001:0x33 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x50 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-server-headless-svc-ssc-vm-g4-rhev4-0635
    [started]  hax                 0x7200000000000001:0x29         inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  rgw                 0x7200000000000001:0x2c         inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@21501
    cortx-data-headless-svc-ssc-vm-g4-rhev4-0635  (RC)
    [started]  hax                 0x7200000000000001:0x7          inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  ioservice           0x7200000000000001:0xa          inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21001
    [started]  ioservice           0x7200000000000001:0x17         inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21002
    [started]  confd               0x7200000000000001:0x24         inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21003
```