### PR TITLE
CORTX-32140: hctl fetch-fids command fails

### DIFF
--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -29,7 +29,7 @@ import logging
 import logging.handlers
 import simplejson
 import inject
-from socket import gethostname
+from socket import getfqdn
 from hax.types import ObjT
 from hax.common import di_configuration
 from hax.util import ConsulUtil, repeat_if_fails
@@ -79,7 +79,7 @@ class Node:
 @repeat_if_fails(max_retries=2)
 def get_log_path():
     cns_utils = ConsulUtil()
-    hostname = gethostname()
+    hostname = getfqdn()
     log_path_key = cns_utils.kv.kv_get(f'{hostname}/log_path')
 
     if log_path_key is None:


### PR DESCRIPTION
As the cortx deployments starts using fdqn instead of just
short hostnames, it is important that the corresponding users
switch to more consistent node names and avoid assumptions that
exepct the system and configured names to be same.

Solution:
Use full node name, socket.getfqdn() instead of just hostname.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>