### PR TITLE
CORTX-28971: update service fids along with process fids

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -187,7 +187,8 @@ QW_F = 0xffffffffffffffff   # QW = QuadWord
 
 ObjTMaskMap = {
     # here for object key - higher 32 bits is masked for dynamic part.
-    ObjT.PROCESS: Fid(QW_F, DW_F)
+    ObjT.PROCESS: Fid(QW_F, DW_F),
+    ObjT.SERVICE: Fid(QW_F, DW_F)
 }
 
 

--- a/hax/test/integration/test_motr.py
+++ b/hax/test/integration/test_motr.py
@@ -799,6 +799,13 @@ def create_stub_get(process_type: str) -> Callable[[str, bool], Any]:
                     "name": "localhost",
                     "state": "M0_NC_UNKNOWN"
                 }))
+        elif key == '0x7300000000000001:0x10':
+            return new_kv('0x7300000000000001:0x10',
+                          json.dumps('0x7300000000000001:0x10'))
+        elif key == '0x7300000000000001:0x11':
+            return new_kv('0x7300000000000001:0x11',
+                          json.dumps('0x7300000000000001:0x11'))
+ 
         raise RuntimeError(f'Unexpected call: key={key}, recurse={recurse}')
 
     return my_get
@@ -849,6 +856,9 @@ def test_nonmkfs_process_stop_causes_drive_offline(mocker, motr, consul_util):
                         'get_node_health_status',
                         return_value='passing')
     mocker.patch.object(consul_util, 'update_drive_state')
+    mocker.patch.object(consul_util,
+                        'get_node_health_status',
+                        return_value='passing')
     mocker.patch.object(consul_util,
                         'get_hax_fid',
                         return_value=Fid(0x7200000000000001, 0x6))


### PR DESCRIPTION
A motr client restart is considered as a permanent failure
and thus, if an existing motr client restarts its existing
fid is updated by Hare. A motr process comprises of motr
services associated to it. Interested motr modules subscribe
to change in the service states, also, motr confc (configuration
cache) maintains a hierarchy of processes and services, thus
if a process fid changes without updating the service fids,
it will not be possible to map a given process to its corresponding
services. Thus, It is important to update the services fids
along with its respective process fid.

Solution:
- Allocate service fids along with its corresponding process fid.
- Make fid allocation routine generic to work for any motr
  configuration object.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>