### PR TITLE
CORTX-27809: Provide an interface/API to query motr client endpoint and fid

### DIFF
--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -91,6 +91,24 @@ def hctl_stat(request):
     return json_response(text=result)
 
 
+# This function implements the http fetch-fids request and thus, takes
+# request a parameter. The respective result is obtained by executing
+# corresponding `hctl-fetch-fids` script.
+def hctl_fetch_fids(request):
+    """This function calls the hare-fetch-fids script from the hax-server in
+    order to provide details about services configured by Hare e.g. Hax,
+    ios, confd, rgw etc
+    """
+    exec = Executor()
+    env = get_python_env()
+    result = exec.run(Program(["/opt/seagate/cortx/hare/libexec/"
+                               "hare-fetch-fids",
+                               "--all",
+                               "--use-kv-store"]),
+                      env=env)
+    return json_response(text=result)
+
+
 def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
     """Converts a dictionary, obtained from JSON data, into a list of
     HA states.
@@ -323,6 +341,7 @@ class ServerRunner:
             web.get('/', hello_reply),
             web.get('/v1/cluster/status', hctl_stat),
             web.get('/v1/cluster/status/bytecount', bytecount_stat),
+            web.get('/v1/cluster/fetch-fids', hctl_fetch_fids),
             web.post('/', process_ha_states(planner, consul_util)),
             web.post(
                 '/watcher/bq',

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -290,6 +290,7 @@ def prepare(args):
     _create_consul_namespace(conf_dir)
     consul_starter = _start_consul(utils, stop_event, conf_dir, log_dir, url)
     utils.save_config_path(url)
+    utils.save_log_path()
     utils.save_node_facts()
     utils.save_drives_info()
     try:

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -37,6 +37,8 @@ from helper.exec import Program, Executor
 from hare_mp.store import ValueProvider
 from hare_mp.types import Disk, DList, Maybe, Text
 
+LOG_DIR_EXT = '/hare/log/'
+
 
 def func_enter(func):
     """
@@ -147,6 +149,15 @@ class Utils:
                                  'blksize': int(disk.blksize.get())})
         disk_key = path.strip('/')
         self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
+
+    @func_log(func_enter, func_leave)
+    @repeat_if_fails()
+    def save_log_path(self):
+        hostname = self.get_local_hostname()
+        machine_id = self.provider.get_machine_id()
+        log_key = self.provider.get('cortx>common>storage>log')
+        log_path = log_key + LOG_DIR_EXT + machine_id
+        self.kv.kv_put(f'{hostname}/log_path', log_path)
 
     @func_log(func_enter, func_leave)
     def is_motr_component(self, machine_id: str) -> bool:

--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -546,6 +546,55 @@ $ hctl fetch-fids -n ssc-vm-c-1813.colo.seagate.com --json
 ]
 ```
 
+In order to fetch fids via http, an endpoint has been added in hax server which returns the fids of all the services.
+The endpoint is /cluster/fetch-fids and can be accessed using a curl command.
+```
+# curl 'http://192.168.59.148:8008/v1/cluster/fetch-fids'
+[
+  {
+    "name": "localhost",
+    "svcs": [
+      {
+        "name": "ioservice",
+        "fid": "0x7200000000000001:0xc",
+        "ep": "inet:tcp:192.168.59.148@21002",
+        "ha_ep": "inet:tcp:192.168.59.148@22001",
+        "uuid": "afeb371c-a069-11ec-bc8b-566fcce40574"
+      },
+      {
+        "name": "m0_client_other",
+        "fid": "0x7200000000000001:0x29",
+        "ep": "inet:tcp:192.168.59.148@21501",
+        "ha_ep": "inet:tcp:192.168.59.148@22001",
+        "profile_fid": "0x7000000000000001:0x4f"
+      },
+      {
+        "name": "m0_client_other",
+        "fid": "0x7200000000000001:0x2c",
+        "ep": "inet:tcp:192.168.59.148@21502",
+        "ha_ep": "inet:tcp:192.168.59.148@22001",
+        "profile_fid": "0x7000000000000001:0x4f"
+      },
+      {
+        "name": "hax",
+        "fid": "0x7200000000000001:0x6",
+        "ep": "inet:tcp:192.168.59.148@22001"
+      },
+      {
+        "name": "confd",
+        "fid": "0x7200000000000001:0x9",
+        "ep": "inet:tcp:192.168.59.148@21001",
+        "ha_ep": "inet:tcp:192.168.59.148@22001",
+        "conf_xc": "/etc/motr/confd.xc",
+        "uuid": "afeb371c-a069-11ec-bc8b-566fcce40574"
+      }
+    ],
+    "ha_ep": "inet:tcp:192.168.59.148@22001",
+    "uuid": "afeb371c-a069-11ec-bc8b-566fcce40574"
+  }
+]
+```
+
 ## Node management
 
 ```

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -23,13 +23,26 @@ import argparse
 import json
 import re
 import sys
+import os
 from typing import List, Optional, Dict, Any
 import logging
+import logging.handlers
 import simplejson
+import inject
+from socket import gethostname
 from hax.types import ObjT
+from hax.common import di_configuration
+from hax.util import ConsulUtil, repeat_if_fails
+from hax.exception import HAConsistencyException
 
 from utils import get_node_name
 from helper.exec import Executor, Program
+
+# This flag will decide how details will be fetched.
+# Flag will be set to True if '--use-kv-store' is passed as argument
+# If flag is set to 'True' then KV store(for e.g. consul) will be used.
+# Default value is 'False' which means details will be fetched from KV file
+g_use_kv_store: bool = False
 
 
 class Node:
@@ -61,6 +74,46 @@ class Node:
 
     def for_json(self):
         return self.__dict__
+
+
+@repeat_if_fails(max_retries=2)
+def get_log_path():
+    cns_utils = ConsulUtil()
+    hostname = gethostname()
+    log_path_key = cns_utils.kv.kv_get(f'{hostname}/log_path')
+
+    if log_path_key is None:
+        log_path = '/var/log/seagate/hare'
+    else:
+        log_path = log_path_key['Value'].decode()
+
+    return log_path
+
+
+def setup_logging() -> None:
+    # Currently if 'hctl fetch-fids' gets called as command then there is
+    # possibility that consul is not accessible as consul client is not
+    # running. In that case default log path will be used. In such case if we
+    # are on LC environment then this default path will not be considered and
+    # hctl.log file will not be part of support bundle generated.
+    try:
+        log_path = get_log_path()
+    except Exception:
+        log_path = '/var/log/seagate/hare'
+
+    log_file = log_path + '/hctl.log'
+    os.makedirs(log_path, exist_ok=True)
+
+    console = logging.StreamHandler(stream=sys.stdout)
+    fhandler = logging.handlers.RotatingFileHandler(log_file,
+                                                    maxBytes=1024 * 1024,
+                                                    mode='a',
+                                                    backupCount=5,
+                                                    encoding=None,
+                                                    delay=False)
+    logging.basicConfig(level=logging.INFO,
+                        handlers=[console, fhandler],
+                        format='%(asctime)s [%(levelname)s] %(message)s')
 
 
 def to_fid(container: int, key: int) -> str:
@@ -276,8 +329,26 @@ def read_file(path: str) -> List[Dict[str, str]]:
     return data
 
 
+@repeat_if_fails(max_retries=5)
+def read_kv() -> Optional[List[Dict[str, str]]]:
+    cns_utils = ConsulUtil()
+    data: List[Dict[str, str]] = []
+    for key in ["m0conf", "m0_client_types"]:
+        kv_data = cns_utils.kv.kv_get(key, recurse=True)
+        if not kv_data:
+            raise RuntimeError(f"'{key}' not found in KV store")
+        for d in kv_data:
+            data.append({'key': d['Key'], 'value': d['Value']})
+
+    return data
+
+
 def get_nodes_for_cluster(path: str) -> List[Node]:
-    file_data: List[Dict[str, str]] = read_file(path)
+    file_data: List[Dict[str, str]] = []
+    if g_use_kv_store:
+        file_data = read_kv()
+    else:
+        file_data = read_file(path)
     nodes: List[Node] = []
     for n in node_names(file_data):
         nodes.append(Node(n))
@@ -350,13 +421,21 @@ def parse_opts(argv):
     p.add_argument('--json',
                    help='show output in JSON format',
                    action='store_true')
+    p.add_argument('--use-kv-store',
+                   help='use KV store for e.g. consul to get data',
+                   action='store_true')
 
     return p.parse_args(argv)
 
 
 def main(argv=None):
     opts = parse_opts(argv)
+    inject.configure(di_configuration)
+    setup_logging()
     try:
+        if opts.use_kv_store:
+            global g_use_kv_store
+            g_use_kv_store = True
         nodes = get_nodes_for_cluster(opts.conf_dir)
 
         if opts.all:
@@ -375,8 +454,12 @@ def main(argv=None):
             else:
                 print(simplejson.dumps(svcs, indent=2, for_json=True))
 
+    except HAConsistencyException as err:
+        logging.error(f"Could not read data from KV store '{err}'")
+        return -1
     except (RuntimeError, FileNotFoundError) as e:
-        print(e, file=sys.stderr)
+        logging.error(e)
+        return -1
 
     return 0
 


### PR DESCRIPTION
**Solution**:
Added support for API for fetching fids and other client info.
Also modified 'hctl fetch-fids' to provide an option to read
info from consul rather than kv file

**Test:**
Tested 1 node deployment, deployment was successful.
Tested api 'curl http://172.16.150.118:8008/v1/cluster/fetch-fids'
```
[root@ssc-vm-g4-rhev4-0635 ~]# curl http://172.16.150.118:8008/v1/cluster/fetch-fids
[
  {
    "name": "cortx-server-headless-svc-ssc-vm-g4-rhev4-0635",
    "svcs": [
      {
        "name": "hax",
        "fid": "0x7200000000000001:0x29",
        "ep": "inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001"
      },
      {
        "name": "rgw",
        "fid": "0x7200000000000001:0x2c",
        "ep": "inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@21501",
        "ha_ep": "inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001",
        "profile_fid": "0x7000000000000001:0x50"
      }
    ],
    "ha_ep": "inet:tcp:cortx-server-headless-svc-ssc-vm-g4-rhev4-0635@22001",
    "uuid": "c316e62c-9fa8-11ec-95b8-32c4ff230ca2"
  },
  {
    "name": "cortx-data-headless-svc-ssc-vm-g4-rhev4-0635",
    "svcs": [
      {
        "name": "ioservice",
        "fid": "0x7200000000000001:0xa",
        "ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21001",
        "ha_ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001",
        "uuid": "c317aea4-9fa8-11ec-8f8c-32c4ff230ca2",
        "be_seg_path": "/dev/sdc"
      },
      {
        "name": "ioservice",
        "fid": "0x7200000000000001:0x17",
        "ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21002",
        "ha_ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001",
        "uuid": "c317aea4-9fa8-11ec-8f8c-32c4ff230ca2",
        "be_seg_path": "/dev/sdf"
      },
      {
        "name": "confd",
        "fid": "0x7200000000000001:0x24",
        "ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@21003",
        "ha_ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001",
        "conf_xc": "/etc/motr/confd.xc",
        "uuid": "c317aea4-9fa8-11ec-8f8c-32c4ff230ca2"
      },
      {
        "name": "hax",
        "fid": "0x7200000000000001:0x7",
        "ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001"
      }
    ],
    "ha_ep": "inet:tcp:cortx-data-headless-svc-ssc-vm-g4-rhev4-0635@22001",
    "uuid": "c317aea4-9fa8-11ec-8f8c-32c4ff230ca2"
  }
]
```