### PR TITLE
CORTX-31185: SNS Repair: hctl repair status command is failing

### DIFF
--- a/utils/hare-rebalance
+++ b/utils/hare-rebalance
@@ -71,6 +71,10 @@ get_ip_addr() {
     curl -sX GET http://localhost:8500/v1/agent/self | jq -r .DebugConfig.BindAddr
 }
 
+get_hax_port() {
+    consul kv get ports/hax | jq -r .http
+}
+
 # process commands
 case $cmd in
     help) usage; exit ;;
@@ -89,7 +93,8 @@ case $cmd in
         # Access HTTP API request to get percentage of re-balance operation
         # This request is synchronous.
         ip_addr=$(get_ip_addr)
-        curl "http://$ip_addr:8008/api/v1/sns/rebalance-status?pool_fid=$pool_fid"
+        hax_port=$(get_hax_port)
+        curl "http://$ip_addr:${hax_port}/api/v1/sns/rebalance-status?pool_fid=$pool_fid"
         echo
         # TODO: JSON is expected. Additional processing may be needed depending on
         # output.

--- a/utils/hare-repair
+++ b/utils/hare-repair
@@ -71,6 +71,10 @@ get_ip_addr() {
     curl -sX GET http://localhost:8500/v1/agent/self | jq -r .DebugConfig.BindAddr
 }
 
+get_hax_port() {
+    consul kv get ports/hax | jq -r .http
+}
+
 # process commands
 case $cmd in
     help) usage; exit ;;
@@ -91,7 +95,8 @@ case $cmd in
         # Access HTTP API request to get percentage of repair operation
         # This request is synchronous.
         ip_addr=$(get_ip_addr)
-        curl "http://$ip_addr:8008/api/v1/sns/repair-status?pool_fid=$pool_fid"
+        hax_port=$(get_hax_port)
+        curl "http://$ip_addr:${hax_port}/api/v1/sns/repair-status?pool_fid=$pool_fid"
         echo
         # TODO: JSON is expected. Additional processing may be needed depending
         # on output.


### PR DESCRIPTION
This issue is common to hare utils: hare-repair, hare-rebalance
Both had the hax port hard-coded to 8008 in the curl query URL for status

Solution:

Derive the hax port using consul kv and pass it as a variable to the URL

Signed-off-by: Deepak Nayak <deepak.nayak@seagate.com>