### PR TITLE
CORTX-28870: Alex scan generate false positive

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -1,0 +1,3 @@
+{
+  "allow": ["execute", "host-hostess", "remains", "reject", "traps", "period", "invalid", "execution", "simple", "failure"]
+}

--- a/.github/workflows/alex_reviewdog.yml
+++ b/.github/workflows/alex_reviewdog.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: reviewdog/action-alex@v1
+      - uses: seagate/action-alex@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: added


### PR DESCRIPTION
Alex scan may report certain words to be prohibited from there use in various documentation or code. For example,

easy might be reported as insensitive. Thus we want to avoid such false positives.



**Solution:**

Add relevant words to the list to avoid such false positives as part of Alex scan configuration.

Signed-off-by: Venkatesh K <venkatesh.k@seagate.com>