### PR TITLE
CORTX-33628 : Hax motr node restart fix

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -235,6 +235,7 @@ def main():
 
         server = ServerRunner(planner,
                               herald,
+                              motr=motr,
                               consul_util=util,
                               hax_state=state)
         server.run(threads_to_wait=[*consumer_threads,

--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -21,7 +21,8 @@ from dataclasses import dataclass, field, fields
 from queue import Queue
 from typing import Any, List, Optional
 
-from hax.types import ConfHaProcess, Fid, HaNote, HAState, StobId, Uint128
+from hax.types import (ConfHaProcess, Fid, HaNote, HAState, StobId, Uint128,
+                       m0HaProcessType)
 
 
 @dataclass(unsafe_hash=True)
@@ -54,6 +55,13 @@ class FirstEntrypointRequest(AnyEntrypointRequest):
 @dataclass
 class ProcessEvent(BaseMessage):
     evt: ConfHaProcess
+
+
+@dataclass
+class ProcessHaEvent(BaseMessage):
+    fid: Fid
+    proc_type: m0HaProcessType
+    states: List[HAState]
 
 
 @dataclass

--- a/hax/hax/motr/hax.c
+++ b/hax/hax/motr/hax.c
@@ -178,9 +178,6 @@ M0_INTERNAL void m0_ha_entrypoint_reply_send(
  */
 PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx)
 {
-	PyGILState_STATE gstate;
-	gstate = PyGILState_Ensure();
-
 	struct hax_context *hc = (struct hax_context *)ctx;
 	struct m0_halon_interface *hi = hc->hc_hi;
 	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
@@ -188,6 +185,8 @@ PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx)
 	struct m0_fs_stats stats;
 	int rc;
 
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
 	Py_BEGIN_ALLOW_THREADS rc =
 	    m0_spiel_filesystem_stats_fetch(spiel, &stats);
 	Py_END_ALLOW_THREADS if (rc != 0)
@@ -213,15 +212,15 @@ PyObject *m0_ha_filesystem_stats_fetch(unsigned long long ctx)
 PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
 	struct m0_fid *proc_fid)
 {
-	PyGILState_STATE gstate;
-	gstate = PyGILState_Ensure();
-
 	struct hax_context *hc = (struct hax_context *)ctx;
 	struct m0_halon_interface *hi = hc->hc_hi;
 	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
 
 	struct m0_proc_counter *count_stats=NULL;
 	int rc;
+
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
 	/* init count_stats */
 	Py_BEGIN_ALLOW_THREADS rc = 
 	    m0_spiel_count_stats_init(&count_stats);
@@ -279,9 +278,6 @@ PyObject *m0_ha_proc_counters_fetch(unsigned long long ctx,
 PyObject *m0_ha_pver_status(unsigned long long ctx,
 	struct m0_fid *pver_fid)
 {
-	PyGILState_STATE gstate;
-	gstate = PyGILState_Ensure();
-
 	struct hax_context *hc = (struct hax_context *)ctx;
 	struct m0_halon_interface *hi = hc->hc_hi;
 	struct m0_spiel *spiel = m0_halon_interface_spiel(hi);
@@ -289,6 +285,9 @@ PyObject *m0_ha_pver_status(unsigned long long ctx,
 	struct m0_conf_pver_info pver_info;
 
 	int rc;
+
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
 	/* call the motr api */
 	Py_BEGIN_ALLOW_THREADS rc =
 	    m0_spiel_conf_pver_status(spiel, pver_fid, &pver_info);
@@ -900,13 +899,14 @@ PyObject* m0_ha_notify(unsigned long long ctx, struct m0_ha_note *notes,
         bool skip_process = false;
 
 	msg = _ha_nvec_msg_alloc(&nvec, 0, M0_HA_NVEC_SET);
-	hax_lock(hc);
 
+	hax_lock(hc);
 	PyGILState_STATE gstate;
 	gstate = PyGILState_Ensure();
 
 	PyObject* hax_mod = getModule("hax.types");
 	PyObject* broadcast_tags = PyList_New(0);
+
 	m0_tl_for(hx_links, &hc->hc_links, hxl)
 	{
 		if (!hxl->hxl_is_active)
@@ -949,8 +949,8 @@ PyObject* m0_ha_notify_hax_only(unsigned long long ctx,
 	uint64_t tag;
 
 	msg = _ha_nvec_msg_alloc(&nvec, 0, M0_HA_NVEC_SET);
-	hax_lock(hc);
 
+	hax_lock(hc);
 	PyGILState_STATE gstate;
 	gstate = PyGILState_Ensure();
 
@@ -1021,7 +1021,6 @@ PyObject* m0_hax_stop(unsigned long long ctx, const struct m0_fid *process_fid,
 			PyList_Append(broadcast_tags, instance);
 		}
 	} m0_tl_endfor;
-
 	Py_DECREF(hax_mod);
 	PyGILState_Release(gstate);
 	hax_unlock(hc);

--- a/hax/hax/motr/planner.py
+++ b/hax/hax/motr/planner.py
@@ -25,7 +25,7 @@ from typing import Callable, Deque, Dict, Optional, Set, Tuple, Type
 from hax.log import TRACE
 from hax.message import (AnyEntrypointRequest, BaseMessage, BroadcastHAStates,
                          Die, HaNvecGetEvent, HaNvecSetEvent, ProcessEvent,
-                         SnsOperation)
+                         ProcessHaEvent, SnsOperation)
 from hax.motr.util import LinkedList
 from hax.types import Fid
 
@@ -324,6 +324,8 @@ class WorkPlanner:
         if not self.state.next_group_commands:
             # current group is empty -> join it freely
             return False
+        if isinstance(cmd, ProcessEvent):
+            return False
         if isinstance(cmd, HaNvecGetEvent):
             # HaNvecGetEvent can be done in parallel to any other commands.
             # No need to form the new group for it.
@@ -339,6 +341,8 @@ class WorkPlanner:
             # e.g. BroadcastHAStates, then the wait needs to explicit.
             # For example, see FirstEntrypoint request code in hax/handler.py.
             return False
+        if isinstance(cmd, ProcessHaEvent):
+            return True
         if isinstance(cmd, BroadcastHAStates):
             return True
 

--- a/hax/hax/queue/__init__.py
+++ b/hax/hax/queue/__init__.py
@@ -3,15 +3,17 @@ import logging
 from queue import Queue
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from hax.message import (BaseMessage, BroadcastHAStates, SnsDiskAttach,
-                         SnsDiskDetach, SnsRebalancePause, SnsRebalanceResume,
-                         SnsRebalanceStart, SnsRebalanceStop, SnsRepairPause,
+from hax.message import (BaseMessage, BroadcastHAStates, ProcessHaEvent,
+                         SnsDiskAttach, SnsDiskDetach, SnsRebalancePause,
+                         SnsRebalanceResume, SnsRebalanceStart,
+                         SnsRebalanceStop, SnsRepairPause,
                          SnsRepairResume, SnsRepairStart, SnsRepairStop)
+from hax.motr import Motr
 from hax.motr.delivery import DeliveryHerald
 from hax.motr.planner import WorkPlanner
 from hax.queue.confobjutil import ConfObjUtil
 from hax.types import (Fid, HaLinkMessagePromise, HAState, MessageId,
-                       ObjHealth)
+                       ObjHealth, m0HaProcessEvent, m0HaProcessType)
 
 LOG = logging.getLogger('hax')
 
@@ -24,10 +26,11 @@ class BQProcessor:
     This is the place where a real processing logic should be located.
     """
     def __init__(self, planner: WorkPlanner, delivery_herald: DeliveryHerald,
-                 conf_obj_util: ConfObjUtil):
+                 motr: Motr, conf_obj_util: ConfObjUtil):
         self.planner = planner
         self.confobjutil = conf_obj_util
         self.herald = delivery_herald
+        self.motr = motr
 
     def process(self, message: Tuple[int, Any]) -> None:
         (i, msg) = message
@@ -56,12 +59,33 @@ class BQProcessor:
             'M0_HA_MSG_NVEC': self.handle_device_state_set,
             'SNS_OP': self.handle_sns_op,
             'STOB_IOQ_ERROR': self.handle_ioq_stob_error,
+            'PROCESS-STATE-UPDATE': self.handle_process_state_update
         }
         if msg_type not in handlers:
             LOG.warn('Unsupported message type given: %s. Message skipped.',
                      msg_type)
             return
         handlers[msg_type](payload)
+
+    def handle_process_state_update(self, payload: Dict[str, Any]) -> None:
+        def _get_ha_state() -> Optional[HAState]:
+            try:
+                fid = Fid.parse(payload['fid'])
+                state_val = getattr(m0HaProcessEvent, payload['state'])
+                state = state_val.event_to_svchealth()
+            except (KeyError, AttributeError) as error:
+                LOG.error('Invalid json payload, no key (%s) present', error)
+                return None
+            return HAState(fid, status=state)
+
+        hastate: Optional[HAState] = _get_ha_state()
+        LOG.debug('ProcessStateUpdate process fid: %s state: %s, type: %s',
+                  payload['fid'], payload['state'], payload['type'])
+        self.planner.add_command(
+            ProcessHaEvent(fid=Fid.parse(payload['fid']),
+                           proc_type=getattr(m0HaProcessType,
+                                             payload['type']),
+                           states=[hastate]))
 
     def handle_device_state_set(self, payload: Dict[str, Any]) -> None:
         # To add check for multiple object entries in a payload.

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -39,6 +39,7 @@ from hax.message import (BaseMessage, BroadcastHAStates, SnsDiskAttach,
 from hax.common import HaxGlobalState
 from hax.motr.delivery import DeliveryHerald
 from hax.exception import HAConsistencyException
+from hax.motr import Motr
 from hax.motr.planner import WorkPlanner
 from hax.queue import BQProcessor
 from hax.queue.confobjutil import ConfObjUtil
@@ -358,11 +359,13 @@ class ServerRunner:
         self,
         planner: WorkPlanner,
         herald: DeliveryHerald,
+        motr: Motr,
         consul_util: ConsulUtil,
         hax_state: HaxGlobalState
     ):
         self.consul_util = consul_util
         self.herald = herald
+        self.motr = motr
         self.planner = planner
         self.hax_state = hax_state
 
@@ -393,6 +396,7 @@ class ServerRunner:
             conf_obj = ConfObjUtil(self.consul_util)
             planner = self.planner
             herald = self.herald
+            motr = self.motr
             consul_util = self.consul_util
 
             app = self._create_server()
@@ -405,7 +409,8 @@ class ServerRunner:
                 web.post(
                     '/watcher/bq',
                     process_bq_update(inbox_filter,
-                                      BQProcessor(planner, herald, conf_obj))),
+                                      BQProcessor(planner, herald, motr,
+                                                  conf_obj))),
                 web.post(
                     '/watcher/processes',
                     process_state_update(planner)),

--- a/hax/hax/types.py
+++ b/hax/hax/types.py
@@ -319,13 +319,13 @@ class HaLinkMessagePromise:
 class ObjHealth(Enum):
     FAILED = (0, HaNoteStruct.M0_NC_FAILED)
     OK = (1, HaNoteStruct.M0_NC_ONLINE)
-    UNKNOWN = (2, HaNoteStruct.M0_NC_TRANSIENT)
-    OFFLINE = (3, HaNoteStruct.M0_NC_TRANSIENT)
-    STOPPED = (4, HaNoteStruct.M0_NC_TRANSIENT)
-    RECOVERING = (5, HaNoteStruct.M0_NC_DTM_RECOVERING)
-    REPAIR = (6, HaNoteStruct.M0_NC_REPAIR)
-    REPAIRED = (7, HaNoteStruct.M0_NC_REPAIRED)
-    REBALANCE = (8, HaNoteStruct.M0_NC_REBALANCE)
+    OFFLINE = (2, HaNoteStruct.M0_NC_TRANSIENT)
+    STOPPED = (3, HaNoteStruct.M0_NC_TRANSIENT)
+    RECOVERING = (4, HaNoteStruct.M0_NC_DTM_RECOVERING)
+    REPAIR = (5, HaNoteStruct.M0_NC_REPAIR)
+    REPAIRED = (6, HaNoteStruct.M0_NC_REPAIRED)
+    REBALANCE = (7, HaNoteStruct.M0_NC_REBALANCE)
+    UNKNOWN = (8, HaNoteStruct.M0_NC_TRANSIENT)
 
     def __repr__(self):
         """Return human-readable constant name (useful in log output)."""
@@ -338,8 +338,8 @@ class ObjHealth(Enum):
         ObjHealth.
         """
         for i in list(ObjHealth):
-            (_, note) = i.value
-            if note == state:
+            # (_, note) = i.value
+            if i.value[1] == state:
                 return i
         return ObjHealth.UNKNOWN
 
@@ -385,8 +385,8 @@ class m0HaProcessEvent(IntEnum):
             m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED: ObjHealth.RECOVERING,
             m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED:
                 ObjHealth.OK,
-            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING: ObjHealth.FAILED,
-            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED: ObjHealth.FAILED}
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPING: ObjHealth.OFFLINE,
+            m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED: ObjHealth.OFFLINE}
         return m0ProcessEvToSvcHealth[self]
 
 
@@ -416,7 +416,7 @@ class m0HaProcessType(IntEnum):
 
 
 class m0HaObjState(IntEnum):
-    M0_NC_UNKNOWN = HaNoteStruct.M0_NC_TRANSIENT
+    M0_NC_UNKNOWN = HaNoteStruct.M0_NC_UNKNOWN
     M0_NC_ONLINE = HaNoteStruct.M0_NC_ONLINE
     M0_NC_FAILED = HaNoteStruct.M0_NC_FAILED
     M0_NC_TRANSIENT = HaNoteStruct.M0_NC_TRANSIENT

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -358,6 +358,7 @@ class ConsulUtil:
             ObjT.ENCLOSURE.name: self.get_encl_state,
             ObjT.CONTROLLER.name: self.get_ctrl_state
         }
+        self.all_node_items: Dict[Any, Any] = {}
 
     def get_consul_node(self, node: str) -> Optional[str]:
         LOG.debug('fetching consul node for node: %s', node)
@@ -496,7 +497,7 @@ class ConsulUtil:
     @repeat_if_fails()
     def fid_to_endpoint(self, proc_fid: Fid) -> Optional[str]:
         pfidk = int(proc_fid.key)
-        process_items = self.get_all_nodes()
+        process_items = self.get_all_nodes_cached()
         regex = re.compile(
             f'^m0conf\\/.*\\/processes\\/{pfidk}\\/endpoint')
         for proc_item in process_items:
@@ -577,6 +578,11 @@ class ConsulUtil:
                                     kv_cache=kv_cache)
         return node_items
 
+    def get_all_nodes_cached(self):
+        if not self.all_node_items:
+            self.all_node_items = self.get_all_nodes()
+        return self.all_node_items
+
     def get_session_node(self, session_id: str) -> str:
         try:
             session = self.cns.session.info(session_id)[1]
@@ -648,7 +654,7 @@ class ConsulUtil:
     def get_services_by_parent_process(self,
                                        process_fid: Fid,
                                        kv_cache=None) -> List[FidWithType]:
-        node_items = self.get_all_nodes(kv_cache=kv_cache)
+        node_items = self.get_all_nodes_cached()
         fidk = str(process_fid.key)
 
         # This is the RegExp to match the keys in Consul KV that describe
@@ -679,7 +685,7 @@ class ConsulUtil:
     def get_disks_by_parent_process(self,
                                     process_fid: Fid,
                                     svc_fid: Fid) -> List[Fid]:
-        node_items = self.get_all_nodes()
+        node_items = self.get_all_nodes_cached()
         # This is the RegExp to match the keys in Consul KV that describe
         # the Motr processes and services that are enclosed into the Motr
         # process that has the given process_fid.
@@ -708,7 +714,7 @@ class ConsulUtil:
 
     @repeat_if_fails()
     def is_proc_client(self, process_fid: Fid) -> bool:
-        node_items = self.get_all_nodes()
+        node_items = self.get_all_nodes_cached()
         fidk = str(process_fid.key)
 
         # This is the RegExp to match the keys in Consul KV that describe
@@ -788,7 +794,7 @@ class ConsulUtil:
         obj_state: int = HaNoteStruct.M0_NC_ONLINE
         if obj_t.name in (ObjT.PROCESS.name, ObjT.SERVICE.name):
             # 'node/<node_name>/process/<process_fidk>/service/type'
-            node_items = self.get_all_nodes(kv_cache=kv_cache)
+            node_items = self.get_all_nodes_cached()
             # TODO [KN] This code is too cryptic. To be refactored.
             keys = getattr(self, 'get_{}_keys'.format(obj_t.name.lower()))(
                 node_items, fidk)
@@ -808,7 +814,6 @@ class ConsulUtil:
             obj_state = self.get_proc_svc_conf_obj_status(obj_t,
                                                           fidk,
                                                           kv_cache=kv_cache)
-
         elif obj_t.name in device_obj_types:
             obj_state = device_obj_types[obj_t.name](obj_t,
                                                      fidk,
@@ -934,8 +939,21 @@ class ConsulUtil:
                 f'Failed to get {node} node health') from e
 
     @repeat_if_fails()
+    def get_proc_node_health(self, proc_fid: Fid) -> ObjHealth:
+        node = self.get_process_node(proc_fid)
+        node_data = self.get_node_health_details(node)
+        if not node_data:
+            return ObjHealth.OFFLINE
+        LOG.debug('node data: %s', node_data)
+        node_status = str(node_data[0]['Status'])
+        if node_status != 'passing':
+            return ObjHealth.OFFLINE
+        return ObjHealth.OK
+
+    @repeat_if_fails()
     @uses_consul_cache
-    def get_node_fid(self, node: str, kv_cache=None) -> Optional[Fid]:
+    def get_node_fid(self, node: str, kv_cache=None,
+                     use_cache=True) -> Optional[Fid]:
         """
         Returns the fid of the given node.
 
@@ -946,7 +964,10 @@ class ConsulUtil:
         # m0conf/nodes/
         # 0x6e00000000000001:0x3:{"name": "ssc-vm-1623.colo.seagate.com",
         #                         "state": "M0_NC_UNKNOWN"}
-        node_items = self.get_all_nodes(kv_cache=kv_cache)
+        if not use_cache:
+            node_items = self.get_all_nodes(kv_cache=kv_cache)
+        else:
+            node_items = self.get_all_nodes_cached()
         for item in node_items:
             key = item['Key']
             key_split = key.split('/')
@@ -1069,7 +1090,7 @@ class ConsulUtil:
         # Example key m0conf/nodes/0x6e00000000000001:0x3/processes/
         #   0x7200000000000001:0x15/services/0x7300000000000001:0x17/sdevs/
         #   0x6400000000000001:0x18:{"path": "/dev/sdc", "state": "offline"}
-        sdev_items = self.get_all_nodes(kv_cache=kv_cache)
+        sdev_items = self.get_all_nodes_cached()
         regex = re.compile(
             f'^m0conf\\/.*\\/processes\\/{ioservice_fid}\\/.*\\/sdevs\\/.*$')
         sdev_fids = []
@@ -1276,6 +1297,19 @@ class ConsulUtil:
             }
         return device_ha_state_map[status].name
 
+    def ha_note_to_objhealth(self, state: int) -> ObjHealth:
+        ha_note_to_objhealth = {
+            HaNoteStruct.M0_NC_FAILED: ObjHealth.FAILED,
+            HaNoteStruct.M0_NC_ONLINE: ObjHealth.OK,
+            HaNoteStruct.M0_NC_TRANSIENT: ObjHealth.OFFLINE,
+            HaNoteStruct.M0_NC_DTM_RECOVERING: ObjHealth.RECOVERING,
+            HaNoteStruct.M0_NC_REPAIR: ObjHealth.REPAIR,
+            HaNoteStruct.M0_NC_REPAIRED: ObjHealth.REPAIRED,
+            HaNoteStruct.M0_NC_REBALANCE: ObjHealth.REBALANCE,
+            HaNoteStruct.M0_NC_UNKNOWN: ObjHealth.UNKNOWN
+        }
+        return ha_note_to_objhealth[state]
+
     @repeat_if_fails()
     def set_node_state(self,
                        node_fid: Fid,
@@ -1287,7 +1321,7 @@ class ConsulUtil:
         #    "value": "{\"name\": \"srvnode-1.data.private\",
         #               \"state\": \"M0_NC_UNKNOWN\"}"
         # }
-        node_items = self.get_all_nodes(kv_cache=kv_cache)
+        node_items = self.get_all_nodes_cached()
         regex = re.compile(f'^m0conf/nodes/{node_fid}$')
         for node in node_items:
             match_result = re.match(regex, node['Key'])
@@ -1366,14 +1400,7 @@ class ConsulUtil:
             val = json.loads(ctrl['Value'])
             state = val['state']
             LOG.debug('Controller=%s state=%s', ctrl_fid, state)
-            if state in (m0HaObjState.M0_NC_TRANSIENT.name,
-                         m0HaObjState.M0_NC_FAILED.name):
-                node = self.get_ctrl_node(ctrl_fid, kv_cache=kv_cache)
-                if (self.get_node_health_status(node, kv_cache=kv_cache) ==
-                        'passing'):
-                    return m0HaObjState.M0_NC_ONLINE
-            else:
-                return m0HaObjState.parse(state)
+            return m0HaObjState.parse(state)
         return m0HaObjState.M0_NC_ONLINE
 
     @repeat_if_fails()
@@ -1391,14 +1418,7 @@ class ConsulUtil:
             val = json.loads(encl['Value'])
             state = val['state']
             LOG.debug('Enclosure=%s state=%s', encl_fid, state)
-            if state in (m0HaObjState.M0_NC_TRANSIENT.name,
-                         m0HaObjState.M0_NC_FAILED.name):
-                node = self.get_encl_node(encl_fid, kv_cache=kv_cache)
-                if (self.get_node_health_status(node, kv_cache=kv_cache) ==
-                        'passing'):
-                    return m0HaObjState.M0_NC_ONLINE
-            else:
-                return m0HaObjState.parse(state)
+            return m0HaObjState.parse(state)
         return m0HaObjState.M0_NC_ONLINE
 
     @repeat_if_fails()
@@ -1412,16 +1432,8 @@ class ConsulUtil:
         if node:
             val = json.loads(node['Value'])
             state = val['state']
-            node_name = val['name']
             LOG.debug('Node=%s state=%s', node_fid, state)
-            if state in (m0HaObjState.M0_NC_TRANSIENT.name,
-                         m0HaObjState.M0_NC_FAILED.name):
-                if (self.get_node_health_status(node_name,
-                                                kv_cache=kv_cache) ==
-                        'passing'):
-                    return m0HaObjState.M0_NC_ONLINE
-            else:
-                return m0HaObjState.parse(state)
+            return m0HaObjState.parse(state)
         return m0HaObjState.M0_NC_ONLINE
 
     @repeat_if_fails()
@@ -1611,7 +1623,11 @@ class ConsulUtil:
                 continue
             val = json.loads(sdev['Value'])
             LOG.debug('Sdev=%s state=%s', str(sdev_fid), val['state'])
-            return drive_to_ha_state_map[str(val['state']).lower()]
+            if str(val['state']).lower() not in ['failed', 'repairing',
+                                                 'repaired', 'rebalancing']:
+                return HaNoteStruct.M0_NC_ONLINE
+            else:
+                return drive_to_ha_state_map[str(val['state']).lower()]
 
         return HaNoteStruct.M0_NC_ONLINE
 
@@ -1685,7 +1701,7 @@ class ConsulUtil:
         # 4. Create sdev fid from sdev fid key.
         # sdev_items = self.kv.kv_get('m0conf/nodes', recurse=True)
         node_fid = self.get_node_fid(node_name)
-        sdev_items = self.get_all_nodes()
+        sdev_items = self.get_all_nodes_cached()
         for x in sdev_items:
             if (f'm0conf/nodes/{node_fid}' in x['Key'] and
                     '/sdevs/' in x['Key']):
@@ -1762,7 +1778,7 @@ class ConsulUtil:
     def drive_name_to_id(self, uid: str) -> str:
         drive_id = ''
         # 'm0conf/nodes/<node_name>/processes/<process_fidk>/disks/<disk_uuid>'
-        node_items = self.get_all_nodes()
+        node_items = self.get_all_nodes_cached()
         for x in node_items:
             if '/disks/' in x['Key'] and uid in x['Key']:
                 drive_id = x['Value']
@@ -1826,7 +1842,7 @@ class ConsulUtil:
         svc_to_motr_status_map = {
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STARTING'):
             local_remote_health_ret(ObjHealth.UNKNOWN,
-                                    ObjHealth.OFFLINE),
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STOPPING'):
             local_remote_health_ret(ObjHealth.UNKNOWN,
                                     ObjHealth.OFFLINE),
@@ -1837,8 +1853,8 @@ class ConsulUtil:
             local_remote_health_ret(ObjHealth.OK,
                                     ObjHealth.OK),
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STOPPED'):
-            local_remote_health_ret(ObjHealth.OK,
-                                    ObjHealth.OFFLINE),
+            local_remote_health_ret(ObjHealth.UNKNOWN,
+                                    ObjHealth.UNKNOWN),
             cur_consul_status('passing', 'Unknown'):
             local_remote_health_ret(ObjHealth.UNKNOWN,
                                     ObjHealth.UNKNOWN),
@@ -1865,8 +1881,8 @@ class ConsulUtil:
                 node, kv_cache=kv_cache)
             if not node_data:
                 return ObjHealth.OFFLINE
+            LOG.debug('node data: %s', node_data)
             node_status = str(node_data[0]['Status'])
-            # if node_status != 'passing' or (not self.is_node_alive(
             if node_status != 'passing':
                 return ObjHealth.OFFLINE
             status = ObjHealth.UNKNOWN
@@ -1906,7 +1922,7 @@ class ConsulUtil:
             # node_items = self.kv.kv_get('m0conf/nodes',
             #                             recurse=True,
             #                             kv_cache=kv_cache)
-            node_items = self.get_all_nodes(kv_cache=kv_cache)
+            node_items = self.get_all_nodes_cached()
             LOG.log(TRACE, 'node items: %s', node_items)
             if ObjT.PROCESS.value == proc_base_fid.container:
                 keys = self.get_process_keys(node_items, fidk)
@@ -1977,7 +1993,7 @@ class ConsulUtil:
 
     def get_service_process_fid(self, svc_fid: Fid, kv_cache=None) -> Fid:
         assert ObjT.SERVICE.value == svc_fid.container
-        node_items = self.get_all_nodes(kv_cache=kv_cache)
+        node_items = self.get_all_nodes_cached()
         keys = self.get_service_keys(node_items, svc_fid.key)
         if len(keys) != 1:
             raise RuntimeError(f'svc_fid:{svc_fid} len:{len(keys)}')
@@ -2005,8 +2021,6 @@ class ConsulUtil:
     @repeat_if_fails()
     def ensure_ioservices_running(self) -> List[bool]:
         statuses = self.get_m0d_statuses()
-        LOG.debug('The following statuses received: %s', statuses)
-        # started = ['M0_CONF_HA_PROCESS_STARTED' == v[1] for v in statuses]
         started = [ObjHealth.OK == v[1] for v in statuses]
         return started
 
@@ -2020,11 +2034,7 @@ class ConsulUtil:
             wait_for_event(event, 2)
 
     def m0ds_stopping(self) -> bool:
-        # statuses = self.get_m0d_statuses()
         statuses = self.get_m0d_statuses()
-        LOG.debug('The following statuses received: %s', statuses)
-        # stopping = [v[1] in ('M0_CONF_HA_PROCESS_STOPPING',
-        #                      'M0_CONF_HA_PROCESS_STOPPED') for v in statuses]
         stopping = [v[1] in (ObjHealth.OFFLINE,
                              ObjHealth.STOPPED) for v in statuses]
         return all(stopping)
@@ -2082,18 +2092,51 @@ class ConsulUtil:
             fin_state = 'offline'
         return fin_state
 
-    def svcHealthToM0Status(self, svc_health: ObjHealth):
-        svcHealthToM0status: dict = {
-            ObjHealth.OK: m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
+    def objHealthToProcessEvent(self, health: ObjHealth):
+        healthToProcessEvent: dict = {
+            ObjHealth.RECOVERING: m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
+            ObjHealth.OK: m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED,
             ObjHealth.FAILED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
+            ObjHealth.OFFLINE: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
             ObjHealth.UNKNOWN: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
             ObjHealth.STOPPED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED
         }
-        return svcHealthToM0status[svc_health]
+        return healthToProcessEvent[health]
+
+    def processEventToObjHealth(self, proc_type: m0HaProcessType,
+                                proc_event: m0HaProcessEvent) -> ObjHealth:
+        motr_to_svc_status = {
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
+                    ObjHealth.OK),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0MKFS,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
+                    ObjHealth.FAILED),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
+                    ObjHealth.RECOVERING),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED): (
+                    ObjHealth.OK),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_M0D,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
+                    ObjHealth.FAILED),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED): (
+                    ObjHealth.RECOVERING),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED): (
+                    ObjHealth.OK),
+            (m0HaProcessType.M0_CONF_HA_PROCESS_OTHER,
+                m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED): (
+                    ObjHealth.FAILED)}
+        LOG.debug('chp_type=%d chp_event=%d',
+                  proc_type, proc_event)
+        return motr_to_svc_status[(proc_type, proc_event)]
 
     def service_health_to_m0dstatus_update(self, proc_fid: Fid,
                                            svc_health: ObjHealth):
-        ev = ConfHaProcess(chp_event=self.svcHealthToM0Status(svc_health),
+        ev = ConfHaProcess(chp_event=self.objHealthToProcessEvent(svc_health),
                            chp_type=int(
                                 m0HaProcessType.M0_CONF_HA_PROCESS_M0D),
                            chp_pid=0,
@@ -2125,7 +2168,7 @@ class ConsulUtil:
         # Example key is as follows
         # m0conf/nodes/0x6e00000000000001:0x3/processes/0x7200000000000001:
         # 0x15:{"name": "m0_server", "state": "M0_NC_UNKNOWN"}
-        node_items = self.get_all_nodes()
+        node_items = self.get_all_nodes_cached()
         regex = re.compile(
             f'^m0conf\\/nodes\\/.*\\/processes\\/{proc_base_fid}$')
         for item in node_items:
@@ -2171,12 +2214,14 @@ class ConsulUtil:
         leader = self.get_leader_node()
         # The call doesn't communicate via Consul REST API
         this_node = self.get_local_nodename()
+        LOG.log(TRACE, 'am_i_rc: local node: %s leader: %s',
+                this_node, leader)
         return leader == this_node
 
     @repeat_if_fails()
     def init_motr_processes_status(self):
         local_node = self.get_local_nodename()
-        fid = self.get_node_fid(local_node)
+        fid = self.get_node_fid(local_node, use_cache=False)
         if not fid or fid is None:
             raise HAConsistencyException(
                 f'node fid not available yet for {local_node}')

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -1623,8 +1623,8 @@ class ConsulUtil:
                 continue
             val = json.loads(sdev['Value'])
             LOG.debug('Sdev=%s state=%s', str(sdev_fid), val['state'])
-            if str(val['state']).lower() not in ['failed', 'repairing',
-                                                 'repaired', 'rebalancing']:
+            if str(val['state']).lower() in ['unknown', 'm0_nc_unknown',
+                                             'dtm_recovering']:
                 return HaNoteStruct.M0_NC_ONLINE
             else:
                 return drive_to_ha_state_map[str(val['state']).lower()]

--- a/hax/helper/ping.py
+++ b/hax/helper/ping.py
@@ -24,7 +24,7 @@ def main():
     try:
         hostname = sys.argv[1]
         port = sys.argv[2]
-        if tcpping(host=hostname, port=port, timeout=1):
+        if tcpping(host=hostname, port=port, timeout=10):
             sys.exit(0)
     except Exception:
         sys.exit(1)

--- a/hax/test/integration/test_server.py
+++ b/hax/test/integration/test_server.py
@@ -23,9 +23,10 @@ from typing import List
 import inject
 import pytest
 import simplejson
+from unittest.mock import Mock
 from hax.common import HaxGlobalState
 from hax.message import BroadcastHAStates, StobId, StobIoqError
-from hax.motr import WorkPlanner
+from hax.motr import WorkPlanner, Motr
 from hax.motr.delivery import DeliveryHerald
 from hax.server import ServerRunner
 from hax.types import Fid, HAState, MessageId, ObjHealth
@@ -67,7 +68,9 @@ async def logging_support(hax_state: HaxGlobalState):
 async def hax_client(mocker, aiohttp_client, herald, planner, consul_util,
                      loop):
     state = inject.instance(HaxGlobalState)
-    srv = ServerRunner(planner, herald, consul_util, state)
+    ffi = Mock(spec=['init_motr_api'])
+    motr = Motr(ffi, None, None, consul_util)
+    srv = ServerRunner(planner, herald, motr, consul_util, state)
     srv._configure()
     return await aiohttp_client(srv.app)
 

--- a/hax/test/test_types.py
+++ b/hax/test/test_types.py
@@ -38,7 +38,7 @@ def test_obj_health_to_ha_note(ha_note: int, health: ObjHealth):
 
 @pytest.mark.parametrize('ha_note,health', [(h.M0_NC_ONLINE, o.OK),
                                             (h.M0_NC_FAILED, o.FAILED),
-                                            (h.M0_NC_TRANSIENT, o.UNKNOWN),
+                                            (h.M0_NC_TRANSIENT, o.OFFLINE),
                                             (h.M0_NC_UNKNOWN, o.UNKNOWN),
                                             (h.M0_NC_REPAIR, o.REPAIR),
                                             (h.M0_NC_REPAIRED, o.REPAIRED),

--- a/utils/update-consul-conf
+++ b/utils/update-consul-conf
@@ -347,6 +347,7 @@ append_hax_svc() {
                         \"--host\", \"$host\",
                         \"--conf-dir\", \"$conf_dir\" ],
             \"interval\": \"1s\",
+            \"timeout\": \"30s\",
             \"status\": \"warning\"
           }
         ]
@@ -376,6 +377,7 @@ append_confd_svc() {
                         \"--host\", \"$host\",
                         \"--conf-dir\", \"$conf_dir\" ],
             \"interval\": \"1s\",
+            \"timeout\": \"30s\",
             \"status\": \"warning\"
           }
         ]
@@ -414,6 +416,7 @@ append_ios_svc() {
                         \"--host\", \"$host\",
                         \"--conf-dir\", \"$conf_dir\" ],
             \"interval\": \"1s\",
+            \"timeout\": \"30s\",
             \"status\": \"warning\"
           }
         ]
@@ -460,6 +463,7 @@ append_motr_client_svc() {
                         \"--host\", \"$host\",
                         \"--conf-dir\", \"$conf_dir\" ],
             \"interval\": \"1s\",
+            \"timeout\": \"30s\",
             \"status\": \"warning\"
           }
         ]
@@ -510,84 +514,6 @@ if [[ $CONFD_IDs ]]; then
                                 "--log-dir",
                                 "TMP_LOG_DIR" ]}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
 fi
-
-append_hax_svc_watch() {
-    local id=$1
-    local fid=$(id2fid $id)
-    local key="processes/$fid"
-
-    jq --arg k "$key" '.watches += [{"type": "key",
-                          "key": $k,
-                          "handler_type": "http",
-                          "http_handler_config": {
-                          "path": "HAX_HTTP_PROTOCOL://localhost:HAX_HTTP_PORT/watcher/processes",
-                          "method": "POST",
-                          "tls_skip_verify": true,
-                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
-}
-
-append_confd_svc_watch() {
-    local id=$1
-    local fid=$(id2fid $id)
-    local key="processes/$fid"
-
-    jq --arg k "$key" '.watches += [{"type": "key",
-                          "key": $k,
-                          "handler_type": "http",
-                          "http_handler_config": {
-                          "path": "HAX_HTTP_PROTOCOL://localhost:HAX_HTTP_PORT/watcher/processes",
-                          "method": "POST",
-                          "tls_skip_verify": true,
-                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
-}
-
-append_ios_svc_watch() {
-    local id=$1
-    local fid=$(id2fid $id)
-    local key="processes/$fid"
-
-    jq --arg k "$key" '.watches += [{"type": "key",
-                          "key": $k,
-                          "handler_type": "http",
-                          "http_handler_config": {
-                          "path": "HAX_HTTP_PROTOCOL://localhost:HAX_HTTP_PORT/watcher/processes",
-                          "method": "POST",
-                          "tls_skip_verify": true,
-                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
-}
-
-append_motr_client_watch() {
-    local id=$1
-    local fid=$(id2fid $id)
-    local key="processes/$fid"
-
-    jq --arg k "$key" '.watches += [{"type": "key",
-                          "key": $k,
-                          "handler_type": "http",
-                          "http_handler_config": {
-                          "path": "HAX_HTTP_PROTOCOL://localhost:HAX_HTTP_PORT/watcher/processes",
-                          "method": "POST",
-                          "tls_skip_verify": true,
-                          "timeout": "10s"}}]' $tmpfile > $tmpfile.tmp && mv -f $tmpfile.tmp $tmpfile
-}
-
-for id in $HAX_ID_ALL; do
-    append_hax_svc_watch $id
-done
-
-for id in $CONFD_IDs_ALL; do
-    append_confd_svc_watch $id
-done
-
-for id in $IOS_IDs_ALL; do
-    append_ios_svc_watch $id
-done
-
-for id in $MOTR_CLIENT_IDS_ALL; do
-    proc=$(echo $id| cut -d':' -f 1)
-    client_id=$(echo $id| cut -d':' -f 2)
-    append_motr_client_watch $client_id
-done
 
 sed -i "s|TMP_CONF_DIR|$conf_dir|" $tmpfile
 sed -i "s|TMP_LOG_DIR|$log_dir|" $tmpfile


### PR DESCRIPTION
    CORTX-33628: Hare ha events are not ordered
    Hare monitors motr and rgw processes for failures and
    broadcasts the same to the entire cluster. But presently
    they are not ordered and there's not way to determine the
    order in which they were processed across the cluster.
    Out of order events affects IO post or during failures
    as events are not delivered properly.
    Worst, it is extremely difficult to debug the same through
    several logs.
    Thus, it is important to maintain the event order and logging.

    Solution:
    - Use broadcast queue to broadcast events and maintain order.
    - Let RC only handle the node failure events.
    - Let local node handle the process failure event.
    - Increase consul service watcher interval and set timeout
      for probe to avoid frequent Consul watcher events.
    - Guard from delayed Consul events by checking process
      node availability and allowing process local node to
      process the event if the corresponding node's alive.