### PR TITLE
CORTX-32329: Hare builds are failing for main and custom-ci branches

### DIFF
--- a/hax/requirements.txt
+++ b/hax/requirements.txt
@@ -19,6 +19,7 @@ recordclass==0.14
 
 #:runtime-requirements:
 idna==2.10
+charset-normalizer==2.0.12
 aiohttp==3.8.1
 click==8.0.1
 dataclasses==0.8


### PR DESCRIPTION
Solution: The issue was with the version of charset-normalizer, a package that
aiohttp (a package required by HARE) was pulling in as a depend. We have now set
the version of charset-normalizer to 2.0.12 - which works with aiohttp 3.8.1
as required by HARE.

Signed-off-by: Deepak Nayak <deepak.nayak@seagate.com>