### PR TITLE
Problem: mistype in hare-bootstrap log message.

### DIFF
--- a/rfc/11/README.md
+++ b/rfc/11/README.md
@@ -81,7 +81,7 @@ $ hctl bootstrap --mkfs --xprt libfab /opt/seagate/cortx/hare/share/cfgen/exampl
 2021-12-29 10:39:10: Starting Consul server on this node............ OK
 2021-12-29 10:39:20: Importing configuration into the KV store... OK
 2021-12-29 10:39:20: Starting Consul on other nodes...Consul ready on all nodes
-2021-12-29 10:39:20: Updating Consul configuraton from the KV store... OK
+2021-12-29 10:39:20: Updating Consul configuration from the KV store... OK
 2021-12-29 10:39:21: Waiting for the RC Leader to get elected.......... OK
 2021-12-29 10:39:28: Starting Motr (phase1, mkfs)... OK
 2021-12-29 10:39:35: Starting Motr (phase1, m0d)... OK

--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -429,7 +429,7 @@ done
 echo 'Consul ready on all nodes'
 
 if [[ $opt_mkfs ]]; then
-    say 'Updating Consul configuraton from the KV store...'
+    say 'Updating Consul configuration from the KV store...'
     update-consul-conf --server --xprt $xprt &
     pid=($!)
     wait4 ${pid[@]}


### PR DESCRIPTION
Solution: update the log message text.

Signed-off-by: Dmitry Kuzmenko <dmitry.kuzmenko@seagate.com>

-----
[View rendered rfc/11/README.md](https://github.com/DmitryKuzmenko/cortx-hare/blob/minor_hare-bootstrap_syntax_fixup/rfc/11/README.md)