### PR TITLE
CORTX-26200 : Hare logs are not rotated as per logrotate configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,8 @@ install-provisioning:
 	 done
 	@$(call _log,copying provisioning/logrotate/hare -> $(LOGROTATE_CONF_DIR))
 	@install --mode=0644 provisioning/logrotate/hare $(LOGROTATE_CONF_DIR)
+	@$(call _log,copying provisioning/logrotate/hare_logrotate.sh -> $(ETC_CRON_DIR))
+	@install --mode=0744 provisioning/logrotate/hare_logrotate.sh $(ETC_CRON_DIR)
 
 # devinstall {{{2
 .PHONY: devinstall

--- a/provisioning/logrotate/hare_logrotate.sh
+++ b/provisioning/logrotate/hare_logrotate.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+LOGROTATE_CONF_FILE=/etc/logrotate.d/hare
+if [[ -f "$LOGROTATE_CONF_FILE" ]]; then
+    /usr/sbin/logrotate $LOGROTATE_CONF_FILE
+    EXITVALUE=$?
+    if [ $EXITVALUE != 0 ]; then
+        /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+    fi
+    exit $EXITVALUE
+else
+    echo "$LOGROTATE_CONF_FILE does not exist"
+fi
+


### PR DESCRIPTION
Although Hare configures logrotate, the default cron job to run logrotate is configured
to be executed daily on RHEL based operating systems. This delays rotation of Hare logs
and Hare logs might grow to more than the configured limit.

Solution:
Explicitly configure a Hare specific cron job to run logrotate hourly.
