### PR TITLE
CORTX-31920: get_machineid_by_nodename() may return None

### DIFF
--- a/hax/hax/ha/ha.py
+++ b/hax/hax/ha/ha.py
@@ -81,10 +81,11 @@ class Ha():
             # when node is offline, rc node sends the offline event.
             resource_id = cns.get_machineid_by_nodename(node_name)
 
-            resource = Resource(type=ObjT.NODE,
-                                id=resource_id,
-                                name=node_name,
-                                status=state)
+            if resource_id:
+                resource = Resource(type=ObjT.NODE,
+                                    id=resource_id,
+                                    name=node_name,
+                                    status=state)
         return resource
 
     def broadcast(self, ha_states: List[HAState]) -> None:


### PR DESCRIPTION
machine id to node name mapping is maintained through
mini-provisioner and not during hctl bootstrap.
Thus get_machineid_by_nodename(), may fail infitely
when bootstrapped through `hctl bootstrap`.
Also don't use cache to get node and service statuses,
that may return false statuses.

Solution:
- Do not repeat get_machineid_by_nodename() on failure.
- Avoid caching node and service statuses.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>