### PR TITLE
CORTX-29099: hare does not map the sns device states correctly

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -330,10 +330,11 @@ class m0HaProcessType(IntEnum):
 
 
 class m0HaObjState(IntEnum):
-    M0_NC_UNKNOWN = HaNoteStruct.M0_NC_UNKNOWN
+    M0_NC_UNKNOWN = HaNoteStruct.M0_NC_TRANSIENT
     M0_NC_ONLINE = HaNoteStruct.M0_NC_ONLINE
     M0_NC_FAILED = HaNoteStruct.M0_NC_FAILED
     M0_NC_TRANSIENT = HaNoteStruct.M0_NC_TRANSIENT
+    M0_NC_REPAIR = HaNoteStruct.M0_NC_REPAIR
     M0_NC_REPAIRED = HaNoteStruct.M0_NC_REPAIRED
     M0_NC_REBALANCE = HaNoteStruct.M0_NC_REBALANCE
     M0_NC_NR = HaNoteStruct.M0_NC_NR
@@ -345,10 +346,11 @@ class m0HaObjState(IntEnum):
     def parse(state: str) -> 'm0HaObjState':
 
         states = {
-            'M0_NC_UNKNOWN': m0HaObjState.M0_NC_UNKNOWN,
+            'M0_NC_UNKNOWN': m0HaObjState.M0_NC_TRANSIENT,
             'M0_NC_ONLINE': m0HaObjState.M0_NC_ONLINE,
             'M0_NC_FAILED': m0HaObjState.M0_NC_FAILED,
             'M0_NC_TRANSIENT': m0HaObjState.M0_NC_TRANSIENT,
+            'M0_NC_REPAIR': m0HaObjState.M0_NC_REPAIR,
             'M0_NC_REPAIRED': m0HaObjState.M0_NC_REPAIRED,
             'M0_NC_REBALANCE': m0HaObjState.M0_NC_REBALANCE,
             'M0_NC_NR': m0HaObjState.M0_NC_NR

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -698,6 +698,10 @@ def create_stub_get(process_type: str) -> Callable[[str, bool], Any]:
             return [
                 new_kv(k, v) for k, v in
                 [('m0conf/sites/0x5300000000000001:0x1/racks'
+                  '/0x6100000000000001:0x2/encls/0x6500000000000001:0x4',
+                  json.dumps({"node": "0x6e00000000000001:0x3",
+                              "state": "M0_NC_UNKNOWN"})),
+                 ('m0conf/sites/0x5300000000000001:0x1/racks'
                   '/0x6100000000000001:0x2/encls/0x6500000000000001:0x4'
                   '/ctrls/0x6300000000000001:0x5',
                   json.dumps({"state": "M0_NC_UNKNOWN"})),
@@ -711,6 +715,15 @@ def create_stub_get(process_type: str) -> Callable[[str, bool], Any]:
                   '/ctrls/0x6300000000000001:0x6',
                   json.dumps({"state": "M0_NC_UNKNOWN"}))]
             ]
+        elif (key == 'm0conf/sites/0x5300000000000001:0x1/racks'
+              '/0x6100000000000001:0x2/encls/0x6500000000000001:0x4'):
+            return new_kv(
+                'm0conf/sites/0x5300000000000001:0x1/racks'
+                '/0x6100000000000001:0x2/encls/0x6500000000000001:0x4',
+                json.dumps({
+                    "node": "0x6e00000000000001:0x3",
+                    "state": "M0_NC_UNKNOWN"
+                }))
         elif key == 'processes/0x7200000000000001:0x15':
             return new_kv(
                 'processes/0x7200000000000001',
@@ -832,6 +845,9 @@ def test_nonmkfs_process_stop_causes_drive_offline(mocker, motr, consul_util):
                         'kv_get',
                         side_effect=create_stub_get('M0_CONF_HA_PROCESS_M0D'))
     mocker.patch.object(consul_util.kv, 'kv_put', return_value=0)
+    mocker.patch.object(consul_util,
+                        'get_node_health_status',
+                        return_value='passing')
     mocker.patch.object(consul_util, 'update_drive_state')
     mocker.patch.object(consul_util,
                         'get_hax_fid',


### PR DESCRIPTION
Hare reports online for sns device states in nvec reply.

Solution:
Map sns device states correctly to their respective ha states during
nvec reply.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>