### PR TITLE
CORTX-30783: Run m0tracedump when creating support bundles

### DIFF
--- a/utils/hare-reportbug
+++ b/utils/hare-reportbug
@@ -148,6 +148,14 @@ for f in ${extra_files[@]}; do
     fi
 done
 
+find "$conf_dir" -type f -name 'm0trace.*' | while read trace; do
+    ## Disable stderr output to suppress these messages:
+    ##
+    ## > lt-m0tracedump: Warning: skipping non-existing trace
+    ## > descriptor 0x7f977d0bdb00 (orig 0x7ff6ad5c9b00)
+    m0tracedump -s -i "$trace" 2>/dev/null | xz > "$trace.yaml.xz" || true
+done
+
 cp --parents $conf_dir/* . 2>/dev/null || true
 cp -r --parents $conf_dir/consul-{env,server,client}-* . 2>/dev/null || true
 cp -r --parents $log_dir/ . 2>/dev/null || true


### PR DESCRIPTION
Motr traces in the support bundles are currently in binary form, which can only be parsed by the exact Motr version that created them. A YAML format is also available that's easier to work with. Motr currently generates YAML traces in its support bundles (see https://github.com/Seagate/cortx-motr/blob/ae3c398111ffae336515613aacd22e89c914683c/utils/m0reportbug#L754 for details). This adds a similar step to Hare's support bundle generation process.