### PR TITLE
CORTX-27062: Dynamic port range to be parsed from config.yaml for hctl over http

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2182,7 +2182,8 @@ Cluster = NamedTuple('Cluster', [('m0conf', Dict[Oid, Any]),
                                  ('consul_servers', List[ConsulAgent]),
                                  ('consul_clients', List[ConsulAgent]),
                                  ('m0_clients', Dict[Oid, Oid]),
-                                 ('m0_client_types', List[str])])
+                                 ('m0_client_types', List[str]),
+                                 ('network_ports', Dict[str, int])])
 
 
 def generate_consul_agents(cluster: Cluster) -> str:
@@ -2305,6 +2306,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                         root.imeta_pver not in m0conf[x].pvers]
         raise RuntimeError('Impossible happened')
 
+    hax_http_port = cluster.network_ports.get('hax_http', 8008)
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
         ('eq-epoch', 1),
@@ -2315,6 +2317,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('bytecount/degraded', 0),
         ('bytecount/critical', 0),
         ('bytecount/damaged', 0),
+        ('ports/hax', json.dumps({'http': hax_http_port})),
         ('m0_client_types', json.dumps(cluster.m0_client_types)),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node
@@ -2520,7 +2523,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
 
 def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     cluster = Cluster(m0conf={}, consul_servers=[], consul_clients=[],
-                      m0_clients={}, m0_client_types=[])
+                      m0_clients={}, m0_client_types=[], network_ports={})
     conf = cluster.m0conf
     root_id = ConfRoot.build(conf)
     # XXX Move all the logic into ConfRoot.build?
@@ -2532,6 +2535,7 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     ports = cluster_desc.get('network_ports')
     if ports:
+        cluster.network_ports.update({k: v for k, v in ports.items()})
         lnet_portals = get_lnet_portal_group(
                            hax=ports['hax'],
                            m0_server=ports['m0_server'],

--- a/cfgen/dhall/types/Ports.dhall
+++ b/cfgen/dhall/types/Ports.dhall
@@ -17,6 +17,7 @@
 
 -- network ports
 { hax : Optional Natural
+, hax_http : Optional Natural
 , m0_server : Optional Natural
 , m0_client_s3 : Optional Natural
 , m0_client_other : Optional Natural

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -81,6 +81,7 @@ profiles:
     pools: [ tier1-nvme, tier2-ssd, tier3-hdd ]
 #network_ports:
 #    hax: 22000
+#    hax_http: 8008
 #    m0_server: 21000
 #    m0_client_s3: 22500
 #    m0_client_other: 21500

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -57,6 +57,7 @@ pools:
 #    substrings: ["Bucket-Name", "Object-Name", "Object-URI"]
 #network_ports:
 #    hax: 22000
+#    hax_http: 8008
 #    m0_server: 21000
 #    m0_client_s3: 22500
 #    m0_client_other: 21500

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -136,6 +136,7 @@ in
 ,  network_ports =
      None
      { hax : Optional Natural
+     , hax_http: Optional Natural
      , m0_server : Optional Natural
      , m0_client_s3 : Optional Natural
      , m0_client_other : Optional Natural

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -173,6 +173,7 @@ def main():
     # bootstrapping operations.
     _remove_stale_session(util)
     cfg: HL_Fids = _get_motr_fids(util)
+    hax_http_port = util.get_hax_http_port()
 
     LOG.info('Welcome to HaX')
     LOG.info(f'Setting up ha_link interface with the options as follows: '
@@ -212,10 +213,13 @@ def main():
                               herald,
                               consul_util=util,
                               hax_state=state)
-        server.run(threads_to_wait=[
-            *consumer_threads, stats_updater, bc_updater, rconfc_starter,
-            event_poller
-        ])
+        server.run(threads_to_wait=[*consumer_threads,
+                                    stats_updater,
+                                    bc_updater,
+                                    rconfc_starter,
+                                    event_poller
+                                    ],
+                   port=hax_http_port)
     except Exception:
         LOG.exception('Exiting due to an exception')
     finally:

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -406,6 +406,10 @@ class ConsulUtil:
     def get_hax_ip_address(self, kv_cache=None) -> str:
         return self._service_data(kv_cache=kv_cache).ip_addr
 
+    def get_hax_http_port(self) -> int:
+        return int(self._local_service_by_name('hax')['ServiceMeta'].get(
+            'http_port', 8008))
+
     @repeat_if_fails()
     def fid_to_endpoint(self, proc_fid: Fid) -> Optional[str]:
         pfidk = int(proc_fid.key)

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -261,6 +261,11 @@ class CdfGenerator:
                 url = conf.get('cortx>hare>hax>endpoints', allow_null=True)
                 _hax = url if url is None else \
                     round(urlparse(url[0]).port / 100) * 100
+                _hax_http = None
+                for u in url or ():
+                    _parsed_url = urlparse(u)
+                    if _parsed_url.scheme in ('http', 'https'):
+                        _hax_http = _parsed_url.port
             elif srv == 'm0_client_other':
                 _client_other = None
             elif srv == 'm0_server':
@@ -274,6 +279,7 @@ class CdfGenerator:
 
         return NetworkPorts(
             hax=Maybe(_hax, 'Natural'),
+            hax_http=Maybe(_hax_http, 'Natural'),
             m0_server=Maybe(_ios, 'Natural'),
             m0_client_other=Maybe(_client_other, 'Natural'),
             m0_client_s3=Maybe(_client_s3, 'Natural'))

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -166,6 +166,7 @@ class FdmiFilterDesc(DhallTuple):
 @dataclass(repr=False)
 class NetworkPorts(DhallTuple):
     hax: Maybe[int]
+    hax_http: Maybe[int]
     m0_server: Maybe[int]
     m0_client_s3: Maybe[int]
     m0_client_other: Maybe[int]

--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -7,7 +7,7 @@
       "service": "ios",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008",
+        "path": "http://localhost:HAX_HTTP_PORT",
         "method": "POST",
         "timeout": "10s"
       }
@@ -17,7 +17,7 @@
       "prefix": "bq/",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008/watcher/bq",
+        "path": "http://localhost:HAX_HTTP_PORT/watcher/bq",
         "method": "POST",
         "timeout": "10s"
       }
@@ -27,7 +27,7 @@
       "prefix": "processes/",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008/watcher/processes",
+        "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
         "method": "POST",
         "timeout": "10s"
       }
@@ -43,7 +43,7 @@
       "service": "s3service",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008",
+        "path": "http://localhost:HAX_HTTP_PORT",
         "method": "POST",
         "timeout": "10s"
       }

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -7,7 +7,7 @@
       "prefix": "bq/",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008/watcher/bq",
+        "path": "http://localhost:HAX_HTTP_PORT/watcher/bq",
         "method": "POST",
         "timeout": "10s"
       }
@@ -17,7 +17,7 @@
       "prefix": "processes/",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008/watcher/processes",
+        "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
         "method": "POST",
         "timeout": "10s"
       }
@@ -27,7 +27,7 @@
       "service": "confd",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008",
+        "path": "http://localhost:HAX_HTTP_PORT",
         "method": "POST",
         "timeout": "10s"
       }
@@ -43,7 +43,7 @@
       "service": "ios",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008",
+        "path": "http://localhost:HAX_HTTP_PORT",
         "method": "POST",
         "timeout": "10s"
       }
@@ -59,7 +59,7 @@
       "service": "s3service",
       "handler_type": "http",
       "http_handler_config": {
-        "path": "http://localhost:8008",
+        "path": "http://localhost:HAX_HTTP_PORT",
         "method": "POST",
         "timeout": "10s"
       }

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -158,6 +158,11 @@ get_profile_from_kv_file() {
     eval $cmd || true
 }
 
+get_hax_http_port_from_kv_file() {
+    local cmd="jq -r '.[] | select (.key==\"ports/hax\") | .value' $kv_file | jq -r '.http'"
+    eval $cmd || true
+}
+
 get_service_addr() {
     if [[ $xprt == 'lnet' ]]; then
         echo ${1%:*}
@@ -282,6 +287,8 @@ fi
 
 SVCS_CONF=''
 
+hax_http_port=$(get_hax_http_port_from_kv_file)
+
 append_hax_svc() {
     local id=$1
     local ep=$(get_service_ep_from_kv_file $id)
@@ -295,7 +302,8 @@ append_hax_svc() {
       \"port\": $port,
       \"meta\":
           {
-            \"transport_type\": \"$xprt\"
+            \"transport_type\": \"$xprt\",
+            \"http_port\": \"$hax_http_port\"
           },
       \"checks\": [
           {
@@ -470,6 +478,7 @@ fi
 
 sed -i "s|TMP_CONF_DIR|$conf_dir|" $tmpfile
 sed -i "s|TMP_LOG_DIR|$log_dir|" $tmpfile
+sed -i "s|HAX_HTTP_PORT|$hax_http_port|" $tmpfile
 
 sudo cp $tmpfile $CONF_FILE
 # Copy consul-server-conf for this node to consul dir.


### PR DESCRIPTION
The htctl http port number for incoming consul connections is hardcoded
as 8008.

Solution:
Handle the http port value in cfgen:
* Read the port number from CDF.yaml as `/network_ports/hax_http`.
* Write the port number in consul-kv.json as `ports/hax`.
Update consul conf:
* Read the port from kv and configure a consul service `hax_http`.
Read and use the value in hax:
* Read the ServicePort with consul util and use it on hax start.

Signed-off-by: Dmitry Kuzmenko <dmitry.kuzmenko@seagate.com>
Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>