### PR TITLE
utils: motr process is reported as offline if its in starting

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -127,6 +127,8 @@ class ConsumerThread(StoppableThread):
                 if state.fid.container == ObjT.PROCESS.value:
                     current_status = self.consul.get_process_current_status(
                         state.status, state.fid)
+                    if current_status == ObjHealth.UNKNOWN:
+                        continue
                     proc_status_remote = self.consul.get_process_status(
                                              state.fid)
                     proc_status: Any = None

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1678,11 +1678,11 @@ class ConsulUtil:
 
         svc_to_motr_status_map = {
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STARTING'):
-            local_remote_health_ret(ObjHealth.OFFLINE,
-                                    ObjHealth.OFFLINE),
+            local_remote_health_ret(ObjHealth.UNKNOWN,
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STOPPING'):
-            local_remote_health_ret(ObjHealth.OFFLINE,
-                                    ObjHealth.OFFLINE),
+            local_remote_health_ret(ObjHealth.UNKNOWN,
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STARTED'):
             local_remote_health_ret(ObjHealth.OK,
                                     ObjHealth.OK),

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -75,7 +75,8 @@ class Svc(Enum):
     Hax = 'hax'
 
 
-@func_log(func_enter, func_leave)
+# Note: func_log method will not work for this function as the
+# relevant log dir does not exists.
 def create_logger_directory(log_dir):
     """Create log directory if not exists."""
     if not os.path.isdir(log_dir):


### PR DESCRIPTION
Consul may send motr process state notification periodically, Hare
checks current state of the motr process as Consul notification can
be delayed. Presently if motr process's Consul service status is
passing but process's motr status is M0_CONF_HA_PROCESS_STARTING,
then Hare reports that process as offline. The same is updated in
Consul KV. This leads to inconsistencies.

Solution:
Report motr process as offline only if the corresponding Consul
service status is warning.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>