### PR TITLE
CORTX-29700: Add Hax service to watches list

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -137,8 +137,7 @@ class ConsumerThread(StoppableThread):
                     # processes.
                     if proc_status_remote.proc_type in (
                             'Unknown',
-                            m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name,
-                            m0HaProcessType.M0_CONF_HA_PROCESS_HA.name):
+                            m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS.name):
                         continue
                     proc_type = m0HaProcessType.str_to_Enum(
                          proc_status_remote.proc_type)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -262,7 +262,7 @@ def process_state_update(planner: WorkPlanner):
                 proc_fid = Fid.parse(item['Key'].split('/')[1])
                 proc_state = proc_status['state']
                 proc_type = proc_status['type']
-                if (proc_type == 'M0_CONF_HA_PROCESS_M0D' and
+                if (proc_type != 'M0_CONF_HA_PROCESS_M0MKFS' and
                         proc_state in ('M0_CONF_HA_PROCESS_STARTED',
                                        'M0_CONF_HA_PROCESS_STOPPED')):
                     ha_states.append(HAState(

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -580,7 +580,7 @@ class ConsulUtil:
             if service_name not in motr_services:
                 continue
             data = self.get_service_data_by_name(service_name)
-            LOG.debug('svc data: %s', data)
+            LOG.log(TRACE, 'svc data: %s', data)
             for item in data:
                 node = self.get_process_node(item.fid, kv_cache=kv_cache)
                 svc_health = self.get_service_health(node,
@@ -1756,7 +1756,7 @@ class ConsulUtil:
             #                             recurse=True,
             #                             kv_cache=kv_cache)
             node_items = self.get_all_nodes(kv_cache=kv_cache)
-            LOG.debug('node items: %s', node_items)
+            LOG.log(TRACE, 'node items: %s', node_items)
             if ObjT.PROCESS.value == proc_fid.container:
                 keys = self.get_process_keys(node_items, fidk)
             elif ObjT.SERVICE.value == proc_fid.container:

--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -34,6 +34,38 @@
     },
     {
       "type": "service",
+      "service": "hax",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:HAX_HTTP_PORT",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
+      "type": "service",
+      "service": "hax",
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
+    },
+    {
+      "type": "service",
+      "service": "confd",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:HAX_HTTP_PORT",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
+      "type": "service",
+      "service": "confd",
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
+    },
+    {
+      "type": "service",
       "service": "ios",
       "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
                 "--log-dir", "TMP_LOG_DIR" ]

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -24,6 +24,22 @@
     },
     {
       "type": "service",
+      "service": "hax",
+      "handler_type": "http",
+      "http_handler_config": {
+        "path": "http://localhost:HAX_HTTP_PORT",
+        "method": "POST",
+        "timeout": "10s"
+      }
+    },
+    {
+      "type": "service",
+      "service": "hax",
+      "args": [ "/opt/seagate/cortx/hare/libexec/consul-watch-handler",
+                "--log-dir", "TMP_LOG_DIR" ]
+    },
+    {
+      "type": "service",
       "service": "confd",
       "handler_type": "http",
       "http_handler_config": {


### PR DESCRIPTION
Problem:
When data pod deleted and its process show offline in
hctl status, but consul kv shows Hax process states
as started.

Solution:
Add Hax service to watcher list.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>