### PR TITLE
CORTX-30793- Change hierarchy {nodeid}>storage>cvg to {nodeid}>cvg

### DIFF
--- a/containers/examples/3node/hare.config.conf.3-node
+++ b/containers/examples/3node/hare.config.conf.3-node
@@ -58,22 +58,20 @@
       },
       "s3_instances": "2",
       "storage_set_id": "storage1",
-      "storage": {
-        "num_cvg": "1",
-        "cvg": [
-          {
-            "data_devices": [
-              "/dev/sdb",
-              "/dev/sdc",
-              "/dev/sdd",
-              "/dev/sde"
-            ],
-            "metadata_devices": [
-              "/dev/sdj"
-            ]
-          }
-        ]
-      }
+      "num_cvg": "1",
+      "cvg": [
+        {
+          "data_devices": [
+            "/dev/sdb",
+            "/dev/sdc",
+            "/dev/sdd",
+            "/dev/sde"
+          ],
+          "metadata_devices": [
+            "/dev/sdj"
+          ]
+        }
+      ]
     },
     "a6422fd1d8b04510b291c03c537c147a": {
       "cluster_id": "my-cluster",
@@ -95,22 +93,20 @@
       },
       "s3_instances": "2",
       "storage_set_id": "storage1",
-      "storage": {
-        "num_cvg": "1",
-        "cvg": [
-          {
-            "data_devices": [
-              "/dev/sdb",
-              "/dev/sdc",
-              "/dev/sdd",
-              "/dev/sde"
-            ],
-            "metadata_devices": [
-              "/dev/sdj"
-            ]
-          }
-        ]
-      }
+      "num_cvg": "1",
+      "cvg": [
+        {
+          "data_devices": [
+            "/dev/sdb",
+            "/dev/sdc",
+            "/dev/sdd",
+            "/dev/sde"
+          ],
+          "metadata_devices": [
+            "/dev/sdj"
+          ]
+        }
+      ]
     },
     "33604d428f544d9596fe0791d7d4d4b0": {
       "cluster_id": "my-cluster",
@@ -132,22 +128,20 @@
       },
       "s3_instances": "2",
       "storage_set_id": "storage1",
-      "storage": {
-        "num_cvg": "1",
-        "cvg": [
-          {
-            "data_devices": [
-              "/dev/sdb",
-              "/dev/sdc",
-              "/dev/sdd",
-              "/dev/sde"
-            ],
-            "metadata_devices": [
-              "/dev/sdj"
-            ]
-          }
-        ]
-      }
+      "num_cvg": "1",
+      "cvg": [
+        {
+          "data_devices": [
+            "/dev/sdb",
+            "/dev/sdc",
+            "/dev/sdd",
+            "/dev/sde"
+          ],
+          "metadata_devices": [
+            "/dev/sdj"
+          ]
+        }
+      ]
     }
   }
 }

--- a/containers/examples/3node/hare.config.conf.n.cvgs.3-node
+++ b/containers/examples/3node/hare.config.conf.n.cvgs.3-node
@@ -58,29 +58,27 @@
       },
       "s3_instances": "2",
       "storage_set_id": "storage1",
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "data_devices": [
-              "/dev/sdb",
-              "/dev/sdc"
-            ],
-            "metadata_devices": [
-              "/dev/sdj"
-            ]
-          },
-          {
-            "data_devices": [
-              "/dev/sdd",
-              "/dev/sde"
-            ],
-            "metadata_devices": [
-              "/dev/sdh"
-            ]
-          }
-        ]
-      }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "data_devices": [
+            "/dev/sdb",
+            "/dev/sdc"
+          ],
+          "metadata_devices": [
+            "/dev/sdj"
+          ]
+        },
+        {
+          "data_devices": [
+            "/dev/sdd",
+            "/dev/sde"
+          ],
+          "metadata_devices": [
+            "/dev/sdh"
+          ]
+        }
+      ]
     },
     "a6422fd1d8b04510b291c03c537c147a": {
       "cluster_id": "my-cluster",
@@ -102,29 +100,27 @@
       },
       "s3_instances": "2",
       "storage_set_id": "storage1",
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "data_devices": [
-              "/dev/sdb",
-              "/dev/sdc"
-            ],
-            "metadata_devices": [
-              "/dev/sdj"
-            ]
-          },
-          {
-            "data_devices": [
-              "/dev/sdd",
-              "/dev/sde"
-            ],
-            "metadata_devices": [
-              "/dev/sdh"
-            ]
-          }
-        ]
-      }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "data_devices": [
+            "/dev/sdb",
+            "/dev/sdc"
+          ],
+          "metadata_devices": [
+            "/dev/sdj"
+          ]
+        },
+        {
+          "data_devices": [
+            "/dev/sdd",
+            "/dev/sde"
+          ],
+          "metadata_devices": [
+            "/dev/sdh"
+          ]
+        }
+      ]
     },
     "33604d428f544d9596fe0791d7d4d4b0": {
       "cluster_id": "my-cluster",
@@ -146,29 +142,27 @@
       },
       "s3_instances": "2",
       "storage_set_id": "storage1",
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "data_devices": [
-              "/dev/sdb",
-              "/dev/sdc"
-            ],
-            "metadata_devices": [
-              "/dev/sdj"
-            ]
-          },
-          {
-            "data_devices": [
-              "/dev/sdd",
-              "/dev/sde"
-            ],
-            "metadata_devices": [
-              "/dev/sdh"
-            ]
-          }
-        ]
-      }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "data_devices": [
+            "/dev/sdb",
+            "/dev/sdc"
+          ],
+          "metadata_devices": [
+            "/dev/sdj"
+          ]
+        },
+        {
+          "data_devices": [
+            "/dev/sdd",
+            "/dev/sde"
+          ],
+          "metadata_devices": [
+            "/dev/sdh"
+          ]
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -163,15 +163,15 @@ class CdfGenerator:
         conf = self.provider
         pool_type = pool.pool_type
         prop_name = 'data'
-        # node>{machine-id}>storage>num_cvg
-        cvg_num = int(conf.get(f'node>{node}>storage>num_cvg'))
+        # node>{machine-id}>num_cvg
+        cvg_num = int(conf.get(f'node>{node}>num_cvg'))
         all_cvg_devices = []
         if pool_type == 'dix':
             prop_name = 'metadata'
         for i in range(cvg_num):
-            # node>{machine-id}>storage>cvg[N]>devices>name
+            # node>{machine-id}>cvg[N]>devices>name
             all_cvg_devices += conf.get(
-                f'node>{node}>storage>cvg[{i}]>devices>{prop_name}')
+                f'node>{node}>cvg[{i}]>devices>{prop_name}')
         return all_cvg_devices
 
     def _validate_pool(self, pool: PoolHandle) -> None:
@@ -217,9 +217,9 @@ class CdfGenerator:
 
         node_count = len(data_nodes)
         machine_id = data_nodes[0]
-        # node>{machine-id}>storage>num_cvg
+        # node>{machine-id}>num_cvg
         cvg_per_node = int(conf.get(
-            f'node>{machine_id}>storage>num_cvg'))
+            f'node>{machine_id}>num_cvg'))
 
         total_unit = layout.data + layout.parity + layout.spare
         if total_unit == 0:
@@ -441,13 +441,13 @@ class CdfGenerator:
             return None
         return Protocol[proto]
 
-    # node>{machine -id}>storage>cvg[N]>devices>data
+    # node>{machine -id}>cvg[N]>devices>data
     def _get_data_devices(self, machine_id: str, cvg: int) -> DList[Text]:
         store = self.provider
         data_devices = DList(
             [Text(device) for device in store.get(
                 f'node>{machine_id}>'
-                f'storage>cvg[{cvg}]>devices>data')], 'List Text')
+                f'cvg[{cvg}]>devices>data')], 'List Text')
         return data_devices
 
     # conf-store returns a list of devices, thus, the function
@@ -458,7 +458,7 @@ class CdfGenerator:
                              cvg: int) -> Text:
         store = self.provider
         metadata_device = Text(store.get(
-            f'node>{machine_id}>storage>cvg[{cvg}]>devices>metadata')[0])
+            f'node>{machine_id}>cvg[{cvg}]>devices>metadata')[0])
         return metadata_device
 
     # This function is kept as place holder with length returning 1,
@@ -509,9 +509,9 @@ class CdfGenerator:
                             self._get_metadata_device(
                                 machine_id, cvg), 'Text')),
                     runs_confd=Maybe(False, 'Bool'))
-                # node>{machine_id}>storage>cvg
+                # node>{machine_id}>cvg
                 for cvg in range(len(store.get(
-                    f'node>{machine_id}>storage>cvg')))
+                    f'node>{machine_id}>cvg')))
                 for m0d in range(self._get_m0d_per_cvg(machine_id, cvg))
             ], 'List M0ServerDesc')
 

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -47,22 +47,20 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_1",
-                "TMPL_DATA_DEVICE_2"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_1",
+              "TMPL_DATA_DEVICE_2"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE"
+            ]
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node
@@ -49,33 +49,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_2": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -93,33 +91,31 @@
       },
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_3": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -137,33 +133,31 @@
       },
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.1-node
@@ -47,22 +47,20 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_1",
-                "TMPL_DATA_DEVICE_2"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_1",
+              "TMPL_DATA_DEVICE_2"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE"
+            ]
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.init.conf.tmpl.3-node
@@ -49,33 +49,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_2": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -92,33 +90,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_3": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -135,33 +131,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.1-node
@@ -47,22 +47,20 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_1",
-                "TMPL_DATA_DEVICE_2"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_1",
+              "TMPL_DATA_DEVICE_2"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE"
+            ]
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.reset.conf.tmpl.3-node
@@ -49,33 +49,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_2": {
       "cluster_id": "TMPL_CLUSTER_ID",

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.1-node
@@ -47,22 +47,20 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_1",
-                "TMPL_DATA_DEVICE_2"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_1",
+              "TMPL_DATA_DEVICE_2"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE"
+            ]
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node
@@ -49,33 +49,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_2": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -92,33 +90,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     },
     "TMPL_MACHINE_ID_3": {
       "cluster_id": "TMPL_CLUSTER_ID",
@@ -135,33 +131,31 @@
         }
       },
       "storage_set": "TMPL_STORAGE_SET_ID",
-      "storage": {
-        "num_cvg": "TMPL_NUM_CVG",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_11",
-                "TMPL_DATA_DEVICE_12"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_1"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "TMPL_DATA_DEVICE_21",
-                "TMPL_DATA_DEVICE_22"
-              ],
-              "metadata": [
-                "TMPL_METADATA_DEVICE_2"
-              ]
-            }
+      "num_cvg": "TMPL_NUM_CVG",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_11",
+              "TMPL_DATA_DEVICE_12"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_1"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "TMPL_DATA_DEVICE_21",
+              "TMPL_DATA_DEVICE_22"
+            ],
+            "metadata": [
+              "TMPL_METADATA_DEVICE_2"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.test.conf.tmpl.3-node.sample
@@ -48,35 +48,35 @@
           ]
         }
       },
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "/dev/sdb",
-                "/dev/sdc",
-                "/dev/sdd"
-              ],
-              "metadata": [
-                "/dev/sde"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "/dev/sdg",
-                "/dev/sdh",
-                "/dev/sdi"
-              ],
-              "metadata": [
-                "/dev/sdj"
-              ]
-            }
+      
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd"
+            ],
+            "metadata": [
+              "/dev/sde"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
+            ],
+            "metadata": [
+              "/dev/sdj"
+            ]
+          }
+        }
+      ]
+    
     },
     "9ec5de3a8b57493e8fc7bfae67ecd3b3": {
       "cluster_id": "my-cluster",
@@ -90,35 +90,33 @@
           ]
         }
       },
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "/dev/sdb",
-                "/dev/sdc",
-                "/dev/sdd"
-              ],
-              "metadata": [
-                "/dev/sde"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "/dev/sdg",
-                "/dev/sdh",
-                "/dev/sdi"
-              ],
-              "metadata": [
-                "/dev/sdj"
-              ]
-            }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd"
+            ],
+            "metadata": [
+              "/dev/sde"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
+            ],
+            "metadata": [
+              "/dev/sdj"
+            ]
+          }
+        }
+      ]
     },
     "846fd26885f8423a8da0626538ed47bc": {
       "cluster_id": "my-cluster",
@@ -132,35 +130,33 @@
           ]
         }
       },
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "/dev/sdb",
-                "/dev/sdc",
-                "/dev/sdd"
-              ],
-              "metadata": [
-                "/dev/sde"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "/dev/sdg",
-                "/dev/sdh",
-                "/dev/sdi"
-              ],
-              "metadata": [
-                "/dev/sdj"
-              ]
-            }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "/dev/sdb",
+              "/dev/sdc",
+              "/dev/sdd"
+            ],
+            "metadata": [
+              "/dev/sde"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
+            ],
+            "metadata": [
+              "/dev/sdj"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -127,7 +127,7 @@ class Utils:
         data_devices = DList(
             [Text(device) for device in self.provider.get(
                 f'node>{machine_id}>'
-                f'storage>cvg[{cvg}]>devices>data')], 'List Text')
+                f'cvg[{cvg}]>devices>data')], 'List Text')
         return data_devices
 
     @func_log(func_enter, func_leave)
@@ -229,7 +229,7 @@ class Utils:
     def save_drives_info(self):
         machine_id = self.provider.get_machine_id()
         if(self.is_motr_io_present(machine_id)):
-            cvgs_key: str = f'node>{machine_id}>storage>cvg'
+            cvgs_key: str = f'node>{machine_id}>cvg'
             for cvg in range(len(self.provider.get(cvgs_key))):
                 data_devs = self.get_data_devices(machine_id, cvg)
                 for dev_path in data_devs.value:

--- a/provisioning/miniprov/samples/sample_provisioner_cluster.json
+++ b/provisioning/miniprov/samples/sample_provisioner_cluster.json
@@ -96,22 +96,21 @@
           "transport_type": "lnet"
         }
       },
-      "storage": {
-        "num_cvg": "1",
-        "cvg": [
-          {
-            "devices": {
-              "metadata": [
-                "/dev/sdb"
-              ],
-              "data": [
-                "/dev/sdc"
-              ]
-            }
+      
+      "num_cvg": "1",
+      "cvg": [
+        {
+          "devices": {
+            "metadata": [
+              "/dev/sdb"
+            ],
+            "data": [
+              "/dev/sdc"
+            ]
           }
-        ],
-        "enclosure_id": "encla971a87aace34e05b4747bb3376d6661"
-      },
+        }
+      ],
+      "enclosure_id": "encla971a87aace34e05b4747bb3376d6661",
       "site_id": "1",
       "rack_id": "1",
       "node_id": "0",

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -190,19 +190,19 @@ class TestCDF(unittest.TestCase):
                     'srvnode-1.data.private',
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[1]>devices>data':
+                'node>MACH_ID>cvg[1]>devices>data':
                 ['/dev/sdc'],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
-                'node>MACH_ID>storage>num_cvg':
+                'node>MACH_ID>num_cvg':
                 2,
-                'node>MACH_ID>storage>cvg':
+                'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
-                'node>MACH_ID>storage>cvg[1]>devices>metadata':
+                'node>MACH_ID>cvg[1]>devices>metadata':
                 ['/dev/meta1'],
                 'cortx>s3>service_instances':
                 1,
@@ -210,7 +210,7 @@ class TestCDF(unittest.TestCase):
                 'tcp',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>num_cvg': 1,
+                'node>MACH_ID>num_cvg': 1,
                 'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
@@ -311,13 +311,13 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'},
                  {'name': 'other'}],
-                'node>MACH_ID>storage>num_cvg': 2,
-                'node>MACH_ID>storage>cvg':
+                'node>MACH_ID>num_cvg': 2,
+                'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
-                'node>MACH_ID>storage>cvg[0]>devices>data': ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata': ['/dev/meta'],
-                'node>MACH_ID>storage>cvg[1]>devices>data': ['/dev/sdc'],
-                'node>MACH_ID>storage>cvg[1]>devices>metadata': ['/dev/meta1'],
+                'node>MACH_ID>cvg[0]>devices>data': ['/dev/sdb'],
+                'node>MACH_ID>cvg[0]>devices>metadata': ['/dev/meta'],
+                'node>MACH_ID>cvg[1]>devices>data': ['/dev/sdc'],
+                'node>MACH_ID>cvg[1]>devices>metadata': ['/dev/meta1'],
                 'node>MACH_ID>hostname':                'myhost',
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>type': 'storage_node',
@@ -467,20 +467,20 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID1>cluster_id': 'CLUSTER_ID',
                 'node>MACH_ID2>cluster_id': 'CLUSTER_ID',
                 'node>MACH_ID3>cluster_id': 'CLUSTER_ID',
-                'node>MACH_ID1>storage>cvg':
+                'node>MACH_ID1>cvg':
                 [{'devices': {'data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'], 'metadata': ['/dev/meta2']}}],
-                'node>MACH_ID2>storage>cvg':
+                'node>MACH_ID2>cvg':
                 [{'devices': {'data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'], 'metadata': ['/dev/meta2']}}],
-                'node>MACH_ID3>storage>cvg':
+                'node>MACH_ID3>cvg':
                 [{'devices': {'data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'], 'metadata': ['/dev/meta2']}}],
-                'node>MACH_ID1>storage>num_cvg': '2',
-                'node>MACH_ID1>storage>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
-                'node>MACH_ID1>storage>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
-                'node>MACH_ID1>storage>cvg[0]>devices>metadata': ['/dev/meta1'],
-                'node>MACH_ID1>storage>cvg[1]>devices>metadata': ['/dev/meta2'],
+                'node>MACH_ID1>num_cvg': '2',
+                'node>MACH_ID1>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
+                'node>MACH_ID1>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
+                'node>MACH_ID1>cvg[0]>devices>metadata': ['/dev/meta1'],
+                'node>MACH_ID1>cvg[1]>devices>metadata': ['/dev/meta2'],
                 'node>MACH_ID1>hostname':                'myhost',
                 'node>MACH_ID1>name': 'mynodename',
                 'node>MACH_ID1>type': 'storage_node',
@@ -489,11 +489,11 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID1>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'node>MACH_ID2>storage>num_cvg': '2',
-                'node>MACH_ID2>storage>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
-                'node>MACH_ID2>storage>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
-                'node>MACH_ID2>storage>cvg[0]>devices>metadata': ['/dev/meta1'],
-                'node>MACH_ID2>storage>cvg[1]>devices>metadata': ['/dev/meta2'],
+                'node>MACH_ID2>num_cvg': '2',
+                'node>MACH_ID2>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
+                'node>MACH_ID2>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
+                'node>MACH_ID2>cvg[0]>devices>metadata': ['/dev/meta1'],
+                'node>MACH_ID2>cvg[1]>devices>metadata': ['/dev/meta2'],
                 'node>MACH_ID2>hostname':                'myhost',
                 'node>MACH_ID2>name': 'mynodename',
                 'node>MACH_ID2>type': 'storage_node',
@@ -502,11 +502,11 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID2>network>data>private_interfaces':                ['eth1', 'eno2'],
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
-                'node>MACH_ID3>storage>num_cvg': '2',
-                'node>MACH_ID3>storage>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
-                'node>MACH_ID3>storage>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
-                'node>MACH_ID3>storage>cvg[0]>devices>metadata': ['/dev/meta1'],
-                'node>MACH_ID3>storage>cvg[1]>devices>metadata': ['/dev/meta2'],
+                'node>MACH_ID3>num_cvg': '2',
+                'node>MACH_ID3>cvg[0]>devices>data': ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd'],
+                'node>MACH_ID3>cvg[1]>devices>data': ['/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh'],
+                'node>MACH_ID3>cvg[0]>devices>metadata': ['/dev/meta1'],
+                'node>MACH_ID3>cvg[1]>devices>metadata': ['/dev/meta2'],
                 'node>MACH_ID3>hostname':                'myhost',
                 'node>MACH_ID3>name': 'mynodename',
                 'node>MACH_ID3>type': 'storage_node',
@@ -544,7 +544,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'node>MACH_ID>storage>num_cvg': 1,
+                'node>MACH_ID>num_cvg': 1,
                 'cluster>num_storage_set': 1,
                 'cluster>storage_set>server_node_count': 1,
                 'cluster>storage_set[0]>name': 'StorageSet-1',
@@ -575,19 +575,19 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>num_cvg':
+                'node>MACH_ID>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>cvg':
+                'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb', '/dev/sdc'], 'metadata': ['/dev/meta', '/dev/meta1']}}],
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[1]>devices>data':
+                'node>MACH_ID>cvg[1]>devices>data':
                 ['/dev/sdc'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta1'],
             }
             return data.get(value)
@@ -659,19 +659,19 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>num_cvg':
+                'node>MACH_ID>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
-                'node>MACH_ID>storage>cvg[1]>devices>data':
+                'node>MACH_ID>cvg[1]>devices>data':
                 ['/dev/sdc'],
-                'node>MACH_ID>storage>cvg[1]>devices>metadata':
+                'node>MACH_ID>cvg[1]>devices>metadata':
                 ['/dev/meta1'],
             }
             return data.get(value)
@@ -719,9 +719,9 @@ class TestCDF(unittest.TestCase):
                 'o2ib',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
             }
             return data.get(value)
@@ -735,7 +735,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'node>MACH_ID>storage>num_cvg': 1,
+                'node>MACH_ID>num_cvg': 1,
                 'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
@@ -765,19 +765,19 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>num_cvg':
+                'node>MACH_ID>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
-                'node>MACH_ID>storage>cvg[1]>devices>data':
+                'node>MACH_ID>cvg[1]>devices>data':
                 ['/dev/sdc'],
-                'node>MACH_ID>storage>cvg[1]>devices>metadata':
+                'node>MACH_ID>cvg[1]>devices>metadata':
                 ['/dev/meta1'],
             }
             return data.get(value)
@@ -796,7 +796,7 @@ class TestCDF(unittest.TestCase):
 
         def ret_values(value: str) -> Any:
             data = {
-                'node>MACH_ID>storage>num_cvg': 1,
+                'node>MACH_ID>num_cvg': 1,
                 'cluster>num_storage_set':
                 1,
                 'cluster>storage_set>server_node_count':
@@ -830,19 +830,19 @@ class TestCDF(unittest.TestCase):
                 ['eth1', 'eno2'],
                 'cortx>s3>service_instances':
                 1,
-                'node>MACH_ID>storage>num_cvg':
+                'node>MACH_ID>num_cvg':
                 2,
                 'cortx>motr>interface_type':
                 'o2ib',
                 'cortx>motr>client_instances':
                 2,
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sda', '/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
-                'node>MACH_ID>storage>cvg[1]>devices>data':
+                'node>MACH_ID>cvg[1]>devices>data':
                 ['/dev/sdc', '/dev/sdd'],
-                'node>MACH_ID>storage>cvg[1]>devices>metadata':
+                'node>MACH_ID>cvg[1]>devices>metadata':
                 ['/dev/meta1'],
             }
             return data.get(value)
@@ -891,16 +891,16 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
-                'node>MACH_ID>storage>cvg':
+                'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sdc'], 'metadata': ['/dev/meta2']}}],
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[1]>devices>data':
+                'node>MACH_ID>cvg[1]>devices>data':
                 ['/dev/sdc'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta1'],
-                'node>MACH_ID>storage>cvg[1]>devices>metadata':
+                'node>MACH_ID>cvg[1]>devices>metadata':
                 ['/dev/meta2'],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2'],
@@ -1012,11 +1012,11 @@ class TestCDF(unittest.TestCase):
                  {'name': 'other'}],
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1'],
-                'node>MACH_ID>storage>cvg':
+                'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta']}}],
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
                 'node>MACH_2_ID>name':                'host-2',
                 'node>MACH_2_ID>hostname':            'host-2',
@@ -1033,11 +1033,11 @@ class TestCDF(unittest.TestCase):
                 'libfab',
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>client_instances':                2,
-                'node>MACH_2_ID>storage>cvg':
+                'node>MACH_2_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta']}}],
-                'node>MACH_2_ID>storage>cvg[0]>devices>data':
+                'node>MACH_2_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_2_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_2_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
             }
             return data[value]
@@ -1141,11 +1141,11 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>components':
                 [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
-                'node>MACH_ID>storage>cvg':
+                'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta']}}],
-                'node>MACH_ID>storage>cvg[0]>devices>data':
+                'node>MACH_ID>cvg[0]>devices>data':
                 ['/dev/sdb'],
-                'node>MACH_ID>storage>cvg[0]>devices>metadata':
+                'node>MACH_ID>cvg[0]>devices>metadata':
                 ['/dev/meta1'],
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',


### PR DESCRIPTION
CORTX-30793: `node>{node_id}>storage>cvg`
 is obsolete

`node>{node_id}>storage>cvg` is replaced with node>{node_id}>cvg, thus
corresponding users must be updated.

Solution:
Replace occurrences or `node>{node_id}>storage>cvg` with node>{node_id}>cvg.

Signed-off-by: Zahid Shaikh <zahid.shaikh@seagate.com>