### PR TITLE
CORTX-28841: MiniProv logging update

### DIFF
--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -758,9 +758,11 @@ def checkRpm(rpm_name):
                                   stderr=subprocess.PIPE,
                                   encoding='utf8')
     out, err = rpm_search.communicate()
-    logging.info(f"Output: {out}")
-    logging.info(f"rpm: {rpm_name} found")
-    logging.info(f"stderr: {err}")
+    if out:
+        logging.info("Output: %s", out)
+    logging.info("RPM: %s found", rpm_name)
+    if err:
+        logging.info("Stderr: %s", err)
     if rpm_search.returncode != 0:
         raise RuntimeError(f"rpm {rpm_name} is missing")
 


### PR DESCRIPTION
Need log related improvements in checkrpm related logs.
The empty "stderr:" and "output:" strings are getting logged un-necessarily.

Solution:
Conditionally do not log anything for empty `err` and `out` values.

Signed-off-by: Dmitry Kuzmenko <dmitry.kuzmenko@seagate.com>