### PR TITLE
Merge dg_bytecount branch to main

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2311,10 +2311,10 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('leader', ''),
         ('last_fidk', _fidk_gen),
         ('failvec', ''),
-        ('bytecount/healthy_byte_count', 0),
-        ('bytecount/degraded_byte_count', 0),
-        ('bytecount/critical_byte_count', 0),
-        ('bytecount/damaged_byte_count', 0),
+        ('bytecount/healthy', 0),
+        ('bytecount/degraded', 0),
+        ('bytecount/critical', 0),
+        ('bytecount/damaged', 0),
         ('m0_client_types', json.dumps(cluster.m0_client_types)),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node

--- a/hax/hax/bytecount.py
+++ b/hax/hax/bytecount.py
@@ -18,10 +18,11 @@
 
 import logging
 from threading import Event
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
-from hax.types import ByteCountStats, Fid, ObjHealth, StoppableThread
+from hax.types import (ByteCountStats, Fid, ObjHealth, PverState,
+                       StoppableThread)
 from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
@@ -42,6 +43,28 @@ class ByteCountUpdater(StoppableThread):
         self.stopped = True
         self.event.set()
 
+    def _get_pver_with_pver_status(self,
+                                   motr: Motr) -> Optional[
+                                       Dict[str, PverState]]:
+        '''
+        Getting a dictionary value of pver and it's state like below example:
+        Ex: {'0x7600000000000001:0x8': PverState.M0_CPS_CRITICAL,
+             '0x7600000000000001:0x9': PverState.M0_CPS_HEALTHY
+            }
+        Pver data is stored in consul kv in format
+        key = ioservices/0x7200000000000001:0x20/pvers/
+              0x7600000000000001:0x6/users/1
+        value = {"bc": 4096, "object_cnt": 1}
+        '''
+        iosservice_items = self.consul.kv.kv_get('ioservices/', recurse=True)
+        pver_items = {}
+        if iosservice_items:
+            for k in iosservice_items:
+                p_ver = k['Key'].split('/')[3]
+                pver_items[p_ver] = motr.get_pver_status(Fid.parse(p_ver))
+            LOG.debug('Received pool version and status: %s', pver_items)
+        return pver_items
+
     @log_exception
     def _execute(self, motr: Motr):
         try:
@@ -55,6 +78,8 @@ class ByteCountUpdater(StoppableThread):
                     continue
                 processes: List[Tuple[Fid, ObjHealth]] = \
                     self.consul.get_proc_fids_with_status(['ios'])
+                if not processes:
+                    continue
                 for ios, status in processes:
                     if status == ObjHealth.OK:
                         byte_count: ByteCountStats = motr.get_proc_bytecount(
@@ -71,6 +96,11 @@ class ByteCountUpdater(StoppableThread):
                                       'will be made timely')
 
                 wait_for_event(self.event, self.interval_sec)
+
+                pver_items = self._get_pver_with_pver_status(motr)
+                if not pver_items:
+                    continue
+                self.consul.update_bc_for_dg_category(pver_items)
         except InterruptedException:
             # No op. _sleep() has interrupted before the timeout exceeded:
             # the application is shutting down.

--- a/hax/hax/bytecount.py
+++ b/hax/hax/bytecount.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,21 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-import datetime
 import logging
 from threading import Event
-
+from typing import List, Tuple
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
-from hax.types import FsStatsWithTime, StoppableThread
+from hax.types import ByteCountStats, Fid, ObjHealth, StoppableThread
 from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
 
 
-class FsStatsUpdater(StoppableThread):
+class ByteCountUpdater(StoppableThread):
     def __init__(self, motr: Motr, consul_util: ConsulUtil, interval_sec=5):
         super().__init__(target=self._execute,
-                         name='fs-stats-updater',
+                         name='byte-count-updater',
                          args=(motr, ))
         self.stopped = False
         self.consul = consul_util
@@ -46,30 +45,31 @@ class FsStatsUpdater(StoppableThread):
     @log_exception
     def _execute(self, motr: Motr):
         try:
-            LOG.info('filesystem stats updater thread has started')
+            LOG.info('byte-count updater thread has started')
             while not self.stopped:
                 if not self.consul.am_i_rc():
                     wait_for_event(self.event, self.interval_sec)
                     continue
-                if (not motr.is_spiel_ready() or (
-                        not all(self.consul.ensure_ioservices_running()))):
+                if not motr.is_spiel_ready():
                     wait_for_event(self.event, self.interval_sec)
                     continue
-                stats = motr.get_filesystem_stats()
-                if not stats:
-                    continue
-                LOG.debug('FS stats are as follows: %s', stats)
-                now_time = datetime.datetime.now()
-                data = FsStatsWithTime(stats=stats,
-                                       timestamp=now_time.timestamp(),
-                                       date=now_time.isoformat())
-                try:
-                    self.consul.update_fs_stats(data)
-                except HAConsistencyException:
-                    LOG.debug('Failed to update Consul KV '
-                              'due to an intermittent error. The '
-                              'error is swallowed since new attempts '
-                              'will be made timely')
+                processes: List[Tuple[Fid, ObjHealth]] = \
+                    self.consul.get_proc_fids_with_status(['ios'])
+                for ios, status in processes:
+                    if status == ObjHealth.OK:
+                        byte_count: ByteCountStats = motr.get_proc_bytecount(
+                            ios)
+                        LOG.debug('Received bytecount: %s', byte_count)
+                        if not byte_count:
+                            continue
+                        try:
+                            self.consul.update_pver_bc(byte_count)
+                        except HAConsistencyException:
+                            LOG.debug('Failed to update Consul KV '
+                                      'due to an intermittent error. The '
+                                      'error is swallowed since new attempts '
+                                      'will be made timely')
+
                 wait_for_event(self.event, self.interval_sec)
         except InterruptedException:
             # No op. _sleep() has interrupted before the timeout exceeded:
@@ -79,4 +79,4 @@ class FsStatsUpdater(StoppableThread):
         except Exception:
             LOG.exception('Aborting due to an error')
         finally:
-            LOG.debug('filesystem stats updater thread exited')
+            LOG.debug('byte-count updater thread exited')

--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -22,7 +22,7 @@ from threading import Event
 
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
-from hax.types import FsStatsWithTime, StoppableThread
+from hax.types import Fid, FsStatsWithTime, ObjT, StoppableThread
 from hax.util import ConsulUtil, wait_for_event
 
 LOG = logging.getLogger('hax')
@@ -55,6 +55,14 @@ class FsStatsUpdater(StoppableThread):
                         not all(self.consul.ensure_ioservices_running()))):
                     wait_for_event(self.event, self.interval_sec)
                     continue
+                # Testing purpose and usage
+                proc_fid = Fid(ObjT.PROCESS.value, 15)
+                byte_count = motr.get_proc_bytecount(proc_fid)
+                LOG.debug('Received bytecount: %s', byte_count)
+                pver_fid = Fid(ObjT.PVER.value, 8)
+                pver_status = motr.get_pver_status(pver_fid)
+                LOG.debug('Received pver: %s', pver_status)
+
                 stats = motr.get_filesystem_stats()
                 if not stats:
                     continue

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -33,7 +33,7 @@ from hax.motr.planner import WorkPlanner
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
                        MessageId, ObjT, FidTypeToObjT, Profile, PverState,
-                       ReprebStatus, ObjHealth, ServiceHealth,
+                       ReprebStatus, ObjHealth,
                        m0HaProcessEvent, m0HaProcessType)
 from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
 

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -32,7 +32,7 @@ from hax.motr.ffi import HaxFFI, make_array, make_c_str
 from hax.motr.planner import WorkPlanner
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FidStruct, FsStats,
                        HaLinkMessagePromise, HaNote, HaNoteStruct, HAState,
-                       MessageId, ObjT, FidTypeToObjT, Profile, PverState,
+                       MessageId, ObjT, FidTypeToObjT, Profile, PverInfo,
                        ReprebStatus, ObjHealth,
                        m0HaProcessEvent, m0HaProcessType)
 from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
@@ -718,13 +718,13 @@ class Motr:
                   bytecount.pvers)
         return bytecount
 
-    def get_pver_status(self, pver_fid: Fid) -> PverState:
-        status = self._ffi.pver_status_fetch(
+    def get_pver_status(self, pver_fid: Fid) -> PverInfo:
+        status: PverInfo = self._ffi.pver_status_fetch(
             self._ha_ctx, pver_fid.to_c())
-        if status < 0:
+        if not status:
             raise RuntimeError('Pool version status unavailable')
-        LOG.debug('Pver status for pver %s: %s', pver_fid, status)
-        return PverState(status)
+        LOG.debug('Pver status for pver %s: %s', pver_fid, status.state)
+        return status
 
     def get_repair_status(self, pool_fid: Fid) -> List[ReprebStatus]:
         LOG.debug('Fetching repair status for pool %s', pool_fid)

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -129,6 +129,16 @@ class HaxFFI:
         lib.m0_ha_filesystem_stats_fetch.restype = c.py_object
         self.filesystem_stats_fetch = lib.m0_ha_filesystem_stats_fetch
 
+        lib.m0_ha_proc_counters_fetch.argtypes = [c.c_void_p,
+                                                  c.POINTER(FidStruct)]
+        lib.m0_ha_proc_counters_fetch.restype = c.py_object
+        self.proc_bytecount_fetch = lib.m0_ha_proc_counters_fetch
+
+        lib.m0_ha_pver_status.argtypes = [c.c_void_p,
+                                          c.POINTER(FidStruct)]
+        lib.m0_ha_pver_status.restype = c.c_int
+        self.pver_status_fetch = lib.m0_ha_pver_status
+
         lib.repair_status.argtypes = [c.c_void_p, c.POINTER(FidStruct)]
         lib.repair_status.restype = c.py_object
         self.repair_status = lib.repair_status

--- a/hax/hax/motr/ffi.py
+++ b/hax/hax/motr/ffi.py
@@ -136,7 +136,7 @@ class HaxFFI:
 
         lib.m0_ha_pver_status.argtypes = [c.c_void_p,
                                           c.POINTER(FidStruct)]
-        lib.m0_ha_pver_status.restype = c.c_int
+        lib.m0_ha_pver_status.restype = c.py_object
         self.pver_status_fetch = lib.m0_ha_pver_status
 
         lib.repair_status.argtypes = [c.c_void_p, c.POINTER(FidStruct)]

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -29,7 +29,7 @@
 #include "fid/fid.h"		/* M0_FID_TINIT */
 #include "ha/halon/interface.h" /* m0_halon_interface */
 #include "spiel/spiel.h"	/* m0_spiel, m0_spiel_filesystem_stats_fetch */
-#include "conf/pvers.h"
+#include "conf/pvers.h"		 /* m0_conf_pver_info, m0_conf_pver_state */
 #include "module/instance.h"
 #include "lib/assert.h"   /* M0_ASSERT */
 #include "lib/memory.h"   /* M0_ALLOC_ARR */
@@ -222,21 +222,21 @@ PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
 
 	struct m0_proc_counter count_stats;
 	int rc;
-	// call the motr api
+	/* call the motr api */
 	Py_BEGIN_ALLOW_THREADS rc =
 	    m0_spiel_proc_counters_fetch(spiel, proc_fid, &count_stats);
 	Py_END_ALLOW_THREADS if (rc != 0)
 	{
 		PyGILState_Release(gstate);
-		// This returns None python object (which is a singleton)
-		// properly with respect to reference counters.
+		/* This returns None python object (which is a singleton)
+		   properly with respect to reference counters. */
 		Py_RETURN_NONE;
 	}
 
 	PyObject *hax_mod = getModule("hax.types");
 	PyObject *py_fid = toFid(&count_stats.pc_proc_fid);
 	int len = count_stats.pc_cnt;
-	// Fetch all byte count stats per pver.
+	/* Fetch all byte count stats per pver. */
 	PyObject *list = PyList_New(len);
 	int i;
 	for (i = 0; i < len; ++i) {
@@ -271,29 +271,28 @@ int m0_ha_pver_status(unsigned long long ctx,
 {
 	PyGILState_STATE gstate;
 	gstate = PyGILState_Ensure();
-	// TODO use motr spiel API for fetching pver_status.
-	/*
+
 	struct hax_context *hc = (struct hax_context *)ctx;
 	struct m0_halon_interface *hi = hc->hc_hi;
 	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
-	struct m0_confc *confc = spiel->spl_core.spc_confc;
+
 	struct m0_conf_pver_info pver_info;
 
 	int rc;
-	// call the motr api
+	/* call the motr api */
 	Py_BEGIN_ALLOW_THREADS rc =
-	    m0_conf_pver_status(pver_fid, confc, &pver_info);
+	    m0_spiel_conf_pver_status(spiel, pver_fid, &pver_info);
 	Py_END_ALLOW_THREADS if (rc != 0)
 	{
 		PyGILState_Release(gstate);
-		// This returns error code.
+		/* This returns error code. */
 		return M0_ERR(rc);
 	}
 	M0_LOG(M0_INFO, "FID:"FID_F", Status:%d",
 		FID_P(&pver_info.cpi_fid), pver_info.cpi_state);
-	enum m0_conf_pver_state status  = pver_info.cpi_state;*/
+	enum m0_conf_pver_state status  = pver_info.cpi_state;
 	PyGILState_Release(gstate);
-	return 2;
+	return status;
 }
 
 static void handle_failvec(const struct hax_msg *hm)

--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -106,6 +106,22 @@ void m0_ha_broadcast_test(unsigned long long ctx);
  */
 PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx);
 
+/*
+ * Invokes m0_spiel_proc_counters_fetch() which fetches bytecount per pool
+ * versions for all pvers under the ios service.
+ * @param proc_fid - Fid of the ios service
+ *
+ * @return Python object of type hax.types.ByteCountStats
+ */
+PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
+	struct m0_fid *proc_fid);
+
+/*
+ * Invokes XXX api to fetch the status of the pool version fid,
+ * provided as an input.
+ */
+int m0_ha_pver_status(unsigned long long ctx, struct m0_fid *pver_fid);
+
 PyObject *m0_hax_stop(unsigned long long ctx, const struct m0_fid *process_fid,
 		      const char *hax_endpoint);
 void m0_hax_link_stopped(unsigned long long ctx, const char *proc_ep);

--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -117,10 +117,12 @@ PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
 	struct m0_fid *proc_fid);
 
 /*
- * Invokes XXX api to fetch the status of the pool version fid,
- * provided as an input.
+ * Invokes m0_spiel_conf_pver_status() to fetch the status and pool version
+ * attributes of the pool version fid provided as an input.
+ *
+ * @return Python object of type hax.types.PverInfo
  */
-int m0_ha_pver_status(unsigned long long ctx, struct m0_fid *pver_fid);
+PyObject *m0_ha_pver_status(unsigned long long ctx, struct m0_fid *pver_fid);
 
 PyObject *m0_hax_stop(unsigned long long ctx, const struct m0_fid *process_fid,
 		      const char *hax_endpoint);

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -183,6 +183,26 @@ FsStatsWithTime = NamedTuple('FsStatsWithTime', [('stats', FsStats),
                                                  ('timestamp', float),
                                                  ('date', str)])
 
+# pver byte count
+PverBC = NamedTuple('PverBC', [('pver_fid', Fid),
+                               ('user_id', int),
+                               ('byte_count', int),
+                               ('object_count', int)])
+
+
+# struct m0_proc_counter
+class ByteCountStats(NamedTuple):
+    proc_fid: Fid
+    pvers: List[PverBC]
+
+
+# enum m0_conf_pver_state
+class PverState(IntEnum):
+    M0_CPS_HEALTHY = 0
+    M0_CPS_DEGRADED = 1
+    M0_CPS_CRITICAL = 2
+    M0_CPS_DAMAGED = 3
+
 
 # enum m0_cm_status
 class SnsCmStatus(Enum):

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -204,6 +204,14 @@ class PverState(IntEnum):
     M0_CPS_DAMAGED = 3
 
 
+PverInfo = NamedTuple('PverInfo', [('fid', Fid),
+                                   ('state', PverState),
+                                   ('data_units', int),
+                                   ('parity_units', int),
+                                   ('pool_width', int),
+                                   ('unit_size', int)])
+
+
 # enum m0_cm_status
 class SnsCmStatus(Enum):
     CM_STATUS_INVALID = 0

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1294,10 +1294,10 @@ class ConsulUtil:
         '''
         pool_ver = self.kv.kv_get('ioservices/', recurse=True)
         pver_state_map = {
-            PverState.M0_CPS_HEALTHY: 'healthy_byte_count',
-            PverState.M0_CPS_DEGRADED: 'degraded_byte_count',
-            PverState.M0_CPS_CRITICAL: 'critical_byte_count',
-            PverState.M0_CPS_DAMAGED: 'damaged_byte_count'
+            PverState.M0_CPS_HEALTHY: 'healthy',
+            PverState.M0_CPS_DEGRADED: 'degraded',
+            PverState.M0_CPS_CRITICAL: 'critical',
+            PverState.M0_CPS_DAMAGED: 'damaged'
         }
         # Calculate total bytecount per pver and store it based on its status.
         data: Dict[PverState, int] = {}

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -531,7 +531,7 @@ class ConsulUtil:
                 svc_health = self.get_service_health(node,
                                                      item.fid.key,
                                                      kv_cache=kv_cache)
-            result += [(item, svc_health) for item in data]
+                result += [(item, svc_health)]
         return result
 
     def get_service_data_by_name(self, name: str) -> List[ServiceData]:

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -559,8 +559,37 @@ def reset(args):
         raise RuntimeError(f'Error during reset : {error}')
 
 
-def kv_cleanup():
+@func_log(func_enter, func_leave)
+@repeat_if_fails()
+def cleanup_node_facts(utils: Utils, cns_utils: ConsulUtil):
+    hostname = utils.get_local_hostname()
+    keys: List[KeyDelete] = [
+        KeyDelete(name=f'{hostname}/facts', recurse=True),
+    ]
+
+    if not cns_utils.kv.kv_delete_in_transaction(keys):
+        logging.error('Delete transaction failed for %s', keys)
+
+
+@func_log(func_enter, func_leave)
+@repeat_if_fails()
+def cleanup_disks_info(utils: Utils, cns_utils: ConsulUtil):
+    hostname = utils.get_local_hostname()
+    keys: List[KeyDelete] = [
+        KeyDelete(name=f'{hostname}/drives', recurse=True),
+    ]
+
+    if not cns_utils.kv.kv_delete_in_transaction(keys):
+        logging.error('Delete transaction failed for %s', keys)
+
+
+@func_log(func_enter, func_leave)
+def kv_cleanup(url):
     util: ConsulUtil = ConsulUtil()
+    conf = ConfStoreProvider(url)
+    utils = Utils(conf)
+    cleanup_disks_info(utils, util)
+    cleanup_node_facts(utils, util)
 
     if is_cluster_running():
         logging.info('Cluster is running, shutting down')
@@ -574,7 +603,11 @@ def kv_cleanup():
         KeyDelete(name='m0conf/', recurse=True),
         KeyDelete(name='processes/', recurse=True),
         KeyDelete(name='stats/', recurse=True),
-        KeyDelete(name='mkfs/', recurse=True)
+        KeyDelete(name='mkfs/', recurse=True),
+        KeyDelete(name='bytecount/', recurse=True),
+        KeyDelete(name='config_path', recurse=False),
+        KeyDelete(name='failvec', recurse=False),
+        KeyDelete(name='m0_client_types', recurse=True)
     ]
 
     logging.info('Deleting Hare KV entries (%s)', keys)
@@ -604,10 +637,11 @@ def get_config_dir(url) -> str:
     return config_path + CONF_DIR_EXT + '/' + machine_id
 
 
+@func_log(func_enter, func_leave)
 def cleanup(args):
     try:
-        kv_cleanup()
         url = args.config[0]
+        kv_cleanup(url)
         logs_cleanup(url)
         config_cleanup(url)
         if args.pre_factory:

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -148,7 +148,7 @@ class Utils:
                                  'size': int(disk.size.get()),
                                  'blksize': int(disk.blksize.get())})
         disk_key = path.strip('/')
-        self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
+        self.kv.kv_put(f'{hostname}/drives/{disk_key}', drive_info)
 
     @func_log(func_enter, func_leave)
     @repeat_if_fails()
@@ -202,7 +202,7 @@ class Utils:
         drive_info = None
         while (not drive_data or drive_data is None):
             try:
-                drive_data = self.kv.kv_get(f'{hostname}/{disk_path}')
+                drive_data = self.kv.kv_get(f'{hostname}/drives/{disk_path}')
                 drive_info = json.loads(drive_data['Value'])
             except TypeError:
                 logging.info('%s details are not available yet, retrying...',

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -38,7 +38,7 @@ from hax.types import Fid
 from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
 
-Byte_count = NamedTuple('Byte_count', [('type', str), ('num_bytes', str)])
+Bytecount = NamedTuple('Bytecount', [('type', str), ('num_bytes', str)])
 
 Profile = NamedTuple('Profile', [
     ('fid', str), ('name', str), ('pools', List[str])])
@@ -100,26 +100,26 @@ def leader_tag(cns: Consul, host: str) -> str:
     return ' (RC)' if kv_value_as_str(cns, 'leader') == host else ''
 
 
-def byte_count(cns: Consul) -> List[Byte_count]:
-    """The byte_count() will return for the specified key ('bytecount/'),
+def bytecount(cns: Consul) -> List[Bytecount]:
+    """The bytecount() will return for the specified key ('bytecount/'),
     or if `recurse` is True then a list of "_value_" for all keys with the
     given prefix is returned.
 
     Each _value_ looks like this:
     ```
     {
-      "byte_count": {
-        "critical_byte_count": 0,
-        "damaged_byte_count": 0,
-        "degraded_byte_count": 0,
-        "healthy_byte_count": 0
+      "bytecount": {
+        "critical": 0,
+        "damaged": 0,
+        "degraded": 0,
+        "healthy": 0
       }
     }
     ```
     """
     bytecount = []
     for x in kv_item(cns, 'bytecount/', recurse=True):
-        bytecount.append(Byte_count(
+        bytecount.append(Bytecount(
             type=x['Key'].split('/')[-1],
             num_bytes=json.loads(x['Value'])))
     return bytecount
@@ -303,7 +303,7 @@ def get_bytecount_status(cns: Consul) -> Dict[str, Any]:
     This function will return a bytecount status in JSON format
     """
     result: Dict[str, Any] = {
-        'byte_count': {x.type: x.num_bytes for x in byte_count(cns)}
+        'bytecount': {x.type: x.num_bytes for x in bytecount(cns)}
     }
     return result
 
@@ -312,7 +312,7 @@ def get_bytecount_status(cns: Consul) -> Dict[str, Any]:
 def get_cluster_status(cns: Consul, consul_util: ConsulUtil,
                        devices_requested: bool) -> Dict[str, Any]:
     result: Dict[str, Any] = {
-        'byte_count': [get_bytecount_status(cns).get('byte_count')],
+        'bytecount': get_bytecount_status(cns).get('bytecount'),
         'pools': [x for x in sns_pools(cns)],
         'profiles': [{'fid': x.fid, 'name': x.name, 'pools': x.pools}
                      for x in profiles(cns)],
@@ -360,9 +360,9 @@ def show_text_status(cns: Consul, consul_util: ConsulUtil,
         def echo(text):
             print(text, file=stream)
 
-        counts = byte_count(cns)
+        counts = bytecount(cns)
         assert counts
-        echo('Byte_count:')
+        echo('Bytecount:')
         for x in counts:
             echo(f'    {x.type} : {x.num_bytes}')
 


### PR DESCRIPTION
Currently, deployment is failing due to missing changes (dg_bytecount) in Motr's main branch. 
Once Motr's `dg_bytecount` branch is merged to main, we can merge this PR.

Tests:

Deployment is successful with Motr's `dg_bytecount` branch.
link - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/1133/

IOs are successful
```
[root@ssc-vm-g2-rhev4-2610 ~]# aws s3 mb s3://test-bucket --endpoint-url http://192.168.54.124:30080                                                     make_bucket: test-bucket
[root@ssc-vm-g2-rhev4-2610 ~]# aws s3 ls --endpoint-url http://192.168.54.124:30080
2022-03-21 02:28:31 test-bucket
[root@ssc-vm-g2-rhev4-2610 ~]#
[root@ssc-vm-g2-rhev4-2610 ~]# dd if=/dev/urandom of=/tmp/9M bs=1M count=9
9+0 records in
9+0 records out
9437184 bytes (9.4 MB) copied, 0.0800336 s, 118 MB/s
[root@ssc-vm-g2-rhev4-2610 ~]# dd if=/dev/urandom of=/tmp/8M bs=1M count=8
8+0 records in
8+0 records out
8388608 bytes (8.4 MB) copied, 0.0686868 s, 122 MB/s
[root@ssc-vm-g2-rhev4-2610 ~]# aws s3 cp /tmp/9M s3://test-bucket/object1 --endpoint-url http://192.168.54.124:30080
upload: ../tmp/9M to s3://test-bucket/object1
[root@ssc-vm-g2-rhev4-2610 ~]#
[root@ssc-vm-g2-rhev4-2610 ~]# aws s3 ls s3://test-bucket --endpoint-url http://192.168.54.124:30080
2022-03-21 02:29:46    9437184 object1
[root@ssc-vm-g2-rhev4-2610 ~]# aws s3 cp /tmp/9M s3://test-bucket/object2 --endpoint-url http://192.168.54.124:30080
upload: ../tmp/9M to s3://test-bucket/object2

[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-2610 /]# hctl status
Bytecount:
    critical : 0
    damaged : 0
    degraded : 0
    healthy : 25165824
Data pool:
    # fid name
    0x6f00000000000001:0x93 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xd2 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2611
    [started]  hax                 0x7200000000000001:0x2b         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@22001
    [started]  ioservice           0x7200000000000001:0x2e         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@21001
    [started]  ioservice           0x7200000000000001:0x3b         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@21002
    [started]  confd               0x7200000000000001:0x48         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@21003
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2621  (RC)
    [started]  hax                 0x7200000000000001:0x7          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@22001
    [started]  ioservice           0x7200000000000001:0xa          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21001
    [started]  ioservice           0x7200000000000001:0x17         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21002
    [started]  confd               0x7200000000000001:0x24         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21003
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2610
    [started]  hax                 0x7200000000000001:0x4f         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@22001
    [started]  ioservice           0x7200000000000001:0x52         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@21001
    [started]  ioservice           0x7200000000000001:0x5f         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@21002
    [started]  confd               0x7200000000000001:0x6c         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@21003
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2611
    [started]  hax                 0x7200000000000001:0x71         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2611@22001
    [started]  rgw                 0x7200000000000001:0x74         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2611@21501
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2610
    [started]  hax                 0x7200000000000001:0x79         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2610@22001
    [started]  rgw                 0x7200000000000001:0x7c         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2610@21501
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2621
    [started]  hax                 0x7200000000000001:0x81         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2621@22001
    [started]  rgw                 0x7200000000000001:0x84         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2621@21501

```