### PR TITLE
CORTX-29142: Bytecount thread exiting due to incorrect process health state.

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -525,7 +525,7 @@ class ConsulUtil:
                 svc_health = self.get_service_health(node,
                                                      item.fid.key,
                                                      kv_cache=kv_cache)
-            result += [(item, svc_health) for item in data]
+                result += [(item, svc_health)]
         return result
 
     def get_service_data_by_name(self, name: str) -> List[ServiceData]:


### PR DESCRIPTION
After cluster or process restart, the 'ios' process health state
was received as 'OK' despite being offline. This led to invoking
motr spiel api for offline ios process and killing bytecount
updater thread.

Solution:
Returning correct health states of processes in get_m0d_statuses() api.

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>