### PR TITLE
CORTX-29150 : rules: `logger` doesn't work in container environment

### DIFF
--- a/rules/sns-rebalance
+++ b/rules/sns-rebalance
@@ -28,14 +28,15 @@ set -e -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 log() {
-    logger --stderr --tag "$0" "$*"
+    # logger --stderr --tag "$0" "$*"
+    echo -n "$*"
 }
 
 cmd=$(jq --raw-output '.cmd' <<<"$HARE_RC_EVENT_PAYLOAD")
 fid=$(jq --raw-output '.fid' <<<"$HARE_RC_EVENT_PAYLOAD")
 
 if [[ -z "$cmd" || -z "$fid" ]]; then
-    logger --stderr "Invalid payload $HARE_RC_EVENT_PAYLOAD"
+    log "Invalid payload $HARE_RC_EVENT_PAYLOAD"
     exit 1
 fi
 

--- a/rules/sns-repair
+++ b/rules/sns-repair
@@ -28,14 +28,15 @@ set -e -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 log() {
-    logger --stderr --tag "$0" "$*"
+    # logger --stderr --tag "$0" "$*"
+    echo -n "$*"
 }
 
 cmd=$(jq --raw-output '.cmd' <<<"$HARE_RC_EVENT_PAYLOAD")
 fid=$(jq --raw-output '.fid' <<<"$HARE_RC_EVENT_PAYLOAD")
 
 if [[ -z "$cmd" || -z "$fid" ]]; then
-    logger --stderr "Invalid payload $HARE_RC_EVENT_PAYLOAD"
+    log "Invalid payload $HARE_RC_EVENT_PAYLOAD"
     exit 1
 fi
 


### PR DESCRIPTION
Hare sns rules scripts use `logger` to log error messages to
standard error. This does not work in container environment as
it tries to access `/dev/log` that is typically linked to
`/run/systemd/journal/dev-log`, which is not present in container
environment if systemd is not enabled.

Solution:
Make logging more generic by echoing the error message instead of using
logger.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>