### PR TITLE
sns: hare issues duplicate sns repair trigger

### DIFF
--- a/rules/sns-repair
+++ b/rules/sns-repair
@@ -51,11 +51,25 @@ case $cmd in
     ;;
 esac
 
-log "handler is called for $cmd, $fid, $op_name"
+log "handler is called for $cmd, $fid"
 
 payload=$(jq --null-input --compact-output \
-             --arg op_name "$op_name" \
+             --arg cmd "$cmd" \
              --arg fid "$fid" \
-             '{ op_name: $op_name, fid: $fid }')
+             '{ cmd: $cmd, fid: $fid }')
 
-h0q bq SNS_OP "$payload"
+get_ip_addr() {
+    curl -sX GET http://localhost:8500/v1/agent/self | jq -r .DebugConfig.BindAddr
+}
+
+ip_addr=$(get_ip_addr)
+
+status_code=$(curl http://${ip_addr}:8008/api/v1/sns/${op_name} \
+                   --silent \
+                   --output /dev/null \
+                   --request POST \
+                   --write-out '%{http_code}\n' \
+                   --data "$payload")
+rc=$?
+[[ status_code -eq 200 && rc -eq 0 ]] \
+    || log "rule failed. http: $status_code, rc: $rc"


### PR DESCRIPTION
Hare uses motr spiel api to trigger sns recovery operations. Presently,
Hare adds the sns operation to broadcast queue, this was changed as part
of commit 7543caf, but since spiel api connects to all the ioservices
in the cluster and sends the trigger to all the ioservices itself, hare,
further invoking the spiel command on all the nodes leads to duplication
of this trigger.

Solution:
Revert to commit `bc44695` and let only rc invoke the spiel command
for sns operations.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>