### PR TITLE
CORTX-29826: Hare-HA: report node status as degraded or offline based on process failures

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2367,6 +2367,16 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                         root.imeta_pver not in m0conf[x].pvers]
         raise RuntimeError('Impossible happened')
 
+    def node_machine_id_map() -> List[Tuple[str, str]]:
+        ids = []
+        for node_id, node in m0conf.items():
+            if (node_id.type is ObjT.node and node.machine_id):
+                # Store machine-id to node-name mapping
+                ids.append((node.machine_id, node.name))
+                # Store node-name to machine-id mapping
+                ids.append((node.name, node.machine_id))
+        return ids
+
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
         ('eq-epoch', 1),
@@ -2381,9 +2391,7 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
            json.dumps({'http': node.network_ports.get('hax_http', 8008)}))
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node)],
         ('m0_client_types', json.dumps(cluster.m0_client_types)),
-        *[(node.machine_id, node.name)
-          for node_id, node in m0conf.items() if (node_id.type is ObjT.node
-                                                  and node.machine_id)],
+        *node_machine_id_map(),
         *[('m0conf/pools/' + oid_to_fidstr(pool_id), m0conf[pool_id]._name)
           for pool_id in sns_pools()],
         *[('m0conf/profiles/' + oid_to_fidstr(prof_id),

--- a/hax/hax/ha/ha.py
+++ b/hax/hax/ha/ha.py
@@ -16,11 +16,18 @@
 # opensource@seagate.com or cortx-questions@seagate.com.
 
 import logging
+from typing import List, NamedTuple, Optional
 from hax.ha.event.node import NodeEvent
 from hax.ha.message_type.message_type import HealthMessage
-from hax.types import ObjT, Fid
+from hax.types import HAState, ObjHealth, ObjT, Fid
 from hax.util import ConsulUtil
 from cortx.utils.conf_store import Conf
+
+LOG = logging.getLogger('hax')
+
+
+Resource = NamedTuple('Resource', [('type', ObjT), ('id', str),
+                                   ('name', str), ('status', str)])
 
 
 class Ha():
@@ -31,17 +38,13 @@ class Ha():
     def __init__(self, util: ConsulUtil):
         self.util = util
 
-    def send_event(self,
-                   resource_type: ObjT,
-                   resource_id: str,
-                   resource_name: str,
-                   resource_status: str):
-        resource = self.resources[resource_type]()
-        event = resource.create_event(resource_id,
-                                      resource_name,
-                                      resource_status)
+    def send_event(self, res: Resource):
+        resource = self.resources[res.type]()
+        event = resource.create_event(res.id,
+                                      res.name,
+                                      res.status)
 
-        interfaces = self.message_types[resource_type]
+        interfaces = self.message_types[res.type]
         for interface in interfaces:
             sender = interface()
             sender.send(event, self.util)
@@ -55,10 +58,51 @@ class Ha():
                 self.util.is_proc_local(fid)):
             resource = self.util.get_process_node(fid)
             resource_id = str(Conf.machine_id)
-            logging.debug('Sending %s event for resource %s',
-                          resource_status, resource)
-            self.send_event(
-                resource_type=parent_resource_type,
-                resource_id=resource_id,
-                resource_name=resource,
-                resource_status=resource_status)
+            LOG.debug('Sending %s event for resource %s',
+                      resource_status, resource)
+            self.send_event(Resource(type=parent_resource_type,
+                                     id=resource_id,
+                                     name=resource,
+                                     status=resource_status))
+
+    def generate_event_for_process(self,
+                                   ha_state: HAState) -> Optional[Resource]:
+        cns = self.util
+        resource = None
+        # TODO handle process 'online' events
+        if (ha_state.status == ObjHealth.OFFLINE and
+                cns.am_i_rc() or cns.is_proc_local(ha_state.fid)):
+
+            node_name = cns.get_process_node(ha_state.fid)
+            node_fid = cns.get_node_fid(node_name)
+            state = cns.get_process_based_node_state(node_fid)
+            # since the node event is not always for local node
+            # when node is offline, rc node sends the offline event.
+            resource_id = cns.get_machineid_by_nodename(node_name)
+
+            resource = Resource(type=ObjT.NODE,
+                                id=resource_id,
+                                name=node_name,
+                                status=state)
+        return resource
+
+    def broadcast(self, ha_states: List[HAState]) -> None:
+
+        resource_map = {
+            ObjT.PROCESS.value: self.generate_event_for_process}
+
+        LOG.debug('Notifying HA with states %s', ha_states)
+        for st in ha_states:
+            obj_type = st.fid.container
+            if obj_type not in resource_map:
+                LOG.exception('Events for object type %s is not supported',
+                              obj_type)
+                continue
+            resource = resource_map[obj_type](st)
+            if resource:
+                LOG.debug('Sending %s event for resource %s:%s',
+                          resource.status, resource.type, resource.name)
+                try:
+                    self.send_event(resource)
+                except Exception as e:
+                    LOG.warning("Send event failed due to '%s'", e)

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -306,6 +306,12 @@ class ConsumerThread(StoppableThread):
                             planner, item.states)
                         result: List[MessageId] = motr.broadcast_ha_states(
                             ha_states)
+                        ha = get_producer(self.consul)
+                        if ha:
+                            ha.broadcast(ha_states)
+                        else:
+                            LOG.warning('Could not sent an event as producer'
+                                        ' is not available')
                         if item.reply_to:
                             item.reply_to.put(result)
                     elif isinstance(item, StobIoqError):


### PR DESCRIPTION
### Description

When consul notifies hax with process failure events, we need to report
aggregated node status to HA.

	- When one or more processes fails but less than total no. of processes
	  running on a particular node, we report node status "degraded", by the
	  local node.

	- When all the processes fail, then RC node reports node status
	  "offline" for that node.

The states of the processes are maintained in consul kv key `process/<process fid>`

### Testing

- killing the pod (node failure)
- process failure notification was received by both the RC node and local node.

local node
- until hax was up, received local process failure events.
- Sent node status=degraded
- once hax was down, nothing happened.

RC node
- Received all the process failure events.
- sent degraded node status
- sent offline node status - when all the motr processes were down and hax up.
- sent offline when hax was down too.

ran sample consumer script to read the events from message bus.

degraded node event
```
Received event={"header": {"version": "1.0", "timestamp": "1651743375.0988984", "event_id": "1651743375f144d30f47494fb088f4b60bdf8171fd"}, "payload": {"source": "hare", "cluster_id": "NOT_DEFINED", "site_id": "NOT_DEFINED", "rack_id": "NOT_DEFINED", "storageset_id": "NOT_DEFINED", "node_id": "1234567abc", "resource_type": "node", "resource_id": "1234567abc", "resource_status": "degraded", "specific_info": {"generation_id": "cortx-data-headless-svc-ssc-vm-g2-rhev4-2621"}}}
```
offline event
```
Received event={"header": {"version": "1.0", "timestamp": "1651743379.7186642", "event_id": "1651743379792f918b4f2c4a3ebe9b3458498235f6"}, "payload": {"source": "hare", "cluster_id": "NOT_DEFINED", "site_id": "NOT_DEFINED", "rack_id": "NOT_DEFINED", "storageset_id": "NOT_DEFINED", "node_id": "1234567abc", "resource_type": "node", "resource_id": "1234567abc", "resource_status": "offline", "specific_info": {"generation_id": "cortx-data-headless-svc-ssc-vm-g2-rhev4-2621"}}}
```