### PR TITLE
CORTX-30898: Endpoint port settings needs to be done at node level instead of cluster level

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -375,6 +375,14 @@ def ipaddr_key(iface: str) -> str:
     return 'ipaddress_' + iface
 
 
+def get_network_ports(node) -> Optional[Dict[str, Any]]:
+    network_ports = None
+    if 'network_ports' in node:
+        network_ports = node['network_ports']
+
+    return network_ports
+
+
 def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
     logging.debug('Enriching cluster description')
     for node in desc['nodes']:
@@ -401,6 +409,20 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
                 float(node['facts']['memorysize_mb']))
 
         logging.debug('Node [hostname=%s] facts=%s', host, node['facts'])
+
+        portalgroup = PortalGroup
+        network_ports = get_network_ports(node)
+        if network_ports is None:
+            node['network_ports'] = {port_type.name: port_type.value
+                                     for port_type in portalgroup}
+        else:
+            for key, value in network_ports.items():
+                if not value:
+                    network_ports[key] = portalgroup[key].value
+            for srv in [port_type.name for port_type in portalgroup]:
+                if srv not in network_ports:
+                    network_ports[srv] = portalgroup[srv].value
+
         if 'm0_servers' not in node:
             continue
 
@@ -423,18 +445,6 @@ def enrich_cluster_desc(desc: Dict[str, Any], mock_p: bool) -> None:
         sns_pools = [pool['name'] for pool in desc['pools']
                      if pool_type(pool) is PoolT.sns]
         desc['profiles'] = [{'name': 'default', 'pools': sns_pools}]
-
-    portalgroup = PortalGroup
-    if 'network_ports' not in desc or not bool(desc['network_ports']):
-        desc['network_ports'] = {port_type.name: port_type.value
-                                 for port_type in portalgroup}
-    else:
-        for key, value in desc['network_ports'].items():
-            if not value:
-                desc['network_ports'][key] = portalgroup[key].value
-        for srv in [port_type.name for port_type in portalgroup]:
-            if srv not in desc['network_ports']:
-                desc['network_ports'][srv] = portalgroup[srv].value
 
 
 def validate_cluster_desc(desc: Dict[str, Any]) -> None:
@@ -1074,11 +1084,13 @@ class ConfNode(ToDhall):
     _downlinks = {Downlink('processes', ObjT.process)}
 
     def __init__(self, name: str, nr_cpu: int, memsize_MB: int,
-                 processes: List[Oid], machine_id: Optional[str] = None):
+                 processes: List[Oid], machine_id: Optional[str] = None,
+                 network_ports: Dict[str, Any] = None):
         self.name = name
         self.nr_cpu = nr_cpu
         self.memsize_MB = memsize_MB
         self.machine_id = machine_id
+        self.network_ports = network_ports
 
         _assert(all(x.type is ObjT.process for x in processes),
                 'All processes must be of ObjT.process type')
@@ -1109,7 +1121,8 @@ class ConfNode(ToDhall):
                               nr_cpu=facts['processorcount'],
                               memsize_MB=facts['_memsize_MB'],
                               processes=[],
-                              machine_id=node_desc.get('machine_id'))
+                              machine_id=node_desc.get('machine_id'),
+                              network_ports=node_desc.get('network_ports'))
         m0conf[parent].nodes.append(node_id)
         return node_id
 
@@ -2231,8 +2244,7 @@ Cluster = NamedTuple('Cluster', [('m0conf', Dict[Oid, Any]),
                                  ('consul_servers', List[ConsulAgent]),
                                  ('consul_clients', List[ConsulAgent]),
                                  ('m0_clients', Dict[Oid, Oid]),
-                                 ('m0_client_types', List[str]),
-                                 ('network_ports', Dict[str, int])])
+                                 ('m0_client_types', List[str])])
 
 
 def generate_consul_agents(cluster: Cluster) -> str:
@@ -2355,7 +2367,6 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
                         root.imeta_pver not in m0conf[x].pvers]
         raise RuntimeError('Impossible happened')
 
-    hax_http_port = cluster.network_ports.get('hax_http', 8008)
     return json.dumps([dict(key=k, value=v) for k, v in (
         ('epoch', 1),
         ('eq-epoch', 1),
@@ -2366,7 +2377,9 @@ def generate_consul_kv(cluster: Cluster, dhall_dir: str) -> str:
         ('bytecount/degraded', 0),
         ('bytecount/critical', 0),
         ('bytecount/damaged', 0),
-        ('ports/hax', json.dumps({'http': hax_http_port})),
+        *[(f'ports/{node.name}/hax',
+           json.dumps({'http': node.network_ports.get('hax_http', 8008)}))
+          for node_id, node in m0conf.items() if (node_id.type is ObjT.node)],
         ('m0_client_types', json.dumps(cluster.m0_client_types)),
         *[(node.machine_id, node.name)
           for node_id, node in m0conf.items() if (node_id.type is ObjT.node
@@ -2572,7 +2585,7 @@ def aux_pool_list(pool_desc: Dict[str, Any],
 
 def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
     cluster = Cluster(m0conf={}, consul_servers=[], consul_clients=[],
-                      m0_clients={}, m0_client_types=[], network_ports={})
+                      m0_clients={}, m0_client_types=[])
     conf = cluster.m0conf
     root_id = ConfRoot.build(conf)
     # XXX Move all the logic into ConfRoot.build?
@@ -2581,23 +2594,6 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
 
     other_clients: Dict[str, List[Tuple[Oid, Oid]]] = {}
     io_ctrls: Dict[Oid, Any] = {}
-
-    ports = cluster_desc.get('network_ports')
-    if ports:
-        cluster.network_ports.update({k: v for k, v in ports.items()})
-        lnet_portals = get_lnet_portal_group(
-                           hax=ports['hax'],
-                           m0_server=tuple(ports['m0_server']),
-                           m0_client_s3=ports['m0_client_s3'],
-                           m0_client_other=ports['m0_client_other'])
-        libfab_portals = get_libfab_portal_group(
-                             hax=ports['hax'],
-                             m0_server=tuple(ports['m0_server']),
-                             m0_client_s3=ports['m0_client_s3'],
-                             m0_client_other=ports['m0_client_other'])
-    else:
-        lnet_portals = get_lnet_portal_group()
-        libfab_portals = get_libfab_portal_group()
 
     for node in cluster_desc['nodes']:
         node_id = ConfNode.build(conf, root_id, node)
@@ -2612,6 +2608,23 @@ def build_cluster(cluster_desc: Dict[str, Any]) -> Cluster:
                     io_ctrls[ctrl_oid] = m0d
                 else:
                     ctrl_ids.append((None, m0d))
+
+        ports = node.get('network_ports')
+        if ports:
+            lnet_portals = get_lnet_portal_group(
+                               hax=ports['hax'],
+                               m0_server=tuple(ports['m0_server']),
+                               m0_client_s3=ports['m0_client_s3'],
+                               m0_client_other=ports['m0_client_other'])
+            libfab_portals = get_libfab_portal_group(
+                                 hax=ports['hax'],
+                                 m0_server=tuple(ports['m0_server']),
+                                 m0_client_s3=ports['m0_client_s3'],
+                                 m0_client_other=ports['m0_client_other'])
+        else:
+            lnet_portals = get_lnet_portal_group()
+            libfab_portals = get_libfab_portal_group()
+
         transport_type = node.get('transport_type', 'libfab')
         if transport_type == 'lnet':
             portalgroup = lnet_portals

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -28,7 +28,6 @@ in
 { create_aux : Optional Bool
 , nodes : List Node
 , pools : List Pool
-, network_ports : Optional ./Ports.dhall
 , profiles : Optional (List ./PoolsRef.dhall)
 , fdmi_filters: Optional (List ./FdmiFilterDesc.dhall)
 }

--- a/cfgen/dhall/types/NodeDesc.dhall
+++ b/cfgen/dhall/types/NodeDesc.dhall
@@ -28,4 +28,5 @@
 , transport_type : Text
 , m0_servers : Optional (List ./M0ServerDesc.dhall)
 , m0_clients : Optional (List ./M0ClientDesc.dhall)
+, network_ports : Optional ./Ports.dhall
 }

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -20,6 +20,18 @@ nodes:
     m0_clients:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run
+    # network_ports:
+    #   hax: 22000
+    #   hax_http: 8008
+    #   m0_server:
+    #   - name: ios
+    #     port: 21000
+    #   - name: confd
+    #     port: 21000
+    #   m0_client_other:
+    #   - name: m0_client_other
+    #     port: 21500
+    #   m0_client_s3: 22500
   - hostname: srvnode-2
     data_iface: enp175s0f1_c2
     data_iface_type: o2ib
@@ -41,6 +53,18 @@ nodes:
     m0_clients:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run
+    # network_ports:
+    #   hax: 22000
+    #   hax_http: 8008
+    #   m0_server:
+    #   - name: ios
+    #     port: 21000
+    #   - name: confd
+    #     port: 21000
+    #   m0_client_other:
+    #   - name: m0_client_other
+    #     port: 21500
+    #   m0_client_s3: 22500
 pools:
   - name: tier1-nvme
     disk_refs:
@@ -79,10 +103,3 @@ profiles:
     pools: [ tier3-hdd ]
   - name: all
     pools: [ tier1-nvme, tier2-ssd, tier3-hdd ]
-#network_ports:
-#    hax: 22000
-#    hax_http: 8008
-#    m0_server: 21000
-#    m0_client_s3: 22500
-#    m0_client_other: 21500
-

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -28,6 +28,18 @@ nodes:
     m0_clients:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run
+    # network_ports:
+    #   hax: 42000
+    #   hax_http: 8004
+    #   m0_server:
+    #   - name: ios
+    #     port: 41000
+    #   - name: confd
+    #     port: 41000
+    #   m0_client_other:
+    #   - name: m0_client_other
+    #     port: 41500
+    #   m0_client_s3: 42500
 create_aux: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool
@@ -55,15 +67,3 @@ pools:
 #    node: localhost
 #    client_index: 1
 #    substrings: ["Bucket-Name", "Object-Name", "Object-URI"]
-# network_ports:
-#   hax: 22000
-#   hax_http: 8008
-#   m0_server:
-#   - name: ios
-#     port: 21000
-#   - name: confd
-#     port: 21000
-#   m0_client_other:
-#   - name: m0_client_other
-#     port: 21500
-#   m0_client_s3: 22500

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -93,6 +93,14 @@ in
             }
           ]
       , m0_clients = Some [ { name = "m0_client_other", instances = 2 } ]
+      , network_ports =
+          None
+          { hax : Optional Natural
+          , hax_http: Optional Natural
+          , m0_server : Optional (List { name: Text, port: Natural })
+          , m0_client_s3 : Optional Natural
+          , m0_client_other : Optional (List { name: Text, port: Natural })
+          }
       }
     ]
 , pools =
@@ -133,12 +141,4 @@ in
           , substrings : List Text
           }
       )
-,  network_ports =
-     None
-     { hax : Optional Natural
-     , hax_http: Optional Natural
-     , m0_server : Optional (List { name: Text, port: Natural })
-     , m0_client_s3 : Optional Natural
-     , m0_client_other : Optional (List { name: Text, port: Natural })
-     }
 } : types.ClusterDesc

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -299,7 +299,7 @@ class CdfGenerator:
             self, nodes: List[NodeDesc]) -> Maybe[List[FdmiFilterDesc]]:
         return Maybe(None, 'List T.FdmiFilterDesc')
 
-    def _create_ports_descriptions(self) -> NetworkPorts:
+    def _create_ports_descriptions(self, hostname: str) -> NetworkPorts:
         conf = self.provider
         m0serverT = ['ios', 'confd']
         m0server_ports = []
@@ -307,28 +307,36 @@ class CdfGenerator:
         for srv in NetworkPorts.__annotations__.keys():
             if srv == 'hax':
                 url = conf.get('cortx>hare>hax>endpoints', allow_null=True)
-                _hax = url if url is None else \
-                    round(urlparse(url[0]).port / 100) * 100
+                _hax = None
                 _hax_http = None
                 for u in url or ():
                     _parsed_url = urlparse(u)
                     if _parsed_url.scheme in ('http', 'https'):
                         _hax_http = _parsed_url.port
+                    else:
+                        if _parsed_url.hostname == hostname:
+                            _hax = round(_parsed_url.port / 100) * 100
             elif srv == 'm0_client_other':
                 for client in self.provider.get_motr_clients():
                     url = client.get('endpoints')
                     if url:
-                        port = round(urlparse(url[0]).port / 100) * 100
-                        client_name = str(client.get('name'))
-                        m0client_ports.append(
-                            ClientPort(name=Text(client_name),
-                                       port=int(port)))
+                        for u in url or ():
+                            _parsed_url = urlparse(u)
+                            if _parsed_url.hostname == hostname:
+                                port = round(_parsed_url.port / 100) * 100
+                                client_name = str(client.get('name'))
+                                m0client_ports.append(
+                                    ClientPort(name=Text(client_name),
+                                               port=int(port)))
             elif srv == 'm0_server':
                 for server in m0serverT:
                     url = conf.get(f'cortx>motr>{server}>endpoints',
                                    allow_null=True)
-                    port = 0 if url is None else \
-                        round(urlparse(url[0]).port / 100) * 100
+                    port = 0
+                    for u in url or ():
+                        _parsed_url = urlparse(u)
+                        if _parsed_url.hostname == hostname:
+                            port = round(_parsed_url.port / 100) * 100
                     m0server_ports.append(
                         ServerPort(name=Text(server),
                                    port=int(port)))
@@ -353,7 +361,6 @@ class CdfGenerator:
         pools = self._create_pool_descriptions()
         profiles = self._create_profile_descriptions(pools)
         fdmi_filters = self._create_fdmi_filter_descriptions(nodes)
-        network_ports = self._create_ports_descriptions()
         create_aux = conf.get('cluster>create_aux',
                               allow_null=True)
 
@@ -365,7 +372,6 @@ class CdfGenerator:
                         node_info=DList(nodes, 'List NodeInfo'),
                         pool_info=DList(pools, 'List PoolInfo'),
                         profile_info=DList(profiles, 'List ProfileInfo'),
-                        ports_info=Maybe(network_ports, 'T.NetworkPorts'),
                         fdmi_filter_info=fdmi_filters))
 
         gencdf = Template(self._gencdf()).substitute(path=dhall_path,
@@ -532,6 +538,9 @@ class CdfGenerator:
         m0_clients = clients if clients else None
 
         node_facts = self.utils.get_node_facts()
+
+        network_ports = self._create_ports_descriptions(hostname)
+
         return NodeDesc(
             hostname=Text(hostname),
             machine_id=Maybe(Text(machine_id), 'Text'),
@@ -542,5 +551,6 @@ class CdfGenerator:
             data_iface_type=Maybe(self._get_iface_type(machine_id), 'P'),
             transport_type=Text(self.utils.get_transport_type()),
             m0_servers=Maybe(servers, 'List M0ServerDesc'),
-            m0_clients=Maybe(m0_clients, 'List M0ClientDesc')
+            m0_clients=Maybe(m0_clients, 'List M0ClientDesc'),
+            ports_info=Maybe(network_ports, 'T.NetworkPorts')
         )

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -47,6 +47,7 @@ let NodeInfo =
       , transport_type : Text
       , m0_servers : Optional (List M0ServerDesc)
       , m0_clients : Optional (List M0ClientDesc)
+      , ports_info : Optional T.NetworkPorts 
       }
 
 let AllowedFailures =
@@ -76,7 +77,6 @@ let ClusterInfo =
       { create_aux : Optional Bool
       , node_info: List NodeInfo
       , pool_info: List PoolInfo
-      , ports_info: Optional T.NetworkPorts
       , profile_info: List ProfileInfo
       , fdmi_filter_info: Optional (List T.FdmiFilterDesc)
       }
@@ -94,6 +94,7 @@ let toNodeDesc
           , transport_type = n.transport_type
           , m0_clients = n.m0_clients
           , m0_servers = n.m0_servers
+          , network_ports = n.ports_info
           }
 
 let toPoolDesc
@@ -114,7 +115,6 @@ let genCdf
       ->  { create_aux = cluster_info.create_aux
           , nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
           , pools = Prelude.List.map PoolInfo T.PoolDesc toPoolDesc cluster_info.pool_info
-          , network_ports = cluster_info.ports_info
           , profiles = Some cluster_info.profile_info
           , fdmi_filters = cluster_info.fdmi_filter_info
           }

--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.3-node.sample
@@ -54,35 +54,33 @@
         }
       },
       "storage_set": "storage1",
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "/dev/sda",
-                "/dev/sdb",
-                "/dev/sdc"
-              ],
-              "metadata": [
-                "/dev/sdd"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "/dev/sdg",
-                "/dev/sdh",
-                "/dev/sdi"
-              ],
-              "metadata": [
-                "/dev/sdj"
-              ]
-            }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "/dev/sda",
+              "/dev/sdb",
+              "/dev/sdc"
+            ],
+            "metadata": [
+              "/dev/sdd"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
+            ],
+            "metadata": [
+              "/dev/sdj"
+            ]
+          }
+        }
+      ]
     },
     "9ec5de3a8b57493e8fc7bfae67ecd3b3": {
       "cluster_id": "my-cluster",
@@ -99,35 +97,33 @@
         }
       },
       "storage_set": "storage1",
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "/dev/sda",
-                "/dev/sdb",
-                "/dev/sdc"
-              ],
-              "metadata": [
-                "/dev/sdd"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "/dev/sdg",
-                "/dev/sdh",
-                "/dev/sdi"
-              ],
-              "metadata": [
-                "/dev/sdj"
-              ]
-            }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "/dev/sda",
+              "/dev/sdb",
+              "/dev/sdc"
+            ],
+            "metadata": [
+              "/dev/sdd"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
+            ],
+            "metadata": [
+              "/dev/sdj"
+            ]
+          }
+        }
+      ]
     },
     "846fd26885f8423a8da0626538ed47bc": {
       "cluster_id": "my-cluster",
@@ -144,35 +140,33 @@
         }
       },
       "storage_set": "storage1",
-      "storage": {
-        "num_cvg": "2",
-        "cvg": [
-          {
-            "devices": {
-              "data": [
-                "/dev/sda",
-                "/dev/sdb",
-                "/dev/sdc"
-              ],
-              "metadata": [
-                "/dev/sdd"
-              ]
-            }
-          },
-          {
-            "devices": {
-              "data": [
-                "/dev/sdg",
-                "/dev/sdh",
-                "/dev/sdi"
-              ],
-              "metadata": [
-                "/dev/sdj"
-              ]
-            }
+      "num_cvg": "2",
+      "cvg": [
+        {
+          "devices": {
+            "data": [
+              "/dev/sda",
+              "/dev/sdb",
+              "/dev/sdc"
+            ],
+            "metadata": [
+              "/dev/sdd"
+            ]
           }
-        ]
-      }
+        },
+        {
+          "devices": {
+            "data": [
+              "/dev/sdg",
+              "/dev/sdh",
+              "/dev/sdi"
+            ],
+            "metadata": [
+              "/dev/sdj"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -110,6 +110,27 @@ class M0ServerDesc(DhallTuple):
 
 
 @dataclass(repr=False)
+class ClientPort(DhallTuple):
+    name: Text
+    port: int
+
+
+@dataclass(repr=False)
+class ServerPort(DhallTuple):
+    name: Text
+    port: int
+
+
+@dataclass(repr=False)
+class NetworkPorts(DhallTuple):
+    hax: Maybe[int]
+    hax_http: Maybe[int]
+    m0_server: Maybe[DList[ServerPort]]
+    m0_client_s3: Maybe[int]
+    m0_client_other: Maybe[DList[ClientPort]]
+
+
+@dataclass(repr=False)
 class NodeDesc(DhallTuple):
     hostname: Text
     machine_id: Maybe[Text]
@@ -121,6 +142,7 @@ class NodeDesc(DhallTuple):
     transport_type: Text
     m0_servers: Maybe[DList[M0ServerDesc]]
     m0_clients: Maybe[DList[M0ClientDesc]]
+    ports_info: Maybe[NetworkPorts]
 
 
 @dataclass(repr=False)
@@ -164,33 +186,11 @@ class FdmiFilterDesc(DhallTuple):
 
 
 @dataclass(repr=False)
-class ClientPort(DhallTuple):
-    name: Text
-    port: int
-
-
-@dataclass(repr=False)
-class ServerPort(DhallTuple):
-    name: Text
-    port: int
-
-
-@dataclass(repr=False)
-class NetworkPorts(DhallTuple):
-    hax: Maybe[int]
-    hax_http: Maybe[int]
-    m0_server: Maybe[DList[ServerPort]]
-    m0_client_s3: Maybe[int]
-    m0_client_other: Maybe[DList[ClientPort]]
-
-
-@dataclass(repr=False)
 class ClusterDesc(DhallTuple):
     create_aux: Maybe[bool]
     node_info: DList[NodeDesc]
     pool_info: DList[PoolDesc]
     profile_info: DList[ProfileDesc]
-    ports_info: Maybe[NetworkPorts]
     fdmi_filter_info: Maybe[List[FdmiFilterDesc]]
 
 

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -327,7 +327,10 @@ class TestCDF(unittest.TestCase):
                 'cortx>s3>service_instances':                1,
                 'cortx>motr>interface_type':                'o2ib',
             }
-            return data.get(value)
+            if value in data:
+                return data.get(value)
+            else:
+                return None
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
@@ -890,7 +893,7 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>name': 'mynodename',
                 'node>MACH_ID>type': 'storage_node',
                 'node>MACH_ID>components':
-                [{'name':'hare'}, {'name': 'motr'}, {'name': 's3'}],
+                [{'name':'hare'}, {'name': 'motr', 'services': ['io']}, {'name': 's3'}],
                 'node>MACH_ID>cvg':
                 [{'devices': {'data': ['/dev/sdb'], 'metadata': ['/dev/meta1']}},
                  {'devices': {'data': ['/dev/sdc'], 'metadata': ['/dev/meta2']}}],
@@ -915,7 +918,10 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_fqdn':
                     'srvnode-1.data.private',
             }
-            return data[value]
+            if value in data:
+                return data[value]
+            else:
+                return None
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
@@ -1040,7 +1046,10 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_2_ID>cvg[0]>devices>metadata':
                 ['/dev/meta'],
             }
-            return data[value]
+            if value in data:
+                return data[value]
+            else:
+                return None
 
         store._raw_get = Mock(side_effect=ret_values)
 
@@ -1162,7 +1171,10 @@ class TestCDF(unittest.TestCase):
                 'node>MACH_ID>network>data>private_interfaces':
                 ['eth1', 'eno2']
             }
-            return data[value]
+            if value in data:
+                return data[value]
+            else:
+                return None
 
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')

--- a/utils/hare-rebalance
+++ b/utils/hare-rebalance
@@ -71,8 +71,12 @@ get_ip_addr() {
     curl -sX GET http://localhost:8500/v1/agent/self | jq -r .DebugConfig.BindAddr
 }
 
+get_nodename() {
+    curl -s http://localhost:8500/v1/agent/self | jq -r .Config.NodeName | cut -d':' -f 1
+}
+
 get_hax_port() {
-    consul kv get ports/hax | jq -r .http
+    consul kv get ports/$(get_nodename)/hax | jq -r .http
 }
 
 # process commands

--- a/utils/hare-repair
+++ b/utils/hare-repair
@@ -71,8 +71,12 @@ get_ip_addr() {
     curl -sX GET http://localhost:8500/v1/agent/self | jq -r .DebugConfig.BindAddr
 }
 
+get_nodename() {
+    curl -s http://localhost:8500/v1/agent/self | jq -r .Config.NodeName | cut -d':' -f 1
+}
+
 get_hax_port() {
-    consul kv get ports/hax | jq -r .http
+    consul kv get ports/$(get_nodename)/hax | jq -r .http
 }
 
 # process commands

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -159,7 +159,7 @@ get_profile_from_kv_file() {
 }
 
 get_hax_http_port_from_kv_file() {
-    local cmd="jq -r '.[] | select (.key==\"ports/hax\") | .value' $kv_file | jq -r '.http'"
+    local cmd="jq -r '.[] | select (.key==\"ports/$(get_node_name)/hax\") | .value' $kv_file | jq -r '.http'"
     eval $cmd || true
 }
 


### PR DESCRIPTION
**Solution**:
Modified CDF format to move the 'network_ports' info under individual node.

**Test:**
```
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-2784 /]# hctl status
Bytecount:
    critical : 0
    damaged : 0
    degraded : 0
    healthy : 0
Data pool:
    # fid name
    0x6f00000000000001:0x9f 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0xde 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2785  (RC)
    [started]  hax                 0x7200000000000001:0x2f         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2785@31101
    [started]  ioservice           0x7200000000000001:0x32         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2785@34101
    [started]  ioservice           0x7200000000000001:0x41         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2785@34102
    [started]  confd               0x7200000000000001:0x50         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2785@33101
    cortx-data-headless-svc-ssc-vm-g3-rhev4-2623
    [started]  hax                 0x7200000000000001:0x7          inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2623@31201
    [started]  ioservice           0x7200000000000001:0xa          inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2623@34201
    [started]  ioservice           0x7200000000000001:0x19         inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2623@34202
    [started]  confd               0x7200000000000001:0x28         inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-2623@33201
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2784
    [started]  hax                 0x7200000000000001:0x57         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2784@31001
    [started]  ioservice           0x7200000000000001:0x5a         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2784@34001
    [started]  ioservice           0x7200000000000001:0x69         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2784@34002
    [started]  confd               0x7200000000000001:0x78         inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2784@33001
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2785
    [started]  hax                 0x7200000000000001:0x7d         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2785@32101
    [started]  rgw_s3              0x7200000000000001:0x80         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2785@35101
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2784
    [started]  hax                 0x7200000000000001:0x85         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2784@32001
    [started]  rgw_s3              0x7200000000000001:0x88         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2784@35001
    cortx-server-headless-svc-ssc-vm-g3-rhev4-2623
    [started]  hax                 0x7200000000000001:0x8d         inet:tcp:cortx-server-headless-svc-ssc-vm-g3-rhev4-2623@32201
    [started]  rgw_s3              0x7200000000000001:0x90         inet:tcp:cortx-server-headless-svc-ssc-vm-g3-rhev4-2623@35201
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-2784 /]# ss -ltupn | grep hax
tcp   LISTEN 0      128    172.16.156.255:31001      0.0.0.0:*    users:(("hax",pid=102,fd=6))
tcp   LISTEN 0      128    172.16.156.255:22003      0.0.0.0:*    users:(("hax",pid=102,fd=31))
```

```
motr:
    clients:
    - endpoints:
      - tcp://cortx-server-headless-svc-ssc-vm-g2-rhev4-2784:35001
      - tcp://cortx-server-headless-svc-ssc-vm-g2-rhev4-2785:35101
      - tcp://cortx-server-headless-svc-ssc-vm-g3-rhev4-2623:35201
      name: rgw_s3
      num_endpoints: 3
      num_instances: 1
    - name: motr_client
      num_instances: 0
      num_subscriptions: 1
      subscriptions:
      - fdmi
    confd:
      endpoints:
      - tcp://cortx-data-headless-svc-ssc-vm-g2-rhev4-2784:33002
      - tcp://cortx-data-headless-svc-ssc-vm-g2-rhev4-2785:33102
      - tcp://cortx-data-headless-svc-ssc-vm-g3-rhev4-2623:33202
      num_endpoints: 3
    interface_family: inet
    ios:
      endpoints:
      - tcp://cortx-data-headless-svc-ssc-vm-g2-rhev4-2784:34001
      - tcp://cortx-data-headless-svc-ssc-vm-g2-rhev4-2785:34101
      - tcp://cortx-data-headless-svc-ssc-vm-g3-rhev4-2623:34201
      
   hax:
      endpoints:
      - https://cortx-hax-svc:22003
      - tcp://cortx-data-headless-svc-ssc-vm-g2-rhev4-2784:31001
      - tcp://cortx-data-headless-svc-ssc-vm-g2-rhev4-2785:31101
      - tcp://cortx-data-headless-svc-ssc-vm-g3-rhev4-2623:31201
      - tcp://cortx-server-headless-svc-ssc-vm-g2-rhev4-2784:32001
      - tcp://cortx-server-headless-svc-ssc-vm-g2-rhev4-2785:32101
      - tcp://cortx-server-headless-svc-ssc-vm-g3-rhev4-2623:32201
```

```
(.py3venv) [root@ssc-vm-g2-rhev4-2221 miniprov]# python ./setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing hare_mp.egg-info/PKG-INFO
writing dependency_links to hare_mp.egg-info/dependency_links.txt
writing entry points to hare_mp.egg-info/entry_points.txt
writing requirements to hare_mp.egg-info/requires.txt
writing top-level names to hare_mp.egg-info/top_level.txt
reading manifest file 'hare_mp.egg-info/SOURCES.txt'
writing manifest file 'hare_mp.egg-info/SOURCES.txt'
running build_ext
test_empty_source_results_empty (test.test_systemd.TestHaxUnitTrasform) ... ok
test_not_everything_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_restart_commented (test.test_systemd.TestHaxUnitTrasform) ... ok
test_invalid_machine_id (test.test_validator.TestValidator) ... ok
test_is_cluster_first_node (test.test_validator.TestValidator) ... ok
test_allowed_failure_generation (test.test_cdf.TestCDF) ... ok
test_both_dix_and_sns_pools_can_exist (test.test_cdf.TestCDF) ... ok
test_disk_refs_can_be_empty (test.test_cdf.TestCDF) ... ok
test_dix_pool_uses_metadata_devices (test.test_cdf.TestCDF) ... ok
test_iface_type_can_be_null (test.test_cdf.TestCDF) ... ok
test_invalid_storage_set_configuration_rejected (test.test_cdf.TestCDF)
This test case checks whether exception will be raise if total ... ok
test_it_works (test.test_cdf.TestCDF) ... ok
test_md_pool_ignored (test.test_cdf.TestCDF) ... ok
test_metadata_is_hardcoded (test.test_cdf.TestCDF) ... ok
test_multiple_nodes_supported (test.test_cdf.TestCDF) ... ok
test_provided_values_respected (test.test_cdf.TestCDF) ... ok
test_template_sane (test.test_cdf.TestCDF) ... ok
test_disks_empty (test.test_cdf.TestTypes) ... ok
test_m0clients (test.test_cdf.TestTypes) ... ok
test_m0server_with_disks (test.test_cdf.TestTypes) ... ok
test_maybe_none (test.test_cdf.TestTypes) ... ok
test_pooldesc_empty (test.test_cdf.TestTypes) ... ok
test_protocol (test.test_cdf.TestTypes) ... ok

----------------------------------------------------------------------
Ran 23 tests in 0.328s

OK
```

```
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-2784 /]# hctl repair status -c /etc/cortx/hare/config/2e76c722a72841509be3527d865ca3c9/
[{"fid": "0x7300000000000001:0x6b", "state": 1, "progress": 13}, {"fid": "0x7300000000000001:0x5c", "state": 1, "progress": 13}, {"fid": "0x7300000000000001:0x43", "state": 1, "progress": 13}, {"fid": "0x7300000000000001:0x34", "state": 1, "progress": 13}, {"fid": "0x7300000000000001:0x1b", "state": 1, "progress": 13}, {"fid": "0x7300000000000001:0xc", "state": 1, "progress": 13}]

[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-2784 /]# hctl rebalance status -c /etc/cortx/hare/config/2e76c722a72841509be3527d865ca3c9/
[{"fid": "0x7300000000000001:0x6b", "state": 1, "progress": 14}, {"fid": "0x7300000000000001:0x5c", "state": 1, "progress": 14}, {"fid": "0x7300000000000001:0x43", "state": 1, "progress": 14}, {"fid": "0x7300000000000001:0x34", "state": 1, "progress": 14}, {"fid": "0x7300000000000001:0x1b", "state": 1, "progress": 14}, {"fid": "0x7300000000000001:0xc", "state": 1, "progress": 14}]
```