### PR TITLE
CORTX-29311: Hare-mini-prov: include missing hare kvs to be deleted during cleanup

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -588,8 +588,37 @@ def reset(args):
         raise RuntimeError(f'Error during reset : {error}')
 
 
-def kv_cleanup():
+@func_log(func_enter, func_leave)
+@repeat_if_fails()
+def cleanup_node_facts(utils: Utils, cns_utils: ConsulUtil):
+    hostname = utils.get_local_hostname()
+    keys: List[KeyDelete] = [
+        KeyDelete(name=f'{hostname}/facts', recurse=True),
+    ]
+
+    if not cns_utils.kv.kv_delete_in_transaction(keys):
+        logging.error('Delete transaction failed for %s', keys)
+
+
+@func_log(func_enter, func_leave)
+@repeat_if_fails()
+def cleanup_disks_info(utils: Utils, cns_utils: ConsulUtil):
+    hostname = utils.get_local_hostname()
+    keys: List[KeyDelete] = [
+        KeyDelete(name=f'{hostname}/drives', recurse=True),
+    ]
+
+    if not cns_utils.kv.kv_delete_in_transaction(keys):
+        logging.error('Delete transaction failed for %s', keys)
+
+
+@func_log(func_enter, func_leave)
+def kv_cleanup(url):
     util: ConsulUtil = ConsulUtil()
+    conf = ConfStoreProvider(url)
+    utils = Utils(conf)
+    cleanup_disks_info(utils, util)
+    cleanup_node_facts(utils, util)
 
     if is_cluster_running():
         logging.info('Cluster is running, shutting down')
@@ -603,7 +632,11 @@ def kv_cleanup():
         KeyDelete(name='m0conf/', recurse=True),
         KeyDelete(name='processes/', recurse=True),
         KeyDelete(name='stats/', recurse=True),
-        KeyDelete(name='mkfs/', recurse=True)
+        KeyDelete(name='mkfs/', recurse=True),
+        KeyDelete(name='bytecount/', recurse=True),
+        KeyDelete(name='config_path', recurse=False),
+        KeyDelete(name='failvec', recurse=False),
+        KeyDelete(name='m0_client_types', recurse=True)
     ]
 
     logging.info('Deleting Hare KV entries (%s)', keys)
@@ -633,10 +666,11 @@ def get_config_dir(url) -> str:
     return config_path + CONF_DIR_EXT + '/' + machine_id
 
 
+@func_log(func_enter, func_leave)
 def cleanup(args):
     try:
-        kv_cleanup()
         url = args.config[0]
+        kv_cleanup(url)
         logs_cleanup(url)
         config_cleanup(url)
         if args.pre_factory:

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -146,7 +146,7 @@ class Utils:
                                  'size': int(disk.size.get()),
                                  'blksize': int(disk.blksize.get())})
         disk_key = path.strip('/')
-        self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
+        self.kv.kv_put(f'{hostname}/drives/{disk_key}', drive_info)
 
     @func_log(func_enter, func_leave)
     def is_motr_component(self, machine_id: str) -> bool:
@@ -191,7 +191,7 @@ class Utils:
         drive_info = None
         while (not drive_data or drive_data is None):
             try:
-                drive_data = self.kv.kv_get(f'{hostname}/{disk_path}')
+                drive_data = self.kv.kv_get(f'{hostname}/drives/{disk_path}')
                 drive_info = json.loads(drive_data['Value'])
             except TypeError:
                 logging.info('%s details are not available yet, retrying...',


### PR DESCRIPTION
Some of the newly added Hare-Consul key values are not included in the list of keys
to be deleted as part of the Hare mini-provisioner cleanup stage, e.g. byte-count.

Solution:
Removed remaining key values from consul kv as part of Hare mini-provisioner 
cleanup stage.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>