### PR TITLE
CORTX-29081: skip parity buffers count while calculating byte count

### DIFF
--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -32,7 +32,7 @@ from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.motr.planner import WorkPlanner
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
-                       MessageId, ObjT, FidTypeToObjT, Profile, PverState,
+                       MessageId, ObjT, FidTypeToObjT, Profile, PverInfo,
                        ReprebStatus, ObjHealth,
                        m0HaProcessEvent, m0HaProcessType)
 from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
@@ -718,13 +718,13 @@ class Motr:
                   bytecount.pvers)
         return bytecount
 
-    def get_pver_status(self, pver_fid: Fid) -> PverState:
-        status = self._ffi.pver_status_fetch(
+    def get_pver_status(self, pver_fid: Fid) -> PverInfo:
+        status: PverInfo = self._ffi.pver_status_fetch(
             self._ha_ctx, pver_fid.to_c())
-        if status < 0:
+        if not status:
             raise RuntimeError('Pool version status unavailable')
-        LOG.debug('Pver status for pver %s: %s', pver_fid, status)
-        return PverState(status)
+        LOG.debug('Pver status for pver %s: %s', pver_fid, status.state)
+        return status
 
     def get_repair_status(self, pool_fid: Fid) -> List[ReprebStatus]:
         LOG.debug('Fetching repair status for pool %s', pool_fid)

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -136,7 +136,7 @@ class HaxFFI:
 
         lib.m0_ha_pver_status.argtypes = [c.c_void_p,
                                           c.POINTER(FidStruct)]
-        lib.m0_ha_pver_status.restype = c.c_int
+        lib.m0_ha_pver_status.restype = c.py_object
         self.pver_status_fetch = lib.m0_ha_pver_status
 
         lib.repair_status.argtypes = [c.c_void_p, c.POINTER(FidStruct)]

--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -117,10 +117,12 @@ PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
 	struct m0_fid *proc_fid);
 
 /*
- * Invokes XXX api to fetch the status of the pool version fid,
- * provided as an input.
+ * Invokes m0_spiel_conf_pver_status() to fetch the status and pool version
+ * attributes of the pool version fid provided as an input.
+ *
+ * @return Python object of type hax.types.PverInfo
  */
-int m0_ha_pver_status(unsigned long long ctx, struct m0_fid *pver_fid);
+PyObject *m0_ha_pver_status(unsigned long long ctx, struct m0_fid *pver_fid);
 
 PyObject *m0_hax_stop(unsigned long long ctx, const struct m0_fid *process_fid,
 		      const char *hax_endpoint);

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -204,6 +204,14 @@ class PverState(IntEnum):
     M0_CPS_DAMAGED = 3
 
 
+PverInfo = NamedTuple('PverInfo', [('fid', Fid),
+                                   ('state', PverState),
+                                   ('data_units', int),
+                                   ('parity_units', int),
+                                   ('pool_width', int),
+                                   ('unit_size', int)])
+
+
 # enum m0_cm_status
 class SnsCmStatus(Enum):
     CM_STATUS_INVALID = 0

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -37,9 +37,9 @@ from urllib3.exceptions import HTTPError
 from hax.common import HaxGlobalState
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FsStatsWithTime,
-                       ObjT, ObjHealth, Profile, PverState, m0HaProcessEvent,
-                       m0HaProcessType, KeyDelete, HaNoteStruct,
-                       m0HaObjState)
+                       ObjT, ObjHealth, Profile, PverInfo, PverState,
+                       m0HaProcessEvent, m0HaProcessType, KeyDelete,
+                       HaNoteStruct, m0HaObjState)
 
 from hax.consul.cache import (uses_consul_cache, invalidates_consul_cache,
                               supports_consul_cache)
@@ -1287,7 +1287,8 @@ class ConsulUtil:
             self.kv.kv_put(key, value)
 
     def update_bc_for_dg_category(self,
-                                  pver_items: Dict[str, PverState]) -> None:
+                                  pver_bc: Dict[str, int],
+                                  pver_state: Dict[str, PverInfo]):
         '''
         This function will update bytecount for subsequent dg state/category
         which will reflect on cluster status.
@@ -1295,26 +1296,21 @@ class ConsulUtil:
         ioservices/0x7200000000000001:0x20/pvers/0x7600000000000001:0x6/users/1
         value = {"bc": 4096, "object_cnt": 1}
         '''
-        pool_ver = self.kv.kv_get('ioservices/', recurse=True)
         pver_state_map = {
             PverState.M0_CPS_HEALTHY: 'healthy',
             PverState.M0_CPS_DEGRADED: 'degraded',
             PverState.M0_CPS_CRITICAL: 'critical',
             PverState.M0_CPS_DAMAGED: 'damaged'
         }
-        # Calculate total bytecount per pver and store it based on its status.
+        # Calculate total bytecount based on pver status.
         data: Dict[PverState, int] = {}
-        for pver, status in pver_items.items():
-            total_bc = 0
-            for pool in pool_ver:
-                if pver in pool['Key']:
-                    total_bc += json.loads(pool['Value'].decode())['bc']
-            LOG.debug('pool version : %s  total_bytecount : %s  Status : %s',
-                      pver, total_bc, pver_state_map[status])
-            if status in data:
-                data[status] += total_bc
+        for pver, info in pver_state.items():
+            bc = pver_bc.get(pver, 0)
+            state = info.state
+            if state in data:
+                data[state] += bc
             else:
-                data[status] = total_bc
+                data[state] = bc
         # Populate the consul kv with total bytecount based on state.
         for state in pver_state_map:
             self.kv.kv_put(f'bytecount/{pver_state_map[state]}',


### PR DESCRIPTION
Currently, the bytecount aggregation for pool configurations except
parity units 0 included the parity buffer count.

We are now calculating the parity buffers and removing those from
the final bytecount of a specific pool version.

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>


### Testing
cdf file
```
pools:
  - name: the pool
    type: sns  # optional; supported values: "sns" (default), "dix", "md"
    disk_refs:
      - { path: /dev/loop0, node: localhost }
      - { path: /dev/loop1, node: localhost }
      - { path: /dev/loop2, node: localhost }
      - { path: /dev/loop3, node: localhost }
      - { path: /dev/loop4, node: localhost }
      - { path: /dev/loop5, node: localhost }
      - { path: /dev/loop6, node: localhost }
      - { path: /dev/loop7, node: localhost }
      - { path: /dev/loop8, node: localhost }
      - { path: /dev/loop9, node: localhost }
    data_units: 2
    parity_units: 1
    spare_units: 0
    #allowed_failures: { site: 0, rack: 0, encl: 0, ctrl: 0, disk: 0 }
```
hctl status
```
$ hctl status
Bytecount:
    critical : 0
    damaged : 0
    degraded : 0
    healthy : 10485760
Data pool:
    # fid name
    0x6f00000000000001:0x3d 'the pool'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x61 'default': 'the pool' None None
Services:
    localhost  (RC)
    [started]  hax        0x7200000000000001:0x7   inet:tcp:192.168.56.39@22001
    [started]  confd      0x7200000000000001:0xa   inet:tcp:192.168.56.39@21001
    [started]  ioservice  0x7200000000000001:0xd   inet:tcp:192.168.56.39@21002
    [started]  ioservice  0x7200000000000001:0x20  inet:tcp:192.168.56.39@21003
    [offline]  m0_client_other  0x7200000000000001:0x33  inet:tcp:192.168.56.39@21501
    [unknown]  m0_client_other  0x7200000000000001:0x36  inet:tcp:192.168.56.39@21502
```

Logs

```
Mar 05 04:02:28 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[49072]: 2022-03-05 04:02:28,325 [DEBUG] {byte-count-updater} Received bytecount: ByteCountStats(proc_fid=0x7200000000000001:0x20, pvers=[PverBC(pver_fid=0x7600000000000001:0x3e, user_id=8881212, byte_count=9437184, object_count=1)])
Mar 05 04:02:28 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[49072]: 2022-03-05 04:02:28,325 [DEBUG] {byte-count-updater} Setting bytecount stats in KV: ioservices/0x7200000000000001:0x20/pvers/0x7600000000000001:0x3e/users/8881212:{"bc": 9437184, "object_cnt": 1}

{byte-count-updater} Received bytecount: ByteCountStats(proc_fid=0x7200000000000001:0xd, pvers=[PverBC(pver_fid=0x7600000000000001:0x3e, user_id=8881212, byte_count=6291456, object_count=1)])
Mar 05 04:02:28 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[49072]: 2022-03-05 04:02:28,311 [DEBUG] {byte-count-updater} Setting bytecount stats in KV: ioservices/0x7200000000000001:0xd/pvers/0x7600000000000001:0x3e/users/8881212:{"bc": 6291456, "object_cnt": 1}


Mar 05 04:02:58 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[49072]: 2022-03-05 04:02:58,334 [DEBUG] {byte-count-updater} Received pool version and status: {'0x7600000000000001:0x3e': PverInfo(fid=0x7600000000000001:0x3e, state=0, data_units=2, parity_units=1, pool_width=10, unit_size=0)}

Mar 05 04:02:58 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[49072]: 2022-03-05 04:02:58,337 [DEBUG] {byte-count-updater} Bytecount with parity buffer: {'0x7600000000000001:0x3e': 15728640}

Mar 05 04:02:58 ssc-vm-g3-rhev4-2743.colo.seagate.com hare-hax[49072]: 2022-03-05 04:02:58,337 [DEBUG] {byte-count-updater} Bytecount without parity buffer: {'0x7600000000000001:0x3e': 10485760}
```

