### PR TITLE
ha: process state update is not a broadcast

### DIFF
--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -23,6 +23,16 @@
       }
     },
     {
+      "type": "keyprefix",
+      "prefix": "processes/",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:8008/watcher/processes",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
       "type": "service",
       "service": "ios",
       "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -13,6 +13,16 @@
       }
     },
     {
+      "type": "keyprefix",
+      "prefix": "processes/",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:8008/watcher/processes",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
       "type": "service",
       "service": "confd",
       "handler_type": "http",


### PR DESCRIPTION

It is possible that Consul may not send service state notifications
periodically as configured, see https://github.com/hashicorp/consul/issues/7069.
Sometimes the notification is sent only on Consul service state change.
During bootstrap if a peer process has not started, Hare reports it as offline
in nvec reply to another process. Relying on Consul notification, Hare expects
that the offline state will be updated to online on receiving a corresponding
periodical Consul notification. But as the notification might get delayed or
not arrive at all, the offline state of the process may not be updated to
online, which may further lead to inconsistencies.

Solution:
Watch `processes/` key value for the updates reported by the individual
process and accordingly broadcast the process state change to peer motr
processes.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>