### PR TITLE
CORTX-32139: bytecount and filesystem stats are not updating

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -590,7 +590,7 @@ class ConsulUtil:
         watchers.The following services are considered [default]: ios, confd.
         """
         if not motr_services:
-            motr_services = set(['ios', 'confd'])
+            motr_services = set(['ios'])
         result = []
         for service_name in self.catalog.get_service_names():
             if service_name not in motr_services:


### PR DESCRIPTION
Hare reports a ioservice as STARTED when it transitions to
M0_CONF_HA_PROCESS_DTM_RECOVERED but confds are reported as online
when they transition to M0_CONF_HA_PROCESS_STARTED. Hare rconfc
starter thread checks if all the ioservices and confds are `online`
before initializing motr spiel api through `get_m0d_statuses()`,
which fetches health (using `get_service_health()`) of both confds
and ioservices. Presently `get_service_health()`, reports RECOVERING
for confd as it does not transition to `M0_CONF_HA_PROCESS_DTM_RECOVERED`
state. This blocks rconfc and spiel api initialization.

Solution:
Invoke `get_service_health()` only for ioservices in `get_m0d_statuses()`

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>