### PR TITLE
CORTX-32070: Disk stuck in rebalancing state after hctl rebalance start cmd

### DIFF
--- a/rules/sns-rebalance
+++ b/rules/sns-rebalance
@@ -63,7 +63,7 @@ get_hax_node_name() {
 }
 
 get_hax_port() {
-    consul kv get ports/hax | jq -r .http
+    consul kv get ports/$(get_hax_node_name)/hax | jq -r .http
 }
 
 get_hax_http_protocol() {


### PR DESCRIPTION
After triggering "hctl rebalance start" command, the disk is not going into the
"online" state, instead of it remains in the "rebalancing" state.
In the sns-rebalance script, get_hax_port() function not able to fetch
ports/hax key from consul kv.

Signed-off-by: Supriya Yadav <supriya.s.chavan@seagate.com>