### PR TITLE
CORTX-27923 - Upgrade aiohttp version to 3.8.1

### DIFF
--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -18,7 +18,7 @@ pytest-timeout==1.4.2
 
 #:runtime-requirements:
 idna==2.10
-aiohttp==3.7.4.post0
+aiohttp==3.8.1
 click==8.0.1
 dataclasses==0.8
 python-consul==1.1.0


### PR DESCRIPTION
Problem:
aiohttp version is old. It needs to be upgraded

Solution:
aiohttp version will be upgraded to 3.8.1
This version is latest version and it is
expected to resolve security 
vulnerabilities.
Corresponding JIRA 
https://jts.seagate.com/browse/CORTX-27923
Detailed test results are documented and
document is attached to JIRA