### PR TITLE
CORTX-29944: Bytecount thread gets aborted when receiving error from motr API

### DIFF
--- a/hax/hax/exception.py
+++ b/hax/hax/exception.py
@@ -35,6 +35,10 @@ class RepairRebalanceException(HaxAPIException):
     pass
 
 
+class BytecountException(HaxAPIException):
+    pass
+
+
 class NotDelivered(RuntimeError):
     def __init__(self, message: str):
         super().__init__()

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -23,7 +23,8 @@ from typing import Any, List, Optional, Tuple
 from time import sleep
 
 from hax.consul.cache import supports_consul_cache, uses_consul_cache
-from hax.exception import ConfdQuorumException, RepairRebalanceException
+from hax.exception import (BytecountException, ConfdQuorumException,
+                           RepairRebalanceException)
 from hax.message import (EntrypointRequest, FirstEntrypointRequest,
                          HaNvecGetEvent, HaNvecSetEvent, ProcessEvent,
                          StobIoqError)
@@ -712,7 +713,7 @@ class Motr:
         bytecount: ByteCountStats = self._ffi.proc_bytecount_fetch(
             self._ha_ctx, proc_fid.to_c())
         if not bytecount:
-            raise RuntimeError('Bytecount stats unavailable')
+            raise BytecountException('Bytecount stats unavailable')
         LOG.debug('Bytecount status for proc fid: %s, stats =%s',
                   str(bytecount.proc_fid),
                   bytecount.pvers)
@@ -722,7 +723,7 @@ class Motr:
         status: PverInfo = self._ffi.pver_status_fetch(
             self._ha_ctx, pver_fid.to_c())
         if not status:
-            raise RuntimeError('Pool version status unavailable')
+            raise BytecountException('Pool version status unavailable')
         LOG.debug('Pver status for pver %s: %s', pver_fid, status.state)
         return status
 


### PR DESCRIPTION
During node failures,  failed services are falsely reported as active due to delay issue by Consul. 
When we try to connect those service we get an error from motr apis.
Instead of aborting the thread, we should keep the thread running but break the iteration and start a new iteration.
Log the error reported.

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>

### Testing
1. 1+0 config, 3N

```
[root@cortx-data-headless-svc-ssc-vm-g4-rhev4-0848 ~]# hctl status --bytecount
{
  "bytecount": {
    "critical": 0,
    "damaged": 1048576000,
    "degraded": 0,
    "healthy": 0
  }
}
```
After pod is up again ---
```
2022-03-31 06:59:14,491 [ERROR] {byte-count-updater} Failed to update Consul KV due to an intermittent error. The error is swallowed since new attempts will be made timely
2022-03-31 07:49:11,523 [ERROR] {byte-count-updater} Failed due to Bytecount stats unavailable. Aborting this iteration. Waiting for next attempt.

[root@cortx-data-headless-svc-ssc-vm-g4-rhev4-0848 /]# hctl status --bytecount
{
  "bytecount": {
    "critical": 0,
    "damaged": 0,
    "degraded": 0,
    "healthy": 1048576000
  }
}
```
2. 2+1 config, 3N
```
[root@cortx-data-headless-svc-ssc-vm-g4-rhev4-0848 /]# hctl status --bytecount
{
  "bytecount": {
    "critical": 0,
    "damaged": 0,
    "degraded": 0,
    "healthy": 1048576000
  }
}
```
after Podfailure
```
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-3031 /]# hctl status --bytecount
{
  "bytecount": {
    "critical": 1048576000,
    "damaged": 0,
    "degraded": 0,
    "healthy": 0
  }
}
```
After pod restart
We did get the errors.. But thread didn’t abort
```
2022-03-31 11:36:09,928 [ERROR] {byte-count-updater} Failed due to Bytecount stats unavailable. Aborting this iteration. Waiting for next attempt.
2022-03-31 11:36:41,043 [ERROR] {byte-count-updater} Failed due to Bytecount stats unavailable. Aborting this iteration. Waiting for next attempt.
```
After a while, bytecount is updated correctly. And also written some data.
```
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-3031 /]# hctl status --bytecount
{
  "bytecount": {
    "critical": 0,
    "damaged": 0,
    "degraded": 0,
    "healthy": 2097152000
  }
}

```
