### PR TITLE
CORTX-31086: init_motr_processes_status does not retry on failure

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -2033,9 +2033,13 @@ class ConsulUtil:
         this_node = self.get_local_nodename()
         return leader == this_node
 
+    @repeat_if_fails()
     def init_motr_processes_status(self):
         local_node = self.get_local_nodename()
         fid = self.get_node_fid(local_node)
+        if not fid or fid is None:
+            raise HAConsistencyException(
+                f'node fid not available yet for {local_node}')
         children = self.kv.kv_get(f'm0conf/nodes/{fid}/processes',
                                   recurse=True)
         for item in children or []:


### PR DESCRIPTION
It is possible that the imported Consul KV might node be available
on all the nodes at real time. This may lead to temporary failures
in subset of configured nodes while reading Consul KVs. In case of
such failures, interested functions must retry based on the KV
availability expectations (i.e. if the KV must be present or can be
NULL).

Solution:
- repeat init_motr_processes_status() if get_node_fid() fails or
returns None.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>