### PR TITLE
Problem: Mini-provisioning testes are broken after 'drives' related changes

### DIFF
--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -115,33 +115,33 @@ class TestCDF(unittest.TestCase):
             utils = Utils(store)
             kv = KVAdapter()
             def my_get(key: str, recurse: bool = False):
-                if key == 'srvnode-1.data.private/dev/sda':
-                    return new_kv('srvnode-1.data.private/dev/sda',
+                if key == 'srvnode-1.data.private/drives/dev/sda':
+                    return new_kv('srvnode-1.data.private/drives/dev/sda',
                                   json.dumps({"path": "/dev/sda",
                                               "size": "4096000",
                                               "blksize": "4096"}))
-                elif key == 'srvnode-1.data.private/dev/sdb':
-                    return new_kv('srvnode-1.data.private/dev/sdb',
+                elif key == 'srvnode-1.data.private/drives/dev/sdb':
+                    return new_kv('srvnode-1.data.private/drives/dev/sdb',
                                   json.dumps({"path": "/dev/sdb",
                                               "size": "4096000",
                                               "blksize": "4096"}))
-                elif key == 'srvnode-1.data.private/dev/sdc':
-                    return new_kv('srvnode-1.data.private/dev/sdc',
+                elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                    return new_kv('srvnode-1.data.private/drives/dev/sdc',
                                   json.dumps({"path": "/dev/sdc",
                                               "size": "4096000",
                                               "blksize": "4096"}))
-                elif key == 'srvnode-1.data.private/dev/sdg':
-                    return new_kv('srvnode-1.data.private/dev/sdg',
+                elif key == 'srvnode-1.data.private/drives/dev/sdg':
+                    return new_kv('srvnode-1.data.private/drives/dev/sdg',
                                   json.dumps({"path": "/dev/sdg",
                                               "size": "4096000",
                                               "blksize": "4096"}))
-                elif key == 'srvnode-1.data.private/dev/sdh':
-                    return new_kv('srvnode-1.data.private/dev/sdh',
+                elif key == 'srvnode-1.data.private/drives/dev/sdh':
+                    return new_kv('srvnode-1.data.private/drives/dev/sdh',
                                   json.dumps({"path": "/dev/sdh",
                                               "size": "4096000",
                                               "blksize": "4096"}))
-                elif key == 'srvnode-1.data.private/dev/sdi':
-                    return new_kv('srvnode-1.data.private/dev/sdi',
+                elif key == 'srvnode-1.data.private/drives/dev/sdi':
+                    return new_kv('srvnode-1.data.private/drives/dev/sdi',
                                   json.dumps({"path": "/dev/sdi",
                                               "size": "4096000",
                                               "blksize": "4096"}))
@@ -239,13 +239,13 @@ class TestCDF(unittest.TestCase):
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
-            if key == 'srvnode-1.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            if key == 'srvnode-1.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-1.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
@@ -339,13 +339,13 @@ class TestCDF(unittest.TestCase):
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
-            if key == 'srvnode-1.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            if key == 'srvnode-1.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-1.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
@@ -601,13 +601,13 @@ class TestCDF(unittest.TestCase):
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
-            if key == 'srvnode-1.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            if key == 'srvnode-1.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-1.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
@@ -924,13 +924,13 @@ class TestCDF(unittest.TestCase):
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
-            if key == 'srvnode-1.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            if key == 'srvnode-1.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-1.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
@@ -1055,13 +1055,13 @@ class TestCDF(unittest.TestCase):
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
-            if key == 'srvnode-1.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            if key == 'srvnode-1.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-1.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
@@ -1069,13 +1069,13 @@ class TestCDF(unittest.TestCase):
                 return new_kv('srvnode-1.data.private/facts',
                               json.dumps({"processorcount": "16",
                                           "memorysize_mb": "4096.123"}))
-            elif key == 'srvnode-2.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            elif key == 'srvnode-2.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-2.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-2.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
@@ -1172,13 +1172,13 @@ class TestCDF(unittest.TestCase):
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False):
-            if key == 'srvnode-1.data.private/dev/sdb':
-                return new_kv('srvnode-1.data.private/dev/sdb',
+            if key == 'srvnode-1.data.private/drives/dev/sdb':
+                return new_kv('srvnode-1.data.private/drives/dev/sdb',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))
-            elif key == 'srvnode-1.data.private/dev/sdc':
-                return new_kv('srvnode-1.data.private/dev/sdc',
+            elif key == 'srvnode-1.data.private/drives/dev/sdc':
+                return new_kv('srvnode-1.data.private/drives/dev/sdc',
                               json.dumps({"path": "/dev/sdb",
                                           "size": "4096000",
                                           "blksize": "4096"}))


### PR DESCRIPTION
**Solution:**
Modified keys used in tests according to new drive related key structure.

Change in the key is as follows
self.kv.kv_put(f'{hostname}/{disk_key}', drive_info)
to
self.kv.kv_put(f'{hostname}/drives/{disk_key}', drive_info)

**Tests:**
```
(.py3venv) [root@ssc-vm-g2-rhev4-2221 miniprov]# git push -f myrepo fix_tests
Everything up-to-date
(.py3venv) [root@ssc-vm-g2-rhev4-2221 miniprov]# python ./setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing hare_mp.egg-info/PKG-INFO
writing dependency_links to hare_mp.egg-info/dependency_links.txt
writing entry points to hare_mp.egg-info/entry_points.txt
writing requirements to hare_mp.egg-info/requires.txt
writing top-level names to hare_mp.egg-info/top_level.txt
reading manifest file 'hare_mp.egg-info/SOURCES.txt'
writing manifest file 'hare_mp.egg-info/SOURCES.txt'
running build_ext
test_empty_source_results_empty (test.test_systemd.TestHaxUnitTrasform) ... ok
test_not_everything_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_restart_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_invalid_machine_id (test.test_validator.TestValidator) ... ok
test_is_cluster_first_node (test.test_validator.TestValidator) ... ok
test_allowed_failure_generation (test.test_cdf.TestCDF) ... ok
test_both_dix_and_sns_pools_can_exist (test.test_cdf.TestCDF) ... ok
test_disk_refs_can_be_empty (test.test_cdf.TestCDF) ... ok
test_dix_pool_uses_metadata_devices (test.test_cdf.TestCDF) ... ok
test_iface_type_can_be_null (test.test_cdf.TestCDF) ... ok
test_invalid_storage_set_configuration_rejected (test.test_cdf.TestCDF)
This test case checks whether exception will be raise if total ... ok
test_it_works (test.test_cdf.TestCDF) ... ok
test_md_pool_ignored (test.test_cdf.TestCDF) ... ok
test_metadata_is_hardcoded (test.test_cdf.TestCDF) ... ok
test_multiple_nodes_supported (test.test_cdf.TestCDF) ... ok
test_provided_values_respected (test.test_cdf.TestCDF) ... ok
test_template_sane (test.test_cdf.TestCDF) ... ok
test_disks_empty (test.test_cdf.TestTypes) ... ok
test_m0clients (test.test_cdf.TestTypes) ... ok
test_m0server_with_disks (test.test_cdf.TestTypes) ... ok
test_maybe_none (test.test_cdf.TestTypes) ... ok
test_pooldesc_empty (test.test_cdf.TestTypes) ... ok
test_protocol (test.test_cdf.TestTypes) ... ok

----------------------------------------------------------------------
Ran 23 tests in 0.357s

OK
```