### PR TITLE
CORTX-28881: Hare needs to stop using 'cortx>common>setup_type'

### DIFF
--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -17,6 +17,7 @@
 #
 
 import logging
+import logging.handlers
 from typing import List
 from threading import Event
 from hax.types import StoppableThread

--- a/provisioning/miniprov/hare_mp/hax_starter.py
+++ b/provisioning/miniprov/hare_mp/hax_starter.py
@@ -17,6 +17,7 @@
 #
 
 import logging
+import logging.handlers
 import sys
 from threading import Event
 import os

--- a/provisioning/setup.yaml
+++ b/provisioning/setup.yaml
@@ -1,7 +1,7 @@
 hare:
   post_install:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup post_install
-    args: --config $URL --report-unavailable-features --configure-logrotate
+    args: --config $URL --configure-logrotate
   init:
     cmd: /opt/seagate/cortx/hare/bin/hare_setup init
     args: --config $URL

--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -43,8 +43,6 @@ Positional arguments:
                         config files are present.
   -l                    The directory where the Hare related log files
                         are present.
-  --no-systemd          When set, systemd facilities will not be used to
-                        generate the logs
 
 Options:
   -h, --help   Show this help and exit.
@@ -55,10 +53,9 @@ bundle_id=$HOSTNAME
 dest_dir=$DEFAULT_DEST_DIR
 log_dir=$DEFAULT_LOG_DIR
 conf_dir=$DEFAULT_CONF_DIR
-use_systemd=true
 
 TEMP=$(getopt --options hm:b:t:c:l: \
-              --longoptions help,systemd-disabled,no-systemd \
+              --longoptions help,systemd-disabled \
               --name "$PROG" -- "$@" || true)
 
 eval set -- "$TEMP"
@@ -69,7 +66,6 @@ while true; do
         -t)                   dest_dir=$2; shift 2 ;;
         -c)                   conf_dir=$2; shift 2 ;;
         -l)                   log_dir=$2; shift 2 ;;
-        --no-systemd)         use_systemd=false; shift ;;
         --)                   shift; break ;;
         *)                    echo 'getopt: internal error...'; exit 1 ;;
     esac
@@ -124,17 +120,15 @@ cd "$dest_dir/hare/$HOSTNAME"
 exec 5>&2
 exec 2> >(tee _reportbug.stderr >&2)
 
-if $use_systemd; then
-    systemd_journal
+systemd_journal
 
-    sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
-         > syslog-pacemaker.json || true
+sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service \
+     > syslog-pacemaker.json || true
 
-    sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
-         > systemctl-status.txt || true
-else
-    running_process_list
-fi
+sudo systemctl --all --full --no-pager status {hare,m0,motr,s3}\* \
+     > systemctl-status.txt || true
+
+running_process_list
 
 # cluster status
 sudo timeout --kill-after 30 15 hctl status \


### PR DESCRIPTION
**Problem**: 'setup_type' key is getting deleted so Hare needs to stop using it

**Solution**:
Above key was getting used during 'post_install' and suuport bundle generation
Modified code to remove references to above key and make solution generic

**Test:**
Tested 1 node deployment, it was successful.
```
[root@ssc-vm-g4-rhev4-0635 k8_cortx_cloud]# kubectl get pods
NAME                                                 READY   STATUS    RESTARTS   AGE
consul-client-h578z                                  1/1     Running   0          4m38s
consul-server-0                                      1/1     Running   0          4m37s
cortx-control-6c77c7b4d8-ndvtt                       1/1     Running   0          3m18s
cortx-data-ssc-vm-g4-rhev4-0635-8444f98b55-qj64l     4/4     Running   0          2m55s
cortx-ha-8594c658dd-h5pkh                            3/3     Running   0          35s
cortx-server-ssc-vm-g4-rhev4-0635-5dc69f5d4f-x5k8x   2/2     Running   0          97s
kafka-0                                              1/1     Running   0          3m53s
openldap-0                                           1/1     Running   0          4m35s
zookeeper-0                                          1/1     Running   0          4m20s
```

```
[root@cortx-server-headless-svc-ssc-vm-g4-rhev4-0635 cortx-server-headless-svc-ssc-vm-g4-rhev4-0635]# hctl status
Byte_count:
    critical_byte_count : 0
    damaged_byte_count : 0
    degraded_byte_count : 0
    healthy_byte_count : 0
Data pool:
    # fid name
    0x6f00000000000001:0x33 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x50 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-server-headless-svc-ssc-vm-g4-rhev4-0635
    [started]  hax        0x7200000000000001:0x29  inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  rgw        0x7200000000000001:0x2c  inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@21501
    cortx-data-headless-svc-ssc-vm-g4-rhev4-0635  (RC)
    [started]  hax        0x7200000000000001:0x7   inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  ioservice  0x7200000000000001:0xa   inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21001
    [started]  ioservice  0x7200000000000001:0x17  inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21002
    [started]  confd      0x7200000000000001:0x24  inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21003
```

```
/opt/seagate/cortx/utils/bin/cortx_support_bundle generate -c yaml:///etc/cortx/cluster.conf -t file:///var/log/cortx/support_bundle -b SBag9s2455 -m "Testing"
Please use the below bundle id for checking the status of support bundle.
--------------
| SBag9s2455 |
--------------
Please Find the file on -> /var/log/cortx/support_bundle/SBag9s2455 .

[root@cortx-server-headless-svc-ssc-vm-g4-rhev4-0635 cortx-server-headless-svc-ssc-vm-g4-rhev4-0635]# ls -l
total 20
-rw-r--r-- 1 root root 3218 Mar  3 13:07 _reportbug.stderr
drwxr-xr-x 4 root root 4096 Mar  3 13:07 etc
-rw-r--r-- 1 root root 1112 Mar  3 13:07 hctl-status.txt
-rw-r--r-- 1 root root 2534 Mar  3 13:07 processes.txt
-rw-r--r-- 1 root root    0 Mar  3 13:07 syslog-pacemaker.json
-rw-r--r-- 1 root root    0 Mar  3 13:07 systemctl-status.txt
drwxr-xr-x 3 root root 4096 Mar  3 13:07 var
```

On LR:
```
[root@ssc-vm-g2-rhev4-2221 cortx-hare]# hctl reportbug
+ [hare-reportbug:26] PROG=hare-reportbug
+ [hare-reportbug:27] DEFAULT_DEST_DIR=/tmp
+ [hare-reportbug:28] DEFAULT_LOG_DIR=/var/lib/hare
+ [hare-reportbug:29] DEFAULT_CONF_DIR=/var/log/seagate/hare
+ [hare-reportbug:52] bundle_id=ssc-vm-g2-rhev4-2221.colo.seagate.com
+ [hare-reportbug:53] dest_dir=/tmp
+ [hare-reportbug:54] log_dir=/var/lib/hare
+ [hare-reportbug:55] conf_dir=/var/log/seagate/hare
++ [hare-reportbug:59] getopt --options hm:b:t:c:l: --longoptions help,systemd-disabled --name hare-reportbug --
+ [hare-reportbug:59] TEMP=' --'
+ [hare-reportbug:61] eval set -- ' --'
++ [hare-reportbug:61] set -- --
+ [hare-reportbug:62] true
+ [hare-reportbug:63] case "$1" in
+ [hare-reportbug:69] shift
+ [hare-reportbug:69] break
+ [hare-reportbug:74] echo 'Bundle_id: ssc-vm-g2-rhev4-2221.colo.seagate.com'
Bundle_id: ssc-vm-g2-rhev4-2221.colo.seagate.com
+ [hare-reportbug:75] echo 'dest_dir: /tmp'
dest_dir: /tmp
+ [hare-reportbug:76] echo 'conf_dir: /var/log/seagate/hare'
conf_dir: /var/log/seagate/hare
+ [hare-reportbug:77] echo 'log_dir: /var/lib/hare'
log_dir: /var/lib/hare
+ [hare-reportbug:99] case "${1:-}" in
+ [hare-reportbug:103] (( 0 != 0 && 0 != 2 ))
+ [hare-reportbug:107] [[ -z ssc-vm-g2-rhev4-2221.colo.seagate.com ]]
+ [hare-reportbug:107] [[ -z /tmp ]]
+ [hare-reportbug:111] [[ -a /tmp ]]
+ [hare-reportbug:111] [[ ! -d /tmp ]]
+ [hare-reportbug:117] mkdir -p /tmp/hare/ssc-vm-g2-rhev4-2221.colo.seagate.com
+ [hare-reportbug:118] cd /tmp/hare/ssc-vm-g2-rhev4-2221.colo.seagate.com
+ [hare-reportbug:120] exec
+ [hare-reportbug:121] exec
++ [hare-reportbug:121] tee _reportbug.stderr
+ [hare-reportbug:123] systemd_journal
+ [hare-reportbug:85:systemd_journal] local nr_boots_max=10
++ [hare-reportbug:86:systemd_journal] sudo journalctl --list-boot
++ [hare-reportbug:86:systemd_journal] wc -l
+ [hare-reportbug:86:systemd_journal] local nr_boots=1
+ [hare-reportbug:87:systemd_journal] (( nr_boots > nr_boots_max ))
+ [hare-reportbug:90:systemd_journal] (( i = 0 ))
+ [hare-reportbug:90:systemd_journal] (( i < nr_boots ))
+ [hare-reportbug:91:systemd_journal] sudo journalctl -b -0 --utc --no-pager
+ [hare-reportbug:90:systemd_journal] (( ++i ))
+ [hare-reportbug:90:systemd_journal] (( i < nr_boots ))
+ [hare-reportbug:125] sudo journalctl --no-pager --full --utc --output=json --unit=pacemaker.service
+ [hare-reportbug:128] sudo systemctl --all --full --no-pager status 'hare*' 'm0*' 'motr*' 's3*'
+ [hare-reportbug:129] true
+ [hare-reportbug:131] running_process_list
+ [hare-reportbug:96:running_process_list] ps aux
+ [hare-reportbug:134] sudo timeout --kill-after 30 15 hctl status
+ [hare-reportbug:137] sysconfig_dir=/etc/sysconfig
+ [hare-reportbug:138] '[' -d /etc/sysconfig ']'
+ [hare-reportbug:144] extra_files=($sysconfig_dir/motr /opt/seagate/cortx-prvsnr/pillar/components/cluster.sls /opt/seagate/cortx/s3/conf/s3config.yaml)
+ [hare-reportbug:145] for f in '${extra_files[@]}'
+ [hare-reportbug:146] [[ -f /etc/sysconfig/motr ]]
+ [hare-reportbug:147] cp --parents /etc/sysconfig/motr .
+ [hare-reportbug:145] for f in '${extra_files[@]}'
+ [hare-reportbug:146] [[ -f /opt/seagate/cortx-prvsnr/pillar/components/cluster.sls ]]
+ [hare-reportbug:145] for f in '${extra_files[@]}'
+ [hare-reportbug:146] [[ -f /opt/seagate/cortx/s3/conf/s3config.yaml ]]
+ [hare-reportbug:151] cp --parents /var/log/seagate/hare/consul-watch-handler.log .
+ [hare-reportbug:152] cp -r --parents '/var/log/seagate/hare/consul-env-*' '/var/log/seagate/hare/consul-server-*' '/var/log/seagate/hare/consul-client-*' .
+ [hare-reportbug:152] true
+ [hare-reportbug:153] cp -r --parents /var/lib/hare/ .
+ [hare-reportbug:154] cp -r --parents /var/log/cluster/ .
+ [hare-reportbug:154] true
+ [hare-reportbug:156] cd ..
+ [hare-reportbug:159] exec
+ [hare-reportbug:161] [[ -s ssc-vm-g2-rhev4-2221.colo.seagate.com/_reportbug.stderr ]]
+ [hare-reportbug:163] tar --remove-files -czf hare_ssc-vm-g2-rhev4-2221.colo.seagate.com.tar.gz ssc-vm-g2-rhev4-2221.colo.seagate.com
+ [hare-reportbug:164] echo 'Created /tmp/hare/hare_ssc-vm-g2-rhev4-2221.colo.seagate.com.tar.gz'

[root@ssc-vm-g2-rhev4-2221 ssc-vm-g2-rhev4-2221.colo.seagate.com]# ls -l
total 168516
drwxr-xr-x 3 root root      4096 Mar  3 06:25 etc
-rw-r--r-- 1 root root       970 Mar  3 06:25 hctl-status.txt
-rw-r--r-- 1 root root     28858 Mar  3 06:25 processes.txt
-rw-r--r-- 1 root root      2164 Mar  3 06:25 _reportbug.stderr
-rw-r--r-- 1 root root         0 Mar  3 06:25 syslog-pacemaker.json
-rw-r--r-- 1 root root     17647 Mar  3 06:25 systemctl-status.txt
-rw-r--r-- 1 root root 172489103 Mar  3 06:25 systemd-journal_0
drwxr-xr-x 4 root root      4096 Mar  3 06:25 var
```