### PR TITLE
CORTX-31897: Handle RC node failure

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -63,6 +63,11 @@ class BroadcastHAStates(BaseMessage):
 
 
 @dataclass
+class ProcessStateUpdate(BaseMessage):
+    states: List[HAState]
+
+
+@dataclass
 class HaNvecGetEvent(BaseMessage):
     hax_msg: int
     nvec: List[HaNote]

--- a/hax/hax/queue/publish.py
+++ b/hax/hax/queue/publish.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 
 import simplejson
 from hax.util import KVAdapter, TxPutKV, repeat_if_fails
@@ -21,12 +21,17 @@ class Publisher:
         self.kv = kv or KVAdapter()
         self.epoch_key = epoch_key
 
-    @repeat_if_fails(wait_seconds=0.1)
-    def publish(self, message_type: str, payload: str) -> int:
-        """Publishes the given message to the queue."""
+    @staticmethod
+    def _get_payload_with_type(message_type: str, payload: str) -> str:
         data = simplejson.loads(payload)
         message = Message(message_type=message_type, payload=data)
         data = simplejson.dumps(message)
+        return str(data)
+
+    @repeat_if_fails(wait_seconds=0.1)
+    def publish(self, message_type: str, payload: str) -> int:
+        """Publishes the given message to the queue."""
+        data = Publisher._get_payload_with_type(message_type, payload)
 
         while True:
             index, value = self.kv.kv_get_raw(self.epoch_key)
@@ -42,6 +47,22 @@ class Publisher:
             ])
             if ok:
                 return next_epoch
+
+    def publish_no_duplicate(self,
+                             message_type: str,
+                             payload: str,
+                             key_suffix: str,
+                             checks: Optional[List[TxPutKV]] = None) -> bool:
+        """Drop the event if the event is already present in the queue."""
+        data = Publisher._get_payload_with_type(message_type, payload)
+
+        new_key = f'{self.queue_prefix}/{key_suffix}'
+        tx_list = []
+        if checks:
+            tx_list.extend(checks)
+        tx_list.append(TxPutKV(key=new_key, value=data, cas=0))
+        ok = self.kv.kv_put_in_transaction(tx_list)
+        return ok
 
 
 class BQPublisher(Publisher):

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -37,8 +37,8 @@ from urllib3.exceptions import HTTPError
 from hax.common import HaxGlobalState
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.types import (ByteCountStats, ConfHaProcess, Fid, FsStatsWithTime,
-                       ObjT, ObjHealth, ObjTMaskMap, Profile, PverInfo,
-                       PverState, m0HaProcessEvent, m0HaProcessType,
+                       HAState, ObjT, ObjHealth, ObjTMaskMap, Profile,
+                       PverInfo, PverState, m0HaProcessEvent, m0HaProcessType,
                        KeyDelete, HaNoteStruct, m0HaObjState)
 
 from hax.consul.cache import (uses_consul_cache, invalidates_consul_cache,
@@ -200,6 +200,12 @@ def wait_for_event(event: Event, interval_sec) -> None:
         raise InterruptedException()
 
 
+def ha_state_to_json(state: HAState) -> str:
+    data = {'fid': str(state.fid),
+            'state': str(state.status.name)}
+    return dump_json(data)
+
+
 class KVAdapter:
     def __init__(self, cns: Optional[Consul] = None):
         self.cns = cns or Consul()
@@ -241,7 +247,7 @@ class KVAdapter:
             b64: bytes = b64encode(v.value.encode())
             b64_str = b64.decode()
 
-            if v.cas:
+            if v.cas is not None:
                 return {
                     'KV': {
                         'Key': v.key,

--- a/rules/process-state-update
+++ b/rules/process-state-update
@@ -22,9 +22,10 @@ set -e -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 log() {
-    # logger --tag "hare/${0##*/}" --stderr "$*"
     echo -n "$*"
 }
-log "Default RC rule handler called for event \
-type: ${HARE_RC_EVENT_TYPE} and payload ${HARE_RC_EVENT_PAYLOAD}. \
-No action."
+
+log "Process state update event is called for \
+payload ${HARE_RC_EVENT_PAYLOAD}."
+
+h0q bq PROC_STATE_UPDATE "$HARE_RC_EVENT_PAYLOAD"


### PR DESCRIPTION
### CORTX-31897: Handle RC node failure 

### Description

RC node failure may lead to missing of the corresponding Consul
updates.
Cache the process update events to the Event Queue.
Avoid caching duplicate events in the Event Queue.

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>

### Testing

1. Failed RC node.
```
 cortx-data-headless-svc-ssc-vm-g2-rhev4-2621  (RC)
    [started]  hax                 0x7200000000000001:0x4          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@22001
    [started]  ioservice           0x7200000000000001:0x5          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21001
    [started]  ioservice           0x7200000000000001:0x6          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21002
    [started]  confd               0x7200000000000001:0x7          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@22002
```

2. new RC node elected

```
2022-07-05 06:46:01 Success! Lock acquired on: leader
```
3. hctl status
```
[root@cortx-data-headless-svc-ssc-vm-g2-rhev4-2611 /]# hctl status
Bytecount:
    critical : 0
    damaged : 0
    degraded : 0
    healthy : 0
Data pool:
    # fid name
    0x6f00000000000001:0x0 'storage-set-1__sns'
Profile:
    # fid name: pool(s)
    0x7000000000000001:0x0 'Profile_the_pool': 'storage-set-1__sns' 'storage-set-1__dix' None
Services:
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2611
    [started]  hax                 0x7200000000000001:0x0          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@22001
    [started]  ioservice           0x7200000000000001:0x1          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@21001
    [started]  ioservice           0x7200000000000001:0x2          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@21002
    [started]  confd               0x7200000000000001:0x3          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2611@22002
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2621
    [offline]  hax                 0x7200000000000001:0x4          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@22001
    [offline]  ioservice           0x7200000000000001:0x5          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21001
    [offline]  ioservice           0x7200000000000001:0x6          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@21002
    [offline]  confd               0x7200000000000001:0x7          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2621@22002
    cortx-data-headless-svc-ssc-vm-g2-rhev4-2610  (RC)
    [started]  hax                 0x7200000000000001:0x8          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@22001
    [started]  ioservice           0x7200000000000001:0x9          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@21001
    [started]  ioservice           0x7200000000000001:0xa          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@21002
    [started]  confd               0x7200000000000001:0xb          inet:tcp:cortx-data-headless-svc-ssc-vm-g2-rhev4-2610@22002
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2621
    [started]  hax                 0x7200000000000001:0xc          inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2621@22001
    [started]  rgw_s3              0x7200000000000001:0xd          inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2621@21001
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2611
    [started]  hax                 0x7200000000000001:0xe          inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2611@22001
    [started]  rgw_s3              0x7200000000000001:0xf          inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2611@21001
    cortx-server-headless-svc-ssc-vm-g2-rhev4-2610
    [started]  hax                 0x7200000000000001:0x10         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2610@22001
    [started]  rgw_s3              0x7200000000000001:0x11         inet:tcp:cortx-server-headless-svc-ssc-vm-g2-rhev4-2610@21001
```
4. Event cached and processed by new RC node

```
32939: Process epoch: eq/0x7200000000000001:0x4: {"message_type": "process-state-update", "payload": {"fid": "0x7200000000000001:0x4", "state": "FAILED"}}HARE_RC_EVENT_TYPE: process-state-update, HARE_RC_EVENT_PAYLOAD: {
  "fid": "0x7200000000000001:0x4",
  "state": "FAILED"
}2022-07-05 06:46:03 Process state update event is called for payload {
2022-07-05 06:46:03   "fid": "0x7200000000000001:0x4",
2022-07-05 06:46:03   "state": "FAILED"
2022-07-05 06:46:05 }.2022-07-05 06:46:05,072 [DEBUG] Bound <class 'hax.common.HaxGlobalState'> to an instance <hax.common.HaxGlobalState object at 0x7f67c9b9c4e0>
2022-07-05 06:46:05 2022-07-05 06:46:05,072 [DEBUG] Created and configured an injector, config=<function di_configuration at 0x7f67cce1fea0>
2022-07-05 06:46:05 2022-07-05 06:46:05,096 [DEBUG] Starting new HTTP connection (1): 127.0.0.1:8500
2022-07-05 06:46:05 2022-07-05 06:46:05,105 [DEBUG] http://127.0.0.1:8500 "GET /v1/kv/epoch HTTP/1.1" 200 95
2022-07-05 06:46:05 2022-07-05 06:46:05,167 [DEBUG] http://127.0.0.1:8500 "PUT /v1/txn HTTP/1.1" 200 225
2022-07-05 06:46:05 2022-07-05 06:46:05,168 [INFO] Written to epoch: 9
2022-07-05 06:46:06 Success! Deleted key: eq/0x7200000000000001:0x4
32984: Process epoch: eq/0x7200000000000001:0x4: {"message_type": "process-state-update", "payload": {"fid": "0x7200000000000001:0x4", "state": "FAILED"}}HARE_RC_EVENT_TYPE: process-state-update, HARE_RC_EVENT_PAYLOAD: {
  "fid": "0x7200000000000001:0x4",
  "state": "FAILED"
}2022-07-05 06:46:08 Process state update event is called for payload {
2022-07-05 06:46:08   "fid": "0x7200000000000001:0x4",
2022-07-05 06:46:08   "state": "FAILED"
2022-07-05 06:46:09 }.2022-07-05 06:46:09,484 [DEBUG] Bound <class 'hax.common.HaxGlobalState'> to an instance <hax.common.HaxGlobalState object at 0x7feaac3aa4e0>
2022-07-05 06:46:09 2022-07-05 06:46:09,484 [DEBUG] Created and configured an injector, config=<function di_configuration at 0x7feaaf62cea0>
2022-07-05 06:46:09 2022-07-05 06:46:09,492 [DEBUG] Starting new HTTP connection (1): 127.0.0.1:8500
2022-07-05 06:46:09 2022-07-05 06:46:09,554 [DEBUG] http://127.0.0.1:8500 "GET /v1/kv/epoch HTTP/1.1" 200 95
2022-07-05 06:46:09 2022-07-05 06:46:09,578 [DEBUG] http://127.0.0.1:8500 "PUT /v1/txn HTTP/1.1" 200 226
2022-07-05 06:46:09 2022-07-05 06:46:09,579 [INFO] Written to epoch: 10
2022-07-05 06:46:10 Success! Deleted key: eq/0x7200000000000001:0x4
```
5. Event added to BQ and further processed
```
2022-07-05 06:46:06,066 [DEBUG] {qconsumer-8} Got ProcessStateUpdate(group=125, states=[HAState(fid=0x7200000000000001:0x4, status=FAILED)]) message from planner
2022-07-05 06:46:09,596 [DEBUG] {ThreadPoolExecutor-0_25} ProcessStateUpdate process fid: 0x7200000000000001:0x4 state: FAILED
2022-07-05 06:46:09,864 [DEBUG] {qconsumer-10} Got ProcessStateUpdate(group=126, states=[HAState(fid=0x7200000000000001:0x4, status=FAILED)]) message from planner
```
