### PR TITLE
CORTX-29488: non rc hax process might update the remote process state

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1376,7 +1376,10 @@ class ConsulUtil:
             if not match_result:
                 continue
             value = json.loads(sdev['Value'])
-            if not device_event and value['state'] == 'failed':
+            if not device_event and value['state'] in ('failed',
+                                                       'repairing',
+                                                       'repaired',
+                                                       'rebalancing'):
                 continue
             value['state'] = state
             result.append(PutKV(key=sdev['Key'], value=json.dumps(value)))


### PR DESCRIPTION
We don't want to allow any hax process to update the remote
process's persistent state, i.e. `processes/<proc-fid>` in-
order to maintain consistency. Thus we allow only RC (recovery
coordinator) to update the remote process's persistent state.
But, this was not working and any hax process was allowed to
update the remote procces's persistent state, which led to
inconsistencies.

Solution:
Allow only RC (recovery coordinator) or process's local hax
to update the remote process's persistent state.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>