### PR TITLE
CORTX-29157: inconsistency in sysconfig file for MOTR_PROFILE_FID key

### DIFF
--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -424,11 +424,11 @@ append_motr_client_svc() {
     local first_profile_fid=$(get_profile_from_kv_file)
     [[ -n $first_profile_fid ]]  # assert
     cat <<EOF | sudo tee /tmp/$motr_client_type-$fid > /dev/null
-MOTR_PROFILE_FID=$first_profile_fid
+MOTR_PROFILE_FID='$first_profile_fid'
 MOTR_CLIENT_EP='$ep'
 MOTR_HA_EP='$HAX_EP'
 MOTR_PROCESS_FID='$fid'
-MOTR_CLIENT_PORT=$client_port
+MOTR_CLIENT_PORT='$client_port'
 EOF
     install_motr_client_conf /tmp/$motr_client_type-$fid $motr_client_type
 }


### PR DESCRIPTION
**Solution:**
Modified 'MOTR_PROFILE_FID' and 'MOTR_CLIENT_PORT' value to be in string format

**Test:** 
Tested 1 node deployment using RGW PR https://github.com/Seagate/cortx-rgw-integration/pull/50
```
[root@ssc-vm-g4-rhev4-0635 ~]# kubectl get pods
NAME                                                 READY   STATUS    RESTARTS   AGE
consul-client-wwm8w                                  1/1     Running   0          42m
consul-server-0                                      1/1     Running   0          42m
cortx-control-678c577b88-gv8ts                       1/1     Running   0          41m
cortx-data-ssc-vm-g4-rhev4-0635-566dc59ff9-49xkh     4/4     Running   0          40m
cortx-ha-7c8dc56d9b-6gcql                            3/3     Running   0          37m
cortx-server-ssc-vm-g4-rhev4-0635-7564d7b54d-jlvr6   2/2     Running   0          38m
kafka-0                                              1/1     Running   0          41m
openldap-0                                           1/1     Running   0          42m
zookeeper-0                                          1/1     Running   0          41m
[root@ssc-vm-g4-rhev4-0635 ~]# kubectl exec -it cortx-server-ssc-vm-g4-rhev4-0635-7564d7b54d-jlvr6 -c cortx-hax -- /bin/bash
[root@cortx-server-headless-svc-ssc-vm-g4-rhev4-0635 /]# hctl status
Byte_count:
    critical_byte_count : 0
    damaged_byte_count : 0
    degraded_byte_count : 0
    healthy_byte_count : 0
Data pool:
    # fid name
    0x6f00000000000001:0x33 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x50 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-server-headless-svc-ssc-vm-g4-rhev4-0635
    [started]  hax        0x7200000000000001:0x29  inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  rgw        0x7200000000000001:0x2c  inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@21501
    cortx-data-headless-svc-ssc-vm-g4-rhev4-0635  (RC)
    [started]  hax        0x7200000000000001:0x7   inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001
    [started]  ioservice  0x7200000000000001:0xa   inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21001
    [started]  ioservice  0x7200000000000001:0x17  inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21002
    [started]  confd      0x7200000000000001:0x24  inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21003

[root@cortx-server-headless-svc-ssc-vm-g4-rhev4-0635 /]# cat /etc/cortx/rgw/sysconfig/cc2eac3fede44b76b5d5c021f1a3989a/rgw-0x7200000000000001\:0x2c
MOTR_PROFILE_FID='0x7000000000000001:0x50'
MOTR_CLIENT_EP='inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@21501'
MOTR_HA_EP='inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001'
MOTR_PROCESS_FID='0x7200000000000001:0x2c'
MOTR_CLIENT_PORT='28071'
```