### PR TITLE
CORTX-29546: CORTX clients pods are not working with after RGW pods are introduced in k8s version 0.1.0

### DIFF
--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -71,6 +71,7 @@ class CdfGenerator:
         client_machines = []
         for client in conf.get_motr_clients():
             name = str(client.get('name'))
+            client_machines.extend(conf.get_machine_ids_for_service(name))
             client_machines.extend(conf.get_machine_ids_for_component(name))
 
         # Avoid adding duplicate machine ids if client and data node
@@ -420,10 +421,12 @@ class CdfGenerator:
         """
         for client in self.provider.get_motr_clients():
             name = str(client.get('name'))
-            if self.utils.is_component(machine_id, name):
-                yield M0ClientDesc(
-                    name=Text(name),
-                    instances=int(str(client.get('num_instances'))))
+            no_instances = int(str(client.get('num_instances')))
+            if no_instances:
+                if self.utils.is_component_or_service(machine_id, name):
+                    yield M0ClientDesc(
+                        name=Text(name),
+                        instances=no_instances)
 
     def _create_node(self, machine_id: str) -> NodeDesc:
         store = self.provider
@@ -432,7 +435,7 @@ class CdfGenerator:
         # node>{machine-id}>name
         iface = self._get_iface(machine_id)
         servers = None
-        if(self.utils.is_motr_component(machine_id)):
+        if(self.utils.is_motr_io_present(machine_id)):
             # Currently, there is 1 m0d per cvg.
             # We will create 1 IO service entry in CDF per cvg.
             # An IO service entry will use data  and metadat devices

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -146,7 +146,7 @@ def is_mkfs_required(url: str) -> bool:
         conf = ConfStoreProvider(url)
         utils = Utils(conf)
         machine_id = conf.get_machine_id()
-        return utils.is_motr_component(machine_id)
+        return utils.is_motr_io_present(machine_id)
     except Exception as error:
         logging.warn('Failed to get pod type (%s). Current stage will '
                      'be assumed as not required by default', error)

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -178,7 +178,14 @@ class ConfStoreProvider(ValueProvider):
         -   name: other
             num_instances: 2
         """
-        return self.get('cortx>motr>clients')
+        clients = self.get('cortx>motr>clients', allow_null=True)
+        if clients is None:
+            return []
+        for client in clients:
+            instances = int(str(client.get('num_instances')))
+            if instances == 0:
+                clients.remove(client)
+        return clients
 
 
 def get_machine_id() -> str:


### PR DESCRIPTION
CORTX-29546: CORTX clients pods are not working after RGW pods are introduced in 
k8s version 0.1.0
Motr client pods are started by deployment scripts, but hctl status is not showing them.
It seems hare is expecting the component is of motr client similar to RGW which is not
there, since it's part of motr (devel) only.

CORTX-29536: Hare stuck in data pod on removing rgw from motr client list - Granular Data
Only deployment
If we remove rgw from motr client section deployment got failed as hare stuck in data
pod deployment, For scenarios: rgw_s3/motr_client instance count to 0/1 (num_client_inst=1)
in solution.yaml file.

Solution:
Instead of the component name as motr look for the service name as a motr_client.
Added null checking scenarios for get_motr_clients function as it's not checking for the
number of instances as 0 and if motr_clients are not present.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>