### PR TITLE
CORTX-29457: locale warnings generated as part of hctl command

### DIFF
--- a/hctl
+++ b/hctl
@@ -123,7 +123,7 @@ is_systemd_enabled() {
 }
 
 locale_set() {
-    if [[ `locale -a | grep "en_US.utf8"` ]]; then
+    if [[ `locale -a 2>/dev/null | grep "en_US.utf8"` ]]; then
         export LANG="en_US.UTF-8"
         export LC_ALL="en_US.UTF-8"
     fi


### PR DESCRIPTION
In container environment, `locale -a` command generates following
warnings,
```
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-1630 /]# locale -a
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_COLLATE to default locale: No such file or directory
```
Hare hctl interface uses `locale -a` to find and set appropriate locale, thus
the above warnings are generated during hctl command execution.

Solution:
Redirect stderr messages generated on `locale -a` execution to `/dev/null`.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>