### PR TITLE
CORTX-29700: ha: function to update motr process state is complicated

### DIFF
--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -340,6 +340,7 @@ class m0HaProcessType(IntEnum):
     M0_CONF_HA_PROCESS_KERNEL = 1
     M0_CONF_HA_PROCESS_M0MKFS = 2
     M0_CONF_HA_PROCESS_M0D = 3
+    M0_CONF_HA_PROCESS_HA = 4
 
     @staticmethod
     def str_to_Enum(t: str):
@@ -350,7 +351,9 @@ class m0HaProcessType(IntEnum):
                  'M0_CONF_HA_PROCESS_M0MKFS':
                  m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
                  'M0_CONF_HA_PROCESS_M0D':
-                 m0HaProcessType.M0_CONF_HA_PROCESS_M0D}
+                 m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                 'M0_CONF_HA_PROCESS_HA':
+                 m0HaProcessType.M0_CONF_HA_PROCESS_HA}
         return types[t]
 
     def __repr__(self):


### PR DESCRIPTION
Presently the handler function to update and broadcast motr
process state changes is a bit convulated and is difficult to
read. Also, hax updates the remote process's state only in
case of node failure but not if process is reported as offline.

Solution:
- Simplify process state update logic.
- Update remote process state if the current state of the
process is either failed or offline.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>