### PR TITLE
CORTX-29741: replace obsolete conf-store keys

### DIFF
--- a/containers/examples/3node/hare.config.conf.3-node
+++ b/containers/examples/3node/hare.config.conf.3-node
@@ -2,7 +2,7 @@
   "cluster": {    
     "my-cluster": {
       "site": {
-        "storage_set_count": "1"
+        "num_storage_set": "1"
       },
       "storage_set": [
         {
@@ -59,7 +59,7 @@
       "s3_instances": "2",
       "storage_set_id": "storage1",
       "storage": {
-        "cvg_count": "1",
+        "num_cvg": "1",
         "cvg": [
           {
             "data_devices": [
@@ -96,7 +96,7 @@
       "s3_instances": "2",
       "storage_set_id": "storage1",
       "storage": {
-        "cvg_count": "1",
+        "num_cvg": "1",
         "cvg": [
           {
             "data_devices": [
@@ -133,7 +133,7 @@
       "s3_instances": "2",
       "storage_set_id": "storage1",
       "storage": {
-        "cvg_count": "1",
+        "num_cvg": "1",
         "cvg": [
           {
             "data_devices": [

--- a/containers/examples/3node/hare.config.conf.n.cvgs.3-node
+++ b/containers/examples/3node/hare.config.conf.n.cvgs.3-node
@@ -2,7 +2,7 @@
   "cluster": {    
     "my-cluster": {
       "site": {
-        "storage_set_count": "1"
+        "num_storage_set": "1"
       },
       "storage_set": [
         {
@@ -59,7 +59,7 @@
       "s3_instances": "2",
       "storage_set_id": "storage1",
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "data_devices": [
@@ -103,7 +103,7 @@
       "s3_instances": "2",
       "storage_set_id": "storage1",
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "data_devices": [
@@ -147,7 +147,7 @@
       "s3_instances": "2",
       "storage_set_id": "storage1",
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "data_devices": [

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -118,8 +118,8 @@ class CdfGenerator:
         conf = self.provider
         pool_type = pool.pool_type
         prop_name = 'data'
-        # node>{machine-id}>storage>cvg_count
-        cvg_num = int(conf.get(f'node>{node}>storage>cvg_count'))
+        # node>{machine-id}>storage>num_cvg
+        cvg_num = int(conf.get(f'node>{node}>storage>num_cvg'))
         all_cvg_devices = []
         if pool_type == 'dix':
             prop_name = 'metadata'
@@ -172,9 +172,9 @@ class CdfGenerator:
 
         node_count = len(data_nodes)
         machine_id = data_nodes[0]
-        # node>{machine-id}>storage>cvg_count
+        # node>{machine-id}>storage>num_cvg
         cvg_per_node = int(conf.get(
-            f'node>{machine_id}>storage>cvg_count'))
+            f'node>{machine_id}>storage>num_cvg'))
 
         total_unit = layout.data + layout.parity + layout.spare
         if total_unit == 0:
@@ -225,11 +225,11 @@ class CdfGenerator:
         pools: List[PoolDesc] = []
         conf = self.provider
         cluster_id = self._get_cluster_id()
-        # cluster>storage_set_count
-        storage_set_count = int(
-            conf.get('cluster>storage_set_count'))
+        # cluster>num_storage_set
+        num_storage_set = int(
+            conf.get('cluster>num_storage_set'))
 
-        for i in range(storage_set_count):
+        for i in range(num_storage_set):
             for pool_type in ('sns', 'dix'):
                 handle = PoolHandle(cluster_id=cluster_id,
                                     pool_type=pool_type,

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "TMPL_STORAGESET_COUNT",
+    "num_storage_set": "NUM_STORAGESET",
     "storage_set": [
       {
         "durability": {
@@ -48,7 +48,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-      "storage_set_count": "TMPL_STORAGESET_COUNT",
+      "num_storage_set": "TMP_NUM_STORAGESET",
       "storage_set": [
         {
           "durability": {
@@ -50,7 +50,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -94,7 +94,7 @@
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -138,7 +138,7 @@
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "1",
+    "num_storage_set": "1",
     "storage_set": [
       {
         "durability": {
@@ -55,7 +55,7 @@
       },
       "storage_set": "storage1",
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {
@@ -100,7 +100,7 @@
       },
       "storage_set": "storage1",
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {
@@ -145,7 +145,7 @@
       },
       "storage_set": "storage1",
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "TMPL_STORAGESET_COUNT",
+    "num_storage_set": "TMPL_NUM_STORAGESET",
     "storage_set": [
       {
         "durability": {
@@ -48,7 +48,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-      "storage_set_count": "TMPL_STORAGESET_COUNT",
+      "num_storage_set": "TMPL_NUM_STORAGESET",
       "storage_set": [
         {
           "durability": {
@@ -50,7 +50,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -93,7 +93,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -136,7 +136,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node.sample
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "1",
+    "num_storage_set": "1",
     "my-cluster": {
       "storage_set": [
         {
@@ -49,7 +49,7 @@
         }
       },
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {
@@ -91,7 +91,7 @@
         }
       },
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {
@@ -133,7 +133,7 @@
         }
       },
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "TMPL_STORAGESET_COUNT",
+    "num_storage_set": "TMPL_NUM_STORAGESET",
     "storage_set": [
       {
         "durability": {
@@ -48,7 +48,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-      "storage_set_count": "TMPL_STORAGESET_COUNT",
+      "num_storage_set": "TMPL_NUM_STORAGESET",
       "storage_set": [
         {
           "durability": {
@@ -50,7 +50,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -93,7 +93,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -136,7 +136,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "TMPL_STORAGESET_COUNT",
+    "num_storage_set": "TMPL_NUM_STORAGESET",
     "storage_set": [
       {
         "durability": {
@@ -48,7 +48,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -1,6 +1,6 @@
 {
   "cluster": {
-      "storage_set_count": "TMPL_STORAGESET_COUNT",
+      "num_storage_set": "TMPL_NUM_STORAGESET",
       "storage_set": [
         {
           "durability": {
@@ -50,7 +50,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -93,7 +93,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {
@@ -136,7 +136,7 @@
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
       "storage": {
-        "cvg_count": "TMPL_CVG_COUNT",
+        "num_cvg": "TMPL_NUM_CVG",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
@@ -1,6 +1,6 @@
 {
   "cluster": {
-    "storage_set_count": "1",
+    "num_storage_set": "1",
     "my-cluster": {
       "storage_set": [
         {
@@ -49,7 +49,7 @@
         }
       },
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {
@@ -91,7 +91,7 @@
         }
       },
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {
@@ -133,7 +133,7 @@
         }
       },
       "storage": {
-        "cvg_count": "2",
+        "num_cvg": "2",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/samples/sample_provisioner_cluster.json
+++ b/provisioning/miniprov/samples/sample_provisioner_cluster.json
@@ -32,7 +32,7 @@
   "cluster": {
     "name": "cortx_cluster",
     "site_count": "1",
-    "storage_set_count": "1",
+    "num_storage_set": "1",
     "network": {
       "management": {
         "virtual_host": "None"
@@ -97,7 +97,7 @@
         }
       },
       "storage": {
-        "cvg_count": "1",
+        "num_cvg": "1",
         "cvg": [
           {
             "devices": {

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -196,7 +196,7 @@ class TestCDF(unittest.TestCase):
                 ['/dev/sdc'],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'node>MACH_ID>storage>cvg_count':
+                'node>MACH_ID>storage>num_cvg':
                 2,
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
@@ -210,8 +210,8 @@ class TestCDF(unittest.TestCase):
                 'tcp',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>cvg_count': 1,
-                'cluster>storage_set_count':
+                'node>MACH_ID>storage>num_cvg': 1,
+                'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
                 1,
@@ -295,7 +295,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'cluster>storage_set_count': 1,
+                'cluster>num_storage_set': 1,
                 'cluster>storage_set>server_node_count':
                 1,
                 'cluster>storage_set[0]>name': 'StorageSet-1',
@@ -311,7 +311,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
                  {'name': 'other'}],
-                'node>MACH_ID>storage>cvg_count': 2,
+                'node>MACH_ID>storage>num_cvg': 2,
                 'node>MACH_ID>storage>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
                 'node>MACH_ID>storage>cvg[0]>devices>data': ['/dev/sdb'],
@@ -453,7 +453,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'cluster>storage_set_count': 1,
+                'cluster>num_storage_set': 1,
                 'cluster>storage_set[0]>name': 'StorageSet-1',
                 'cluster>storage_set[0]>durability>sns':
                 {'data': 4, 'parity' : 2, 'spare' : 0},
@@ -476,7 +476,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID3>storage>cvg':
                 [{'devices': {'data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'], 'metadata': ['/dev/meta2']}}],
-                'node>MACH_ID1>storage>cvg_count': '2',
+                'node>MACH_ID1>storage>num_cvg': '2',
                 'node>MACH_ID1>storage>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
                 'node>MACH_ID1>storage>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
                 'node>MACH_ID1>storage>cvg[0]>devices>metadata': ['/dev/meta1'],
@@ -489,7 +489,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID1>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'node>MACH_ID2>storage>cvg_count': '2',
+                'node>MACH_ID2>storage>num_cvg': '2',
                 'node>MACH_ID2>storage>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
                 'node>MACH_ID2>storage>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
                 'node>MACH_ID2>storage>cvg[0]>devices>metadata': ['/dev/meta1'],
@@ -502,7 +502,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID2>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'node>MACH_ID3>storage>cvg_count': '2',
+                'node>MACH_ID3>storage>num_cvg': '2',
                 'node>MACH_ID3>storage>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
                 'node>MACH_ID3>storage>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
                 'node>MACH_ID3>storage>cvg[0]>devices>metadata': ['/dev/meta1'],
@@ -544,8 +544,8 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'node>MACH_ID>storage>cvg_count': 1,
-                'cluster>storage_set_count': 1,
+                'node>MACH_ID>storage>num_cvg': 1,
+                'cluster>num_storage_set': 1,
                 'cluster>storage_set>server_node_count': 1,
                 'cluster>storage_set[0]>name': 'StorageSet-1',
                 'cluster>storage_set[0]>nodes': ['MACH_ID'],
@@ -575,7 +575,7 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>cvg_count':
+                'node>MACH_ID>storage>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
@@ -632,7 +632,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'cluster>storage_set_count':
+                'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
                 1,
@@ -659,7 +659,7 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>cvg_count':
+                'node>MACH_ID>storage>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
@@ -688,7 +688,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'cluster>storage_set_count':
+                'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
                 1,
@@ -735,8 +735,8 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'node>MACH_ID>storage>cvg_count': 1,
-                'cluster>storage_set_count':
+                'node>MACH_ID>storage>num_cvg': 1,
+                'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
                 1,
@@ -765,7 +765,7 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>cvg_count':
+                'node>MACH_ID>storage>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
@@ -796,8 +796,8 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'node>MACH_ID>storage>cvg_count': 1,
-                'cluster>storage_set_count':
+                'node>MACH_ID>storage>num_cvg': 1,
+                'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
                 1,
@@ -830,7 +830,7 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>cvg_count':
+                'node>MACH_ID>storage>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
@@ -990,7 +990,7 @@ class TestCDF(unittest.TestCase):
                     'MACH_ID': 'stub',
                     'MACH_2_ID': 'stub'
                 },
-                'cluster>storage_set_count':
+                'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
                 2,

--- a/provisioning/miniprov/test/test_templates.py
+++ b/provisioning/miniprov/test/test_templates.py
@@ -82,7 +82,7 @@ def is_content_ok(content: str, mocker, kv_adapter) -> bool:
 def placeholders() -> Dict[str, str]:
     return {
         'TMPL_CLUSTER_ID': 'stub_cluster_id',
-        'TMPL_CVG_COUNT': '1',
+        'TMPL_NUM_CVG': '1',
         'TMPL_DATA_DEVICE_1': '/dev/sdb',
         'TMPL_DATA_DEVICE_2': '/dev/sdc',
         'TMPL_DATA_DEVICE_11': '/dev/sdb',
@@ -103,7 +103,7 @@ def placeholders() -> Dict[str, str]:
         'TMPL_S3SERVER_INSTANCES_COUNT': '4',
         'TMPL_SERVER_NODE_NAME': 'srvnode-1',
         'TMPL_SPARE_UNITS_COUNT': '0',
-        'TMPL_STORAGESET_COUNT': '1',
+        'TMPL_NUM_STORAGESET': '1',
         'TMPL_STORAGESET_NAME': 'storage-set',
         'TMPL_STORAGE_SET_ID': 'storage-set',
         'TMPL_PRIVATE_FQDN': 'my-node-1',


### PR DESCRIPTION
keys replaced old to new:
cvg_count to num_cvg
storage_set_count to num_storage_set
Also changed: 
TMPL_CVG_COUNT TO TMPL_NUM_CVG
TMPL_STORAGESET_COUNT TO TMPL_NUM_STORAGESET
Signed-off-by: Lakshita Jain <lakshita.jain@seagate.com>

Signed-off-by: Lakshita Jain <lakshita.jain@seagate.com>