### PR TITLE
CORTX-32139: bytecount statistics do not update

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -329,6 +329,22 @@ class CatalogAdapter:
                 'Could not access Consul Catalog') from e
 
 
+class ProcessGroup:
+    def __init__(self, buckets_count: int):
+        self.buckets: int = buckets_count
+        self.process_locks = []
+        for _ in range(self.buckets):
+            self.process_locks.append(Lock())
+
+    def process_group_lock(self, proc_fid: Fid):
+        group = proc_fid.key % self.buckets
+        self.process_locks[group].acquire()
+
+    def process_group_unlock(self, proc_fid: Fid):
+        group = proc_fid.key % self.buckets
+        self.process_locks[group].release()
+
+
 class ConsulUtil:
     def __init__(self, raw_client: Optional[Consul] = None):
         self.cns: Consul = raw_client or Consul()


### PR DESCRIPTION
In order to broadcast every motr process state update in cluster to
every other motr process, Hare watches the every motr process's state
machine transitions. A possible race between motr process state updates
can occur where the motr process reports M0_CONF_HA_PROCESS_STARTED and
hare updates the same in Consul, this triggeres a notification locally
as well as to remote processes. When local process in handling this
M0_CONF_HA_PROCESS_STARTED state transition notification, it is possible
the motr process reported M0_CONF_HA_PROCESS_DTM_RECOVERED and its
corresponding state machine in Consul KV was accordingly transitioned.
But the in-progress processing of M0_CONF_HA_PROCESS_STARTED state
transition, happening in a separate thread, might already be
updating the process state in Consul KV, thus overwriting the process
state transition of M0_CONF_HA_PROCESS_DTM_RECOVERED back to
M0_CONF_HA_PROCESS_STARTED. This leads to inconsistencies.

Solution:
A possible approach of distributed locking on the process state machine
can be used here but that may affect performance as for every process state
transition and its corresponding notification, corresponding lock will
have to accessed.
Another approach is to let the RC hax or local hax corresponding to the
process update the process state machine corresponding to the state
transition notification only in case of failures. As the happy path
state transitions will be done by the process explicitly as part of
startup. We just need to handle process failure related state transitions
where the corresponding process is not able to report the transition
explicitly.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>