### PR TITLE
CORTX-32421: [2.0.0-837-07603][v0.7.0][27N] Server pods going into CrashLoopBackOff state during deployment

### DIFF
--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -799,7 +799,7 @@ class ConsulUtil:
             node_val = self.kv.kv_get(node_key, kv_cache=kv_cache)
             data = node_val['Value']
             node_name: str = json.loads(data)['name']
-            if (self.get_node_health_status(node_name) !=
+            if (self.get_node_health_status(node_name, kv_cache=kv_cache) !=
                     'passing'):
                 obj_state = ObjHealth.OFFLINE.to_ha_note_status()
 
@@ -898,8 +898,10 @@ class ConsulUtil:
             raise HAConsistencyException(
                 'Failed to members data from Consul') from e
 
+    @uses_consul_cache
     def get_node_health_details(
-            self, node: str) -> Optional[List[Dict[str, Any]]]:
+            self, node: str,
+            kv_cache=None) -> Optional[List[Dict[str, Any]]]:
         """
         Returns the list of health checks (as it is reported by Consul, see
         'Health: node' section at
@@ -914,13 +916,14 @@ class ConsulUtil:
             raise HAConsistencyException(
                 f'Failed to get {node} node health: {e}')
 
-    def get_node_health_status(self, node: str) -> str:
+    @uses_consul_cache
+    def get_node_health_status(self, node: str, kv_cache=None) -> str:
         """
         Returns the node health status string returned by Consul.
         Possible return values: passing, warning, critical
         """
         try:
-            node_data = self.get_node_health_details(node)
+            node_data = self.get_node_health_details(node, kv_cache=kv_cache)
             # if not node_data or (not self.is_node_alive(node,
             #                                             kv_cache=kv_cache)):
             if not node_data:
@@ -974,6 +977,7 @@ class ConsulUtil:
             return name
         return None
 
+    @repeat_if_fails()
     @uses_consul_cache
     def get_node_name_by_machineid(self,
                                    machineid: str,
@@ -994,7 +998,7 @@ class ConsulUtil:
     def get_machineid_by_nodename(self,
                                   nodename: str,
                                   kv_cache=None,
-                                  allow_null=False) -> Optional[str]:
+                                  allow_null=False):
         """
         Returns the machine id by its node-name value or None if the given
         node-name doesn't correspond to any node.
@@ -1365,7 +1369,7 @@ class ConsulUtil:
             if state in (m0HaObjState.M0_NC_TRANSIENT.name,
                          m0HaObjState.M0_NC_FAILED.name):
                 node = self.get_ctrl_node(ctrl_fid, kv_cache=kv_cache)
-                if (self.get_node_health_status(node) ==
+                if (self.get_node_health_status(node, kv_cache=kv_cache) ==
                         'passing'):
                     return m0HaObjState.M0_NC_ONLINE
             else:
@@ -1390,7 +1394,7 @@ class ConsulUtil:
             if state in (m0HaObjState.M0_NC_TRANSIENT.name,
                          m0HaObjState.M0_NC_FAILED.name):
                 node = self.get_encl_node(encl_fid, kv_cache=kv_cache)
-                if (self.get_node_health_status(node) ==
+                if (self.get_node_health_status(node, kv_cache=kv_cache) ==
                         'passing'):
                     return m0HaObjState.M0_NC_ONLINE
             else:
@@ -1412,7 +1416,8 @@ class ConsulUtil:
             LOG.debug('Node=%s state=%s', node_fid, state)
             if state in (m0HaObjState.M0_NC_TRANSIENT.name,
                          m0HaObjState.M0_NC_FAILED.name):
-                if (self.get_node_health_status(node_name) ==
+                if (self.get_node_health_status(node_name,
+                                                kv_cache=kv_cache) ==
                         'passing'):
                     return m0HaObjState.M0_NC_ONLINE
             else:
@@ -1702,20 +1707,22 @@ class ConsulUtil:
                            kv_cache=None) -> MotrConsulProcInfo:
         proc_base_fid = self.get_process_base_fid(fid)
         key = f'processes/{proc_base_fid}'
-        status = self.kv.kv_get(key, allow_null=True)
+        status = self.kv.kv_get(key, kv_cache=kv_cache, allow_null=True)
         if status:
             val = json.loads(status['Value'])
             return MotrConsulProcInfo(val['state'], val['type'])
         else:
             return MotrConsulProcInfo('Unknown', 'Unknown')
 
+    @uses_consul_cache
     def get_process_status_local(self,
                                  fid: Fid,
-                                 proc_node=None) -> MotrConsulProcInfo:
+                                 proc_node=None,
+                                 kv_cache=None) -> MotrConsulProcInfo:
         proc_base_fid = self.get_process_base_fid(fid)
         this_node = self.get_local_nodename()
         key = f'{this_node}/processes/{proc_base_fid}'
-        status = self.kv.kv_get(key, allow_null=True)
+        status = self.kv.kv_get(key, kv_cache=kv_cache, allow_null=True)
         if status:
             val = json.loads(status['Value'])
             return MotrConsulProcInfo(val['state'], val['type'])
@@ -1829,10 +1836,6 @@ class ConsulUtil:
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_DTM_RECOVERED'):
             local_remote_health_ret(ObjHealth.OK,
                                     ObjHealth.OK),
-            # It is possible that Consul service status was reported as
-            # warning earlier and now the service is back online.
-            # Thus report the status as ONLINE for now. If the service
-            # goes offline Consul will report the same.
             cur_consul_status('passing', 'M0_CONF_HA_PROCESS_STOPPED'):
             local_remote_health_ret(ObjHealth.OK,
                                     ObjHealth.OFFLINE),
@@ -1858,7 +1861,8 @@ class ConsulUtil:
             local_remote_health_ret(ObjHealth.OFFLINE,
                                     ObjHealth.OFFLINE)}
         try:
-            node_data = self.get_node_health_details(node)
+            node_data = self.get_node_health_details(
+                node, kv_cache=kv_cache)
             if not node_data:
                 return ObjHealth.OFFLINE
             node_status = str(node_data[0]['Status'])


### PR DESCRIPTION
**Solution**:
Revert only caching related part of "CORTX-31920: get_machineid_by_nodename() may return None"
This reverts commit fc55437fa66ad992e633b626dd50d51ec0e00c80.

**Testing:**
```
[root@ssc-vm-g2-rhev4-1630 ~]#  kubectl get pods
NAME                                                 READY   STATUS    RESTARTS       AGE
cortx-consul-client-249m4                            1/1     Running   0              121m
cortx-consul-client-4xv9g                            1/1     Running   0              121m
cortx-consul-client-4zpgw                            1/1     Running   0              121m
cortx-consul-client-5wjph                            1/1     Running   0              121m
cortx-consul-client-6dcrx                            1/1     Running   0              121m
cortx-consul-client-6hz65                            1/1     Running   0              121m
cortx-consul-client-6mvt2                            1/1     Running   0              122m
cortx-consul-client-6xwsz                            1/1     Running   0              121m
cortx-consul-client-7ftrb                            1/1     Running   0              121m
cortx-consul-client-8l5kb                            1/1     Running   0              122m
cortx-consul-client-9tjjc                            1/1     Running   0              121m
cortx-consul-client-b84sz                            1/1     Running   0              121m
cortx-consul-client-ck5nt                            1/1     Running   0              121m
cortx-consul-client-cmsk4                            1/1     Running   0              121m
cortx-consul-client-fr267                            1/1     Running   0              121m
cortx-consul-client-ggbml                            1/1     Running   0              121m
cortx-consul-client-ggcqr                            1/1     Running   0              122m
cortx-consul-client-mhzz9                            1/1     Running   0              121m
cortx-consul-client-mljwx                            1/1     Running   0              121m
cortx-consul-client-q85cs                            1/1     Running   0              121m
cortx-consul-client-qhz65                            1/1     Running   0              121m
cortx-consul-client-qn8cv                            1/1     Running   0              121m
cortx-consul-client-t8xx5                            1/1     Running   0              122m
cortx-consul-client-tb8nx                            1/1     Running   0              122m
cortx-consul-client-x9k8q                            1/1     Running   0              121m
cortx-consul-client-zbv4n                            1/1     Running   0              121m
cortx-consul-client-znvt9                            1/1     Running   0              122m
cortx-consul-server-0                                1/1     Running   1 (29m ago)    121m
cortx-consul-server-1                                1/1     Running   2 (36m ago)    122m
cortx-consul-server-2                                1/1     Running   0              122m
cortx-control-d768f869b-dnxnn                        1/1     Running   0              120m
cortx-data-ssc-vm-g2-rhev4-1631-75d797cf67-z6csd     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-1632-6f5b6dc44b-b29n9     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-1635-599696bb5f-zc96m     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-2237-7b47dc5474-vrb6k     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-2238-79596688cf-jrwbq     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3031-c64d5cb7f-2rmll      4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3156-7c76646779-697kp     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3157-5d7787886d-7zm8b     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3158-7c7745df65-dxtcn     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3159-dd866c578-vgf7d      4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3160-67d5c48976-5cp5b     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3161-54c7944f9f-mfcxz     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3162-5f8c868b6-rc8gh      4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3163-7d964c5f85-xkmzm     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3164-7f6896db48-hn2qg     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3165-6bcd4d747f-j5wf5     4/4     Running   0              119m
cortx-data-ssc-vm-g2-rhev4-3166-565958f874-xl8gm     4/4     Running   0              118m
cortx-data-ssc-vm-g2-rhev4-3167-789bf765-m2zww       4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2107-7df849cb59-548qd     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2184-c7c5dd66-4qc6n       4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2198-6c68c759c5-bcmsl     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2278-66b9bfb64d-p7dsp     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2279-7c65c7b96c-jvrx5     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2281-6bd8f58d76-4xsw5     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2282-65b4f45f57-qbnrk     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2283-5576db9574-kpcbs     4/4     Running   0              118m
cortx-data-ssc-vm-g3-rhev4-2284-867568cbbc-ldtf9     4/4     Running   0              118m
cortx-ha-f4cfc7db9-rkbmw                             3/3     Running   0              101m
cortx-kafka-0                                        1/1     Running   2 (123m ago)   124m
cortx-kafka-1                                        1/1     Running   2 (123m ago)   124m
cortx-kafka-2                                        1/1     Running   2 (123m ago)   124m
cortx-server-ssc-vm-g2-rhev4-1631-f8f7d56fb-4s7lz    2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-1632-678fbbc77d-26r5c   2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-1635-6548fcc77b-r6kpd   2/2     Running   1 (96m ago)    112m
cortx-server-ssc-vm-g2-rhev4-2237-79fc8794d6-kfnns   2/2     Running   6 (68m ago)    112m
cortx-server-ssc-vm-g2-rhev4-2238-75b88656d4-499h7   2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-3031-64548767fb-9jxwv   2/2     Running   3 (86m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3156-7dbb485f44-8m4n6   2/2     Running   3 (86m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3157-5658f698b6-96f98   2/2     Running   1 (96m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3158-598ccf6df6-9n22z   2/2     Running   7 (60m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3159-85cbcf4894-l659c   2/2     Running   1 (96m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3160-76b9b4698b-tpm6x   2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-3161-68db4fd8b8-n564f   2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-3162-66cfc7967d-lhxll   2/2     Running   2 (91m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3163-7f6d54d67b-6cwtp   2/2     Running   3 (86m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3164-5999cf96cd-df5sc   2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-3165-7cdc4757c6-pjkdz   2/2     Running   4 (80m ago)    112m
cortx-server-ssc-vm-g2-rhev4-3166-7d686d458-m6bh4    2/2     Running   0              112m
cortx-server-ssc-vm-g2-rhev4-3167-dd7f6dd5b-v85q9    2/2     Running   0              112m
cortx-server-ssc-vm-g3-rhev4-2107-565fbdb568-pf7nj   2/2     Running   3 (86m ago)    112m
cortx-server-ssc-vm-g3-rhev4-2184-55d7dcddf8-w48bq   2/2     Running   3 (86m ago)    112m
cortx-server-ssc-vm-g3-rhev4-2198-5b49b9698d-lz522   2/2     Running   1 (96m ago)    112m
cortx-server-ssc-vm-g3-rhev4-2278-69c55f7d4b-p5cwr   2/2     Running   0              112m
cortx-server-ssc-vm-g3-rhev4-2279-556946b448-qjkg9   2/2     Running   2 (91m ago)    112m
cortx-server-ssc-vm-g3-rhev4-2281-6446b8f666-p76cx   2/2     Running   0              112m
cortx-server-ssc-vm-g3-rhev4-2282-76844b984-wjsn8    2/2     Running   0              112m
cortx-server-ssc-vm-g3-rhev4-2283-79d8f6ffc4-77zt5   2/2     Running   0              112m
cortx-server-ssc-vm-g3-rhev4-2284-56cfd95cbd-gs5v9   2/2     Running   3 (86m ago)    112m
cortx-zookeeper-0                                    1/1     Running   0              124m
cortx-zookeeper-1                                    1/1     Running   0              124m
cortx-zookeeper-2                                    1/1     Running   0              124m

```
```
[root@cortx-server-headless-svc-ssc-vm-g2-rhev4-1635 /]# hctl status | grep offline
[root@cortx-server-headless-svc-ssc-vm-g2-rhev4-1635 /]#
```