### PR TITLE
CORTX-32483: all2all dtm test fails

### DIFF
--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -310,7 +310,7 @@ class ConsumerThread(StoppableThread):
                 ids: List[MessageId] = motr.broadcast_ha_states(
                                        [
                                            HAState(fid=req.process_fid,
-                                                   status=ObjHealth.FAILED)
+                                                   status=ObjHealth.OFFLINE)
                                        ],
                                        notify_devices=False,
                                        proc_skip_list=[req.process_fid])

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -139,7 +139,7 @@ def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
         svc_status = ObjHealth.OK
         for check in node['Checks']:
             if check.get('Status') != 'passing':
-                svc_status = ObjHealth.FAILED
+                svc_status = ObjHealth.OFFLINE
             svc_id = check.get('ServiceID')
             if svc_id:
                 ha_states.append(HAState(

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1262,6 +1262,7 @@ class ConsulUtil:
 
         device_ha_state_map = {
             ObjHealth.UNKNOWN: m0HaObjState.M0_NC_TRANSIENT,
+            ObjHealth.RECOVERING: m0HaObjState.M0_NC_DTM_RECOVERING,
             ObjHealth.OK: m0HaObjState.M0_NC_ONLINE,
             ObjHealth.OFFLINE: m0HaObjState.M0_NC_TRANSIENT,
             ObjHealth.FAILED: m0HaObjState.M0_NC_FAILED,
@@ -1532,6 +1533,8 @@ class ConsulUtil:
                            kv_cache=None) -> None:
         device_state_map = {
             ObjHealth.OK: 'online',
+            ObjHealth.UNKNOWN: 'offline',
+            ObjHealth.RECOVERING: 'dtm_recovering',
             ObjHealth.FAILED: 'failed',
             ObjHealth.OFFLINE: 'offline',
             ObjHealth.REPAIR: 'repairing',
@@ -1583,6 +1586,7 @@ class ConsulUtil:
             'unknown': HaNoteStruct.M0_NC_ONLINE,
             'm0_nc_unknown': HaNoteStruct.M0_NC_ONLINE,
             'online': HaNoteStruct.M0_NC_ONLINE,
+            'dtm_recovering': HaNoteStruct.M0_NC_DTM_RECOVERING,
             'offline': HaNoteStruct.M0_NC_TRANSIENT,
             'failed': HaNoteStruct.M0_NC_FAILED,
             'repairing': HaNoteStruct.M0_NC_REPAIR,
@@ -2061,8 +2065,9 @@ class ConsulUtil:
             if p_fid not in all_procs:
                 continue
             # Checking if status is M0_CONF_HA_PROCESS_STARTED
-            if all_procs[p_fid] == \
-                    m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED.name:
+            if all_procs[p_fid] in (
+                    m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED.name,
+                    m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED.name):
                 started_processes += 1
         LOG.debug('total procs=%s, started procs=%s', total_processes,
                   started_processes)

--- a/hax/test/integration/test_server.py
+++ b/hax/test/integration/test_server.py
@@ -80,8 +80,8 @@ async def test_hello_works(hax_client):
 
 
 @pytest.mark.parametrize('status,health', [('passing', ObjHealth.OK),
-                                           ('warning', ObjHealth.FAILED),
-                                           ('critical', ObjHealth.FAILED)])
+                                           ('warning', ObjHealth.OFFLINE),
+                                           ('critical', ObjHealth.OFFLINE)])
 async def test_service_health_broadcast(hax_client, planner, status: str,
                                         health: ObjHealth):
     service_health = [{


### PR DESCRIPTION
On process restart, before replying to the first entrypoint request,
Hare notifies the process as M0_NC_FAILED to rest of the motr cluster.
But this restricts dtm recovery completion on process restart as the
process is marked as FAILED and not OFFLINE.

Solution:
Notify OFFLINE instead of FAILED on process restart.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>