### PR TITLE
CORTX-30537: add a way to disable formulaic pool versions

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -2016,8 +2016,11 @@ class ConfPool(ToDhall):
             m0conf[parent].mdpool = pool_id
         else:
             assert t is PoolT.sns
-            for v in gen_allowances(tolerance):
-                ConfPverF.build(m0conf, pool_id, base=pver, allowance=v)
+            generate_formulaic_pvers: bool = cluster_desc.get(
+                                           'generate_formulaic_pvers', False)
+            if generate_formulaic_pvers:
+                for v in gen_allowances(tolerance):
+                    ConfPverF.build(m0conf, pool_id, base=pver, allowance=v)
 
         return pool_id
 

--- a/cfgen/dhall/types/ClusterDesc.dhall
+++ b/cfgen/dhall/types/ClusterDesc.dhall
@@ -26,6 +26,7 @@ let Pool = ./PoolDesc.dhall
 
 in
 { create_aux : Optional Bool
+, generate_formulaic_pvers : Optional Bool
 , nodes : List Node
 , pools : List Pool
 , profiles : Optional (List ./PoolsRef.dhall)

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -44,6 +44,7 @@ nodes:
     #     port: 41500
     #   m0_client_s3: 42500
 create_aux: false # optional; supported values: "false" (default), "true"
+generate_formulaic_pvers: false # optional; supported values: "false" (default), "true"
 pools:
   - name: the pool
     type: sns  # optional; supported values: "sns" (default), "dix", "md"

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -23,6 +23,7 @@ let types = ../dhall/types.dhall
 
 in
 { create_aux = Some False
+, generate_formulaic_pvers = Some False
 , nodes =
     [ { hostname = "localhost"
       , machine_id = None Text

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -378,6 +378,7 @@ class CdfGenerator:
 
         params_text = str(
             ClusterDesc(create_aux=Maybe(create_aux, 'Bool'),
+                        generate_formulaic_pvers=Maybe(False, 'Bool'),
                         node_info=DList(nodes, 'List NodeInfo'),
                         pool_info=DList(pools, 'List PoolInfo'),
                         profile_info=DList(profiles, 'List ProfileInfo'),

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -77,6 +77,7 @@ let ProfileInfo =
 
 let ClusterInfo =
       { create_aux : Optional Bool
+      , generate_formulaic_pvers: Optional Bool
       , node_info: List NodeInfo
       , pool_info: List PoolInfo
       , profile_info: List ProfileInfo
@@ -116,6 +117,7 @@ let genCdf
     : ClusterInfo -> T.ClusterDesc
     =     \(cluster_info : ClusterInfo)
       ->  { create_aux = cluster_info.create_aux
+          , generate_formulaic_pvers = cluster_info.generate_formulaic_pvers
           , nodes = Prelude.List.map NodeInfo T.NodeDesc toNodeDesc cluster_info.node_info
           , pools = Prelude.List.map PoolInfo T.PoolDesc toPoolDesc cluster_info.pool_info
           , profiles = Some cluster_info.profile_info

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -192,6 +192,7 @@ class FdmiFilterDesc(DhallTuple):
 @dataclass(repr=False)
 class ClusterDesc(DhallTuple):
     create_aux: Maybe[bool]
+    generate_formulaic_pvers: Maybe[bool]
     node_info: DList[NodeDesc]
     pool_info: DList[PoolDesc]
     profile_info: DList[ProfileDesc]


### PR DESCRIPTION
Hare automatically generates formulaic pool versions (i.e. different
combinations of layouts) based on the tolerances for failure domains
and corresponding layout parameters. In some configuration cases,
these multiple poolversions may not be required and in-order to use
other fault tolerant and recovery methods (e.g. automatic data recovery
on process restart). Thus, there needs to be a way to disable
generating formulaic pool versions.

Solution:
- Add a flag in cdf to disable formulaic pool versions.
- Update cfgen to read corresponding flag and skip generating
  formulaic pool versions.
- Add corresponding flag to hare mini-provisioner, set it to False
  by default.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>