### PR TITLE
CORTX-29486: Hare fails to communicate on 0.0.0.0 consul bind address

### DIFF
--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -68,7 +68,9 @@ class ConsulStarter(StoppableThread):
                                                       delay=False)
             LOG.addHandler(fh)
             cmd = ['consul', 'agent', f'-bind={self.bind_addr}',
-                   f'-client={self.client_addr}', '-datacenter=dc1',
+                   f'-advertise={self.bind_addr}',
+                   f'-client=127.0.0.1 {self.bind_addr}',
+                   '-datacenter=dc1',
                    f'-data-dir={self.data_dir}', '-enable-script-checks',
                    f'-config-dir={self.config_dir}', '-domain=consul',
                    '-serf-lan-port=8301']

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -29,6 +29,7 @@ import os
 import shutil
 import subprocess
 import sys
+import socket
 from enum import Enum
 from sys import exit
 from time import sleep, perf_counter
@@ -222,6 +223,7 @@ def _start_consul(utils: Utils,
 
     provider = ConfStoreProvider(url)
     consul_endpoints = provider.get('cortx>external>consul>endpoints')
+    hostname = utils.get_local_hostname()
 
     # remove tcp://
     peers = []
@@ -233,9 +235,11 @@ def _start_consul(utils: Utils,
         peer = ('/'.join(key[2:]))
         peers.append(peer)
 
+    bind_addr = socket.gethostbyname(hostname)
     consul_starter = ConsulStarter(utils=utils, stop_event=stop_event,
                                    log_dir=log_dir, data_dir=data_dir,
-                                   config_dir=config_dir, peers=peers)
+                                   config_dir=config_dir, peers=peers,
+                                   bind_addr=bind_addr)
     consul_starter.start()
 
     return consul_starter


### PR DESCRIPTION
Hare configures consul client agent with 0.0.0.0 bind address. Some
of the Hare rules fetch the bind address from Consul in-order to
communicate over http, but communication fails as 0.0.0.0 resolution
fails.

Solution:
Bind Consul client agent to a specific ip address instead of 0.0.0.0.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>