### PR TITLE
CORTX-29710: Hare-HA - Correct the message format sent from Hare to ha

### DIFF
--- a/hax/hax/ha/message_interface/message_interface.py
+++ b/hax/hax/ha/message_interface/message_interface.py
@@ -89,8 +89,7 @@ class MessageBusInterface(MessageInterface):
             raise Exception('initialize_bus skipped as configpath not found')
 
     def send(self, event: HaEvent):
-        event_to_send = json.dumps(event)
-        self.producer.send([event_to_send])
+        self.producer.send([event])
 
     def _register_message_type(self, message_type,
                                partitions: int = 1):

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -2033,7 +2033,7 @@ class ConsulUtil:
                 started_processes += 1
         LOG.debug('total procs=%s, started procs=%s', total_processes,
                   started_processes)
-        fin_state = 'degarded'
+        fin_state = 'degraded'
         if total_processes == started_processes:
             fin_state = 'online'
         elif started_processes == 0:


### PR DESCRIPTION
**Solution**:
Fixed format by removing json.dump()
Also fixed 'degraded' event related issue

**Test:**
Tested 3 node deployment.
Following are few of the events generated
```
Received event={'header': {'version': '1.0', 'timestamp': '1654601238.428012', 'event_id': '1654601238d2b4b6f7a0af4feab5c3266c7c28ba20'}, 'payload': {'source': 'hare', 'cluster_id': 'NOT_DEFINED', 'site_id': 'NOT_DEFINED', 'rack_id': 'NOT_DEFINED', 'storageset_id': 'NOT_DEFINED', 'node_id': 'a4760ca16c728947f2bf2db1b16c85f1', 'resource_type': 'node', 'resource_id': 'a4760ca16c728947f2bf2db1b16c85f1', 'resource_status': 'degraded', 'specific_info': {'generation_id': 'cortx-data-headless-svc-ssc-vm-g2-rhev4-2784'}}}
Received event={'header': {'version': '1.0', 'timestamp': '1654601241.102206', 'event_id': '165460124175163ac5454740a98b279f4900597504'}, 'payload': {'source': 'hare', 'cluster_id': 'NOT_DEFINED', 'site_id': 'NOT_DEFINED', 'rack_id': 'NOT_DEFINED', 'storageset_id': 'NOT_DEFINED', 'node_id': 'a4760ca16c728947f2bf2db1b16c85f1', 'resource_type': 'node', 'resource_id': 'a4760ca16c728947f2bf2db1b16c85f1', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-data-headless-svc-ssc-vm-g2-rhev4-2784'}}}
```

Also confirmed @Madhura-08 that events are in proper format HA is able to traverse events correctly