### PR TITLE
Problem: CORTX-29866 Make motr server and client processes port range configurable per process type

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -4,7 +4,7 @@ import abc
 import argparse
 import ast
 import sys
-from enum import Enum, auto, IntEnum
+from enum import Enum, auto
 from functools import lru_cache, wraps
 import itertools
 import json
@@ -430,7 +430,7 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
                                  for port_type in portalgroup}
     else:
         for key, value in desc['network_ports'].items():
-            if value is None:
+            if not value:
                 desc['network_ports'][key] = portalgroup[key].value
         for srv in [port_type.name for port_type in portalgroup]:
             if srv not in desc['network_ports']:
@@ -852,40 +852,65 @@ ProcT = Enum('ProcT', 'hax m0_server m0_client_s3 m0_client_other')
 ProcT.__doc__ = 'Type of process'
 
 
-class PortalGroup(IntEnum):
-    hax = 22000,
-    m0_server = 21000,
-    m0_client_s3 = 22500,
-    m0_client_other = 21500
+class m0ProcT(Enum):
+    confd = 21001
+    ios = 21002
+
+
+class PortalGroup(Enum):
+    hax = 22000
+    m0_server = [{'name': 'confd', 'port': m0ProcT.confd},
+                 {'name': 'ios', 'port': m0ProcT.ios}]
+    m0_client_s3 = 22500
+    m0_client_other = [{'name': 'default', 'port': 22500}]
 
 
 class Portals:
-    def __init__(self, hax=22000, m0_server=21000, m0_client_s3=22500,
-                 m0_client_other=21500):
+    def __init__(self, hax=22000,
+                 m0_server=[{'name': 'confd', 'port': m0ProcT.confd},
+                            {'name': 'ios', 'port': m0ProcT.ios}],
+                 m0_client_s3=22500,
+                 m0_client_other=[{'name': 'default', 'port': 4}]):
         self.hax = hax
         self.m0_server = m0_server
-        self.m0_client_s3 = m0_client_s3
+        self.m0_client_s3 = [m0_client_s3]
         self.m0_client_other = m0_client_other
 
     def get_portal_group(self):
-        return IntEnum('PortalGroup',
-                       {'hax': self.hax,
-                        'm0_server': self.m0_server,
-                        'm0_client_s3': self.m0_client_s3,
-                        'm0_client_other': self.m0_client_other})
+        return {'hax': self.hax,
+                'm0_server': self.m0_server,
+                'm0_client_s3': self.m0_client_s3,
+                'm0_client_other': self.m0_client_other}
 
 
-def get_lnet_portal_group(hax=1, m0_server=2,
-                          m0_client_s3=3, m0_client_other=4) -> Portals:
-    return Portals(hax=hax, m0_server=m0_server, m0_client_s3=m0_client_s3,
-                   m0_client_other=m0_client_other)
+def get_lnet_portal_group(
+        hax=1,
+        m0_server=[{'name': 'confd', 'port': 2},
+                   {'name': 'ios', 'port': 2}],
+        m0_client_s3=3,
+        m0_client_other=[]
+        ) -> Portals:
+    protal_group = Portals(hax=hax, m0_server=m0_server,
+                           m0_client_s3=m0_client_s3,
+                           m0_client_other=m0_client_other)
+    protal_group.m0_client_other.append({'name': 'default',
+                                         'port': 4})
+    return protal_group
 
 
-def get_libfab_portal_group(hax=22000, m0_server=21000,
-                            m0_client_s3=22500,
-                            m0_client_other=21500) -> Portals:
-    return Portals(hax=hax, m0_server=m0_server, m0_client_s3=m0_client_s3,
-                   m0_client_other=m0_client_other)
+def get_libfab_portal_group(
+        hax=22000,
+        m0_server=[{'name': 'confd', 'port': m0ProcT.confd},
+                   {'name': 'ios', 'port': m0ProcT.ios}],
+        m0_client_s3=22500,
+        m0_client_other=[]
+        ) -> Portals:
+    protal_group = Portals(hax=hax, m0_server=m0_server,
+                           m0_client_s3=m0_client_s3,
+                           m0_client_other=m0_client_other)
+    protal_group.m0_client_other.append({'name': 'default',
+                                         'port': 22500})
+    return protal_group
 
 
 class Endpoint:
@@ -896,16 +921,20 @@ class LnetEndpoint(Endpoint):
     _tmids: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, proto: NetProtocol, ipaddr: str,
-                 portalgroup: PortalGroup,
+                 portalgroup: Tuple[str, Any],
                  tmid: int = None):
         self.proto = proto
         assert ipaddr
         self.ipaddr = ipaddr
-        assert portalgroup.value > 0
         self.portalgroup = portalgroup
+        if isinstance(portalgroup[1], int):
+            portal = portalgroup[1]
+        else:
+            portal = portalgroup[1].value
+        assert portal > 0
         if tmid is None:
-            self.tmid = self._tmids.setdefault((ipaddr, portalgroup.value), 1)
-            self._tmids[(ipaddr, portalgroup.value)] += 1
+            self.tmid = self._tmids.setdefault((ipaddr, portal), 1)
+            self._tmids[(ipaddr, portal)] += 1
         else:
             assert tmid > 0
             self.tmid = tmid
@@ -931,17 +960,21 @@ class LibfabricEndpoint(Endpoint):
     ep_map: Dict[Tuple[str, int], int] = {}
 
     def __init__(self, NetFamily: str, proto: NetProtocol, ipaddr: str,
-                 portalgroup: PortalGroup):
+                 portalgroup: Tuple[str, Any]):
         self.netfamily = NetFamily
         self.proto = proto
         assert ipaddr
         self.ipaddr = ipaddr
-        assert portalgroup.value > 0
         self.portalgroup = portalgroup
+        if isinstance(portalgroup[1], int):
+            portal = portalgroup[1]
+        else:
+            portal = portalgroup[1].value
+        assert portal > 0
         self.portal = 0
-        self.portal = self.ep_map.setdefault((ipaddr, portalgroup.value),
-                                             (portalgroup.value + 1))
-        self.ep_map[(ipaddr, portalgroup.value)] += 1
+        self.portal = self.ep_map.setdefault((ipaddr, portal),
+                                             (portal + 1))
+        self.ep_map[(ipaddr, portal)] += 1
 
     def __repr__(self):
         args = ', '.join([f'netfamily={self.netfamily!r}',
@@ -1138,17 +1171,31 @@ class ConfProcess(ToDhall):
         proto = node_desc.get('data_iface_type', 'tcp')
         transport_type = node_desc.get('transport_type', 'libfab')
         portal_group = portalgroup.get_portal_group()
+        if proc_t.name in ['m0_server', 'm0_client_other']:
+            found = False
+            for item in portal_group[proc_t.name]:
+                if item['name'] == proc_name:
+                    portal = (proc_t.name, item['port'])
+                    found = True
+                    break
+            if not found:
+                for client in portal_group[proc_t.name]:
+                    if item['name'] == 'default':
+                        portal = ('m0_client_other', item['port'])
+                        break
+        else:
+            portal = (proc_t.name, portal_group[proc_t.name])
         ep: Any = (
             LibfabricEndpoint(NetFamily='inet', proto=NetProtocol[proto],
                               ipaddr=facts[ipaddr_key(
                                            node_desc['data_iface'])],
-                              portalgroup=portal_group[proc_t.name]))
+                              portalgroup=portal))
         if transport_type == 'lnet':
             # Creates Lnet endpoint, remove once deprecated.
             ep = LnetEndpoint(proto=NetProtocol[proto],
                               ipaddr=facts[ipaddr_key(
                                            node_desc['data_iface'])],
-                              portalgroup=portal_group[proc_t.name])
+                              portalgroup=portal)
         proc_id = new_oid(ObjT.process)
         meta_data = None
         if proc_desc is not None and proc_t is ProcT.m0_server:
@@ -2240,7 +2287,7 @@ def consul_kv_sdevs(m0conf: Dict[Oid, Any]) -> Dict[str, str]:
             assert proc_id.type is ObjT.process
             proc_key = f'{node_key}/processes/' + oid_to_fidstr(proc_id)
             # XXX-VERIFYME Can we really convert from portal (int) to name?
-            proc_name = m0conf[proc_id].endpoint.portalgroup.name
+            proc_name = m0conf[proc_id].endpoint.portalgroup[0]
             d[proc_key] = json.dumps({'name': proc_name,
                                       'state': 'M0_NC_UNKNOWN'})
             for svc_id in m0conf[proc_id].services:
@@ -2538,12 +2585,12 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
         cluster.network_ports.update({k: v for k, v in ports.items()})
         lnet_portals = get_lnet_portal_group(
                            hax=ports['hax'],
-                           m0_server=ports['m0_server'],
+                           m0_server=tuple(ports['m0_server']),
                            m0_client_s3=ports['m0_client_s3'],
                            m0_client_other=ports['m0_client_other'])
         libfab_portals = get_libfab_portal_group(
                              hax=ports['hax'],
-                             m0_server=ports['m0_server'],
+                             m0_server=tuple(ports['m0_server']),
                              m0_client_s3=ports['m0_client_s3'],
                              m0_client_other=ports['m0_client_other'])
     else:
@@ -2577,10 +2624,15 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
             for ctrl_id in ctrl_ids:
                 m0d = ctrl_id[1]
                 conf_ctrl_id: Optional[Oid] = ctrl_id[0]
-                ConfProcess.build(conf, node_id, portalgroup, node,
-                                  ProcT.m0_server, m0d, conf_ctrl_id)
                 if m0d['runs_confd']:
                     confd_p = True
+                    ConfProcess.build(conf, node_id, portalgroup, node,
+                                      ProcT.m0_server, m0d, conf_ctrl_id,
+                                      proc_name='confd')
+                else:
+                    ConfProcess.build(conf, node_id, portalgroup, node,
+                                      ProcT.m0_server, m0d, conf_ctrl_id,
+                                      proc_name='ios')
 
         ipaddr = node['facts'][ipaddr_key(node['data_iface'])]
         (cluster.consul_servers if confd_p else cluster.consul_clients).\

--- a/cfgen/dhall/types.dhall
+++ b/cfgen/dhall/types.dhall
@@ -54,6 +54,8 @@
 , PoolsRef     = ./types/PoolsRef.dhall
 , FdmiFilterDesc = ./types/FdmiFilterDesc.dhall
 , NetworkPorts = ./types/Ports.dhall
+, ClientPort   = ./types/ClientPort.dhall
+, ServerPort   = ./types/ServerPort.dhall
 
 , Obj         = ./types/Obj.dhall
 , ObjT        = ./types/ObjT.dhall

--- a/cfgen/dhall/types/ClientPort.dhall
+++ b/cfgen/dhall/types/ClientPort.dhall
@@ -1,8 +1,10 @@
 {-
-  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
@@ -10,15 +12,13 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
+
   For any questions about this software or licensing,
   please email opensource@seagate.com or cortx-questions@seagate.com.
 
 -}
 
--- network ports
-{ hax : Optional Natural
-, hax_http : Optional Natural
-, m0_server : Optional (List ./ServerPort.dhall)
-, m0_client_s3 : Optional Natural
-, m0_client_other : Optional (List ./ClientPort.dhall)
+{ name : Text
+, port : Natural
 }
+

--- a/cfgen/dhall/types/ServerPort.dhall
+++ b/cfgen/dhall/types/ServerPort.dhall
@@ -1,8 +1,10 @@
 {-
-  Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+  Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
@@ -10,15 +12,13 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
+
   For any questions about this software or licensing,
   please email opensource@seagate.com or cortx-questions@seagate.com.
 
 -}
 
--- network ports
-{ hax : Optional Natural
-, hax_http : Optional Natural
-, m0_server : Optional (List ./ServerPort.dhall)
-, m0_client_s3 : Optional Natural
-, m0_client_other : Optional (List ./ClientPort.dhall)
+{ name : Text
+, port : Natural
 }
+

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -55,10 +55,15 @@ pools:
 #    node: localhost
 #    client_index: 1
 #    substrings: ["Bucket-Name", "Object-Name", "Object-URI"]
-#network_ports:
-#    hax: 22000
-#    hax_http: 8008
-#    m0_server: 21000
-#    m0_client_s3: 22500
-#    m0_client_other: 21500
-
+# network_ports:
+#   hax: 22000
+#   hax_http: 8008
+#   m0_server:
+#   - name: ios
+#     port: 21000
+#   - name: confd
+#     port: 21000
+#   m0_client_other:
+#   - name: m0_client_other
+#     port: 21500
+#   m0_client_s3: 22500

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -137,8 +137,8 @@ in
      None
      { hax : Optional Natural
      , hax_http: Optional Natural
-     , m0_server : Optional Natural
+     , m0_server : Optional (List { name: Text, port: Natural })
      , m0_client_s3 : Optional Natural
-     , m0_client_other : Optional Natural
+     , m0_client_other : Optional (List { name: Text, port: Natural })
      }
 } : types.ClusterDesc

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -6,18 +6,63 @@ from typing import Iterator, List, Optional, Tuple
 from math import floor, ceil
 import pkg_resources
 from urllib.parse import urlparse
+from enum import Enum, auto
 
 from cortx.utils.cortx import Const
 from hare_mp.store import ValueProvider
 from hare_mp.types import (ClusterDesc, DiskRef, DList, Maybe, NodeDesc,
                            PoolDesc, PoolType, ProfileDesc, Protocol, Text,
                            M0ServerDesc, DisksDesc, AllowedFailures, Layout,
-                           FdmiFilterDesc, NetworkPorts, M0ClientDesc)
+                           FdmiFilterDesc, NetworkPorts, M0ClientDesc,
+                           ClientPort, ServerPort)
 from hare_mp.utils import func_log, func_enter, func_leave, Utils
 
 DHALL_PATH = '/opt/seagate/cortx/hare/share/cfgen/dhall'
 DHALL_EXE = '/opt/seagate/cortx/hare/bin/dhall'
 DHALL_TO_YAML_EXE = '/opt/seagate/cortx/hare/bin/dhall-to-yaml'
+
+
+class procT(Enum):
+    """Motr service type
+    """
+    M0_CST_MDS = 1
+    M0_CST_IOS = auto()
+    M0_CST_CONFD = auto()
+    M0_CST_RMS = auto()
+    M0_CST_STATS = auto()
+    M0_CST_HA = auto()
+    M0_CST_SSS = auto()
+    M0_CST_SNS_REP = auto()
+    M0_CST_SNS_REB = auto()
+    M0_CST_ADDB2 = auto()
+    M0_CST_CAS = auto()
+    M0_CST_DIX_REP = auto()
+    M0_CST_DIX_REB = auto()
+    M0_CST_DS1 = auto()
+    M0_CST_DS2 = auto()
+    M0_CST_FIS = auto()
+    M0_CST_FDMI = auto()
+    M0_CST_BE = auto()
+    M0_CST_M0T1FS = auto()
+    M0_CST_CLIENT = auto()
+    M0_CST_ISCS = auto()
+
+    '''def SvcT_to_proc(stype: SvcT) -> str:
+        svcT_to_proc = {
+            M0_CST_MDS: 'mds',
+            M0_CST_IOS: 'ios',
+            M0_CST_CONFD: 'confd',
+            M0_CST_RMS: 'rms',
+            M0_CST_STATS: 'stats',
+            M0_CST_HA: 'ha',
+            M0_CST_SSS: 'sss',
+            M0_CST_SNS_REP: 'sns_repair',
+            M0_CST_SNS_REB: 'sns_rebalance',
+            M0_CST_ADDB2: 'addb',
+            M0_CST_CAS: 'cas'}'''
+
+    def __repr__(self):
+        return self.name
 
 
 @dataclass
@@ -256,7 +301,9 @@ class CdfGenerator:
 
     def _create_ports_descriptions(self) -> NetworkPorts:
         conf = self.provider
-
+        m0serverT = ['ios', 'confd']
+        m0server_ports = []
+        m0client_ports = []
         for srv in NetworkPorts.__annotations__.keys():
             if srv == 'hax':
                 url = conf.get('cortx>hare>hax>endpoints', allow_null=True)
@@ -268,11 +315,23 @@ class CdfGenerator:
                     if _parsed_url.scheme in ('http', 'https'):
                         _hax_http = _parsed_url.port
             elif srv == 'm0_client_other':
-                _client_other = None
+                for client in self.provider.get_motr_clients():
+                    url = client.get('endpoints')
+                    if url:
+                        port = round(urlparse(url[0]).port / 100) * 100
+                        client_name = str(client.get('name'))
+                        m0client_ports.append(
+                            ClientPort(name=Text(client_name),
+                                       port=int(port)))
             elif srv == 'm0_server':
-                url = conf.get('cortx>motr>ios>endpoints', allow_null=True)
-                _ios = url if url is None else \
-                    round(urlparse(url[0]).port / 100) * 100
+                for server in m0serverT:
+                    url = conf.get(f'cortx>motr>{server}>endpoints',
+                                   allow_null=True)
+                    port = 0 if url is None else \
+                        round(urlparse(url[0]).port / 100) * 100
+                    m0server_ports.append(
+                        ServerPort(name=Text(server),
+                                   port=int(port)))
             else:
                 url = conf.get('cortx>motr>client>endpoints', allow_null=True)
                 _client_s3 = url if url is None else \
@@ -281,8 +340,10 @@ class CdfGenerator:
         return NetworkPorts(
             hax=Maybe(_hax, 'Natural'),
             hax_http=Maybe(_hax_http, 'Natural'),
-            m0_server=Maybe(_ios, 'Natural'),
-            m0_client_other=Maybe(_client_other, 'Natural'),
+            m0_server=Maybe(DList(m0server_ports, 'List ServerPort'),
+                            'List ServerPort'),
+            m0_client_other=Maybe(DList(m0client_ports, 'List ClientPort'),
+                                  'List ClientPort'),
             m0_client_s3=Maybe(_client_s3, 'Natural'))
 
     def _get_cdf_dhall(self) -> str:

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -26,6 +26,16 @@ let M0ClientDesc =
       , instances : Natural
       }
 
+let ClientPort =
+      { name: Text
+      , port: Natural
+      }
+
+let ServerPort =
+      { name: Text
+      , port: Natural
+      }
+
 let NodeInfo =
       { hostname : Text
       , machine_id : Optional Text

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -164,12 +164,24 @@ class FdmiFilterDesc(DhallTuple):
 
 
 @dataclass(repr=False)
+class ClientPort(DhallTuple):
+    name: Text
+    port: int
+
+
+@dataclass(repr=False)
+class ServerPort(DhallTuple):
+    name: Text
+    port: int
+
+
+@dataclass(repr=False)
 class NetworkPorts(DhallTuple):
     hax: Maybe[int]
     hax_http: Maybe[int]
-    m0_server: Maybe[int]
+    m0_server: Maybe[DList[ServerPort]]
     m0_client_s3: Maybe[int]
-    m0_client_other: Maybe[int]
+    m0_client_other: Maybe[DList[ClientPort]]
 
 
 @dataclass(repr=False)


### PR DESCRIPTION
**Solution:**
Modified 'NetworkPorts' to include list of endpoints for clients as well as ios and confd.
cfgen will use endpoint according to type of process

```
network_ports:
  m0_server:
  - 29000
  - 22000
  m0_client_other:
  - name: rgw
    port: 21000
  m0_client_s3: null
  hax: 22000
```

**Testing in progress**

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>