### PR TITLE
CORTX-31298: watching processes/ prefix is in-efficient

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -149,10 +149,8 @@ class ConsumerThread(StoppableThread):
             for state in ha_states:
                 if state.fid.container == ObjT.PROCESS.value:
                     is_proc_local = self.consul.is_proc_local(state.fid)
-                    current_status = state.status
-                    if state.status in (ObjHealth.OFFLINE, ObjHealth.FAILED):
-                        current_status = cns.get_process_current_status(
-                            state.status, state.fid)
+                    current_status = cns.get_process_current_status(
+                        state.status, state.fid)
                     if current_status == ObjHealth.UNKNOWN:
                         continue
                     proc_status_remote = cns.get_process_status(state.fid)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -254,22 +254,22 @@ def process_state_update(planner: WorkPlanner):
             # pudb.remote.set_trace(term_size=(80, 40), port=9998)
             ha_states: List[HAState] = []
             LOG.debug('process status: %s', data)
-            for item in data:
-                proc_val = base64.b64decode(item['Value'])
-                proc_status = json.loads(str(proc_val.decode('utf-8')))
-                LOG.debug('process update item key %s item val: %s',
-                          item['Key'].split('/')[1], proc_status)
-                proc_fid = Fid.parse(item['Key'].split('/')[1])
-                proc_state = proc_status['state']
-                proc_type = proc_status['type']
-                if (proc_type != 'M0_CONF_HA_PROCESS_M0MKFS' and
-                        proc_state in ('M0_CONF_HA_PROCESS_STARTED',
-                                       'M0_CONF_HA_PROCESS_STOPPED')):
-                    ha_states.append(HAState(
-                        fid=proc_fid,
-                        status=proc_state_to_objhealth[proc_state]))
-            planner.add_command(
-                BroadcastHAStates(states=ha_states, reply_to=None))
+            proc_status_val = base64.b64decode(data['Value']).decode("utf-8")
+            proc_status = json.loads(proc_status_val)
+            LOG.debug('process status %s', proc_status)
+            proc_fid = Fid.parse(data['Key'].split('/')[1])
+            proc_state = proc_status['state']
+            proc_type = proc_status['type']
+            if (proc_type != 'M0_CONF_HA_PROCESS_M0MKFS' and
+                proc_state in ('M0_CONF_HA_PROCESS_STARTED',
+                               'M0_CONF_HA_PROCESS_STOPPED')):
+                LOG.debug('Adding item key %d item val: %s',
+                          proc_fid.key, proc_status)
+                ha_states.append(HAState(
+                    fid=proc_fid,
+                    status=proc_state_to_objhealth[proc_state]))
+                planner.add_command(
+                    BroadcastHAStates(states=ha_states, reply_to=None))
 
         # Note that planner.add_command is potentially a blocking call
         try:

--- a/systemd/consul-client-conf.json.in
+++ b/systemd/consul-client-conf.json.in
@@ -23,16 +23,6 @@
       }
     },
     {
-      "type": "keyprefix",
-      "prefix": "processes/",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
-        "method": "POST",
-        "timeout": "10s"
-      }
-    },
-    {
       "type": "service",
       "service": "hax",
       "handler_type": "http",

--- a/systemd/consul-server-conf.json.in
+++ b/systemd/consul-server-conf.json.in
@@ -13,16 +13,6 @@
       }
     },
     {
-      "type": "keyprefix",
-      "prefix": "processes/",
-      "handler_type": "http",
-      "http_handler_config": {
-        "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
-        "method": "POST",
-        "timeout": "10s"
-      }
-    },
-    {
       "type": "service",
       "service": "hax",
       "handler_type": "http",

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -476,6 +476,80 @@ if [[ $CONFD_IDs ]]; then
                                 "TMP_LOG_DIR" ]}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
 fi
 
+append_hax_svc_watch() {
+    local id=$1
+    local fid=$(id2fid $id)
+    local key="processes/$fid"
+
+    jq --arg k "$key" '.watches += [{"type": "key",
+                          "key": $k,
+                          "handler_type": "http",
+                          "http_handler_config": {
+                          "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
+                          "method": "POST",
+                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
+}
+
+append_confd_svc_watch() {
+    local id=$1
+    local fid=$(id2fid $id)
+    local key="processes/$fid"
+
+    jq --arg k "$key" '.watches += [{"type": "key",
+                          "key": $k,
+                          "handler_type": "http",
+                          "http_handler_config": {
+                          "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
+                          "method": "POST",
+                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
+}
+
+append_ios_svc_watch() {
+    local id=$1
+    local fid=$(id2fid $id)
+    local key="processes/$fid"
+
+    jq --arg k "$key" '.watches += [{"type": "key",
+                          "key": $k,
+                          "handler_type": "http",
+                          "http_handler_config": {
+                          "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
+                          "method": "POST",
+                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
+}
+
+append_motr_client_watch() {
+    local id=$1
+    local fid=$(id2fid $id)
+    local key="processes/$fid"
+
+    jq --arg k "$key" '.watches += [{"type": "key",
+                          "key": $k,
+                          "handler_type": "http",
+                          "http_handler_config": {
+                          "path": "http://localhost:HAX_HTTP_PORT/watcher/processes",
+                          "method": "POST",
+                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
+}
+
+for id in $HAX_ID; do
+    append_hax_svc_watch $id
+done
+
+for id in $CONFD_IDs; do
+    append_confd_svc_watch $id
+done
+
+for id in $IOS_IDs; do
+    append_ios_svc_watch $id
+done
+
+for id in $MOTR_CLIENT_IDS; do
+    proc=$(echo $id| cut -d':' -f 1)
+    client_id=$(echo $id| cut -d':' -f 2)
+    append_motr_client_watch $client_id
+done
+
 sed -i "s|TMP_CONF_DIR|$conf_dir|" $tmpfile
 sed -i "s|TMP_LOG_DIR|$log_dir|" $tmpfile
 sed -i "s|HAX_HTTP_PORT|$hax_http_port|" $tmpfile


### PR DESCRIPTION
Hare watches entire `processes/` kv tree for corresponding process
state changes. But, consul generates notification for entire tree
for even a single process state change. This adds to delay in
processing of the relevant events.

Solution:
Watch specific processes kv per processes so that only relevant
Csonul events are generated.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>