### PR TITLE
CORTX-33728: Actual status of resource is not available in 'event_type' field

### DIFF
--- a/hax/hax/ha/handler/node.py
+++ b/hax/hax/ha/handler/node.py
@@ -66,7 +66,7 @@ class NodeEventHandler(EventHandler):
 
         self.planner.add_command(
             BroadcastHAStates(states=[
-                HAState(fid=node_fid, status=get_health(msg.event_type))
+                HAState(fid=node_fid, status=get_health(msg.resource_status))
             ],
                               reply_to=None))
 

--- a/hax/hax/ha/message_interface/message_interface.py
+++ b/hax/hax/ha/message_interface/message_interface.py
@@ -34,7 +34,7 @@ ADMIN_ID = "hare_admin"
 @dataclass
 class Event:
     version: str
-    event_type: str
+    resource_status: str
     event_id: str
     resource_type: str
     cluster_id: str
@@ -159,7 +159,7 @@ class MessageBusInterface(MessageInterface):
         payload = data['payload']
         header = data['header']
         return Event(version=header['version'],
-                     event_type='NOT_DEFINED',
+                     resource_status=payload['resource_status'],
                      event_id=header['event_id'],
                      resource_type=payload['resource_type'],
                      cluster_id=payload['cluster_id'],


### PR DESCRIPTION
When HA send node online event to Hare event_type is not poppulate anymore.
Instead status(online, failed, offline) is available in resource_status.

**Solution**:
Modified code to use 'resource_status' instead of 'event_type'

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>