### PR TITLE
CORTX-31431: PreMerge Issue: loops devices are not getting detached 

### DIFF
--- a/jenkins/bootstrap-singlenode
+++ b/jenkins/bootstrap-singlenode
@@ -30,6 +30,8 @@ echo 'options lnet networks=tcp(eth1) config_on_load=1' \
      > /etc/modprobe.d/lnet.conf
 
 for i in {0..9}; do
+    losetup -d /dev/loop$i || true
+    sleep 1s
     dd if=/dev/zero of=/var/motr/disk$i.img bs=1M seek=9999 count=1
     losetup /dev/loop$i /var/motr/disk$i.img
 done

--- a/jenkins/prepare-yum-repos
+++ b/jenkins/prepare-yum-repos
@@ -24,10 +24,11 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 export
 
 STORAGE='http://cortx-storage.colo.seagate.com'
+REPO_PATH=$1
 
 cat <<EOF > /etc/yum.repos.d/motr_last_successful.repo
 [motr-dev]
-baseurl=$STORAGE/releases/cortx/github/main/centos-7.9.2009/last_successful/
+baseurl=$REPO_PATH/last_successful/
 gpgcheck=0
 name=motr-dev
 enabled=1
@@ -35,17 +36,9 @@ EOF
 
 cat <<EOF > /etc/yum.repos.d/motr_uploads.repo
 [motr-uploads]
-baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.9.2009-2.0.0-k8/motr_uploads/
+baseurl=$REPO_PATH/last_successful_prod/3rd_party/motr/
 gpgcheck=0
 name=motr-uploads
-enabled=1
-EOF
-
-cat <<EOF > /etc/yum.repos.d/lustre_release.repo
-[lustre]
-baseurl=$STORAGE/releases/cortx/third-party-deps/centos/centos-7.9.2009-2.0.0-k8/lustre/custom/tcp/
-gpgcheck=0
-name=lustre
 enabled=1
 EOF
 


### PR DESCRIPTION
PreMerge Jenkins Job failing due to couple of issues,
1. On RoclyLinux VM, still we are using Repository which is pointing to CentOS7.9.
2. losetup: set up and control loop devices is not working because, it not getting detached as expected.

Solution:
1. Repository changes in jenkins/prepare-yum-repos file to rockylinux.
2. Detach loop device before setting up.