### PR TITLE
broadcast: broadcast message processing is in-efficient

### DIFF
--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -268,8 +268,8 @@ def process_state_update(planner: WorkPlanner):
                     ha_states.append(HAState(
                         fid=proc_fid,
                         status=proc_state_to_objhealth[proc_state]))
-                    planner.add_command(
-                        BroadcastHAStates(states=ha_states, reply_to=None))
+            planner.add_command(
+                BroadcastHAStates(states=ha_states, reply_to=None))
 
         # Note that planner.add_command is potentially a blocking call
         try:


### PR DESCRIPTION
It is possible that several broadcast requests are received by hax
through various events and sources, e.g. Consul, HA, etc. Hax watches
several Consul keys for updates, although Consul sends these updates
in a batch, hax processes them individually. This adds to processing
delay. Additionally, while processing every broadcast request, hax
performs some redundant operations with respect fetching some
peripheral information from Consul.

Solution:
- Process broadcast requests in batches.
- Avoid redundant operations, e.g. checking is a node is an rc node,
fetching local process status, etc.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>