### PR TITLE
CORTX-32347: Add support for log device in CDF

### DIFF
--- a/cfgen/dhall/types/M0ServerDesc.dhall
+++ b/cfgen/dhall/types/M0ServerDesc.dhall
@@ -20,5 +20,7 @@
 
 -- m0d process
 { runs_confd : Optional Bool
-, io_disks : { meta_data : Optional Text, data : (List ./IODisk.dhall) }
+, io_disks : { meta_data : Optional Text,
+               data : (List ./IODisk.dhall),
+               log : (List ./IODisk.dhall) }
 }

--- a/cfgen/examples/ci-boot1-2ios.yaml
+++ b/cfgen/examples/ci-boot1-2ios.yaml
@@ -8,11 +8,13 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/loop0
             - path: /dev/loop1
             - path: /dev/loop2
+          log:
             - path: /dev/loop3
       - io_disks:
           data:
@@ -21,6 +23,7 @@ nodes:
             - path: /dev/loop6
             - path: /dev/loop7
             - path: /dev/loop8
+          log:
             - path: /dev/loop9
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -31,13 +34,11 @@ pools:
       - { path: /dev/loop0, node: localhost }
       - { path: /dev/loop1, node: localhost }
       - { path: /dev/loop2, node: localhost }
-      - { path: /dev/loop3, node: localhost }
       - { path: /dev/loop4, node: localhost }
       - { path: /dev/loop5, node: localhost }
       - { path: /dev/loop6, node: localhost }
       - { path: /dev/loop7, node: localhost }
       - { path: /dev/loop8, node: localhost }
-      - { path: /dev/loop9, node: localhost }
     #type: sns  # optional; supported values: "sns" (default), "dix", "md"
     data_units: 1
     parity_units: 0

--- a/cfgen/examples/ci-boot2-1confd.yaml
+++ b/cfgen/examples/ci-boot2-1confd.yaml
@@ -7,6 +7,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/vdb
@@ -14,6 +15,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -30,6 +32,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -42,13 +45,11 @@ pools:
       - { path: /dev/vdd, node: ssu1 }
       - { path: /dev/vde, node: ssu1 }
       - { path: /dev/vdf, node: ssu1 }
-      - { path: /dev/vdg, node: ssu1 }
       - { path: /dev/vdb, node: ssu2 }
       - { path: /dev/vdc, node: ssu2 }
       - { path: /dev/vdd, node: ssu2 }
       - { path: /dev/vde, node: ssu2 }
       - { path: /dev/vdf, node: ssu2 }
-      - { path: /dev/vdg, node: ssu2 }
     #type: sns  # optional; supported values: "sns" (default), "dix", "md"
     data_units: 1
     parity_units: 0

--- a/cfgen/examples/ci-boot2.yaml
+++ b/cfgen/examples/ci-boot2.yaml
@@ -7,6 +7,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/vdb
@@ -14,6 +15,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -26,6 +28,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/vdb
@@ -33,6 +36,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -45,13 +49,11 @@ pools:
       - { path: /dev/vdd, node: ssu1 }
       - { path: /dev/vde, node: ssu1 }
       - { path: /dev/vdf, node: ssu1 }
-      - { path: /dev/vdg, node: ssu1 }
       - { path: /dev/vdb, node: ssu2 }
       - { path: /dev/vdc, node: ssu2 }
       - { path: /dev/vdd, node: ssu2 }
       - { path: /dev/vde, node: ssu2 }
       - { path: /dev/vdf, node: ssu2 }
-      - { path: /dev/vdg, node: ssu2 }
     #type: sns  # optional; supported values: "sns" (default), "dix", "md"
     data_units: 1
     parity_units: 0

--- a/cfgen/examples/ci-boot3.yaml
+++ b/cfgen/examples/ci-boot3.yaml
@@ -7,6 +7,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/vdb
@@ -14,6 +15,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -26,6 +28,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/vdb
@@ -33,6 +36,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -45,6 +49,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/vdb
@@ -52,6 +57,7 @@ nodes:
             - path: /dev/vdd
             - path: /dev/vde
             - path: /dev/vdf
+          log:
             - path: /dev/vdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -64,19 +70,16 @@ pools:
       - { path: /dev/vdd, node: ssu1 }
       - { path: /dev/vde, node: ssu1 }
       - { path: /dev/vdf, node: ssu1 }
-      - { path: /dev/vdg, node: ssu1 }
       - { path: /dev/vdb, node: ssu2 }
       - { path: /dev/vdc, node: ssu2 }
       - { path: /dev/vdd, node: ssu2 }
       - { path: /dev/vde, node: ssu2 }
       - { path: /dev/vdf, node: ssu2 }
-      - { path: /dev/vdg, node: ssu2 }
       - { path: /dev/vdb, node: ssu3 }
       - { path: /dev/vdc, node: ssu3 }
       - { path: /dev/vdd, node: ssu3 }
       - { path: /dev/vde, node: ssu3 }
       - { path: /dev/vdf, node: ssu3 }
-      - { path: /dev/vdg, node: ssu3 }
     #type: sns  # optional; supported values: "sns" (default), "dix", "md"
     data_units: 1
     parity_units: 0

--- a/cfgen/examples/ldr1-cluster.yaml
+++ b/cfgen/examples/ldr1-cluster.yaml
@@ -12,11 +12,13 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/sdd
             - path: /dev/sde
             - path: /dev/sdf
+          log:
             - path: /dev/sdg
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -30,11 +32,13 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/sdh
             - path: /dev/sdi
             - path: /dev/sdj
+          log:
             - path: /dev/sdk
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -45,11 +49,9 @@ pools:
       - { path: /dev/sdd, node: pod_c1 }
       - { path: /dev/sde, node: pod_c1 }
       - { path: /dev/sdf, node: pod_c1 }
-      - { path: /dev/sdg, node: pod_c1 }
       - { path: /dev/sdh, node: pod_c2 }
       - { path: /dev/sdi, node: pod_c2 }
       - { path: /dev/sdj, node: pod_c2 }
-      - { path: /dev/sdk, node: pod_c2 }
     #type: sns  # optional; supported values: "sns" (default), "dix", "md"
     data_units: 1
     parity_units: 0

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -8,6 +8,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           meta_data: /dev/vg_metadata_srvnode-1/lv_raw_metadata
           data:
@@ -18,6 +19,8 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathd
             - path: /dev/disk/by-id/dm-name-mpathe
             - path: /dev/disk/by-id/dm-name-mpathf
+          log:
+            - path: /dev/disk/by-id/dm-name-mpathff
     m0_clients:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run
@@ -42,6 +45,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           meta_data: /dev/vg_metadata_srvnode-2/lv_raw_metadata
           data:
@@ -52,6 +56,8 @@ nodes:
             - path: /dev/disk/by-id/dm-name-mpathj
             - path: /dev/disk/by-id/dm-name-mpathk
             - path: /dev/disk/by-id/dm-name-mpathl
+          log:
+            - path: /dev/disk/by-id/dm-name-mpathm
     m0_clients:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run

--- a/cfgen/examples/singlenode.yaml
+++ b/cfgen/examples/singlenode.yaml
@@ -11,6 +11,7 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
           meta_data: null
       - runs_confd: null
         io_disks:
@@ -24,7 +25,8 @@ nodes:
             - path: /dev/loop6 
             - path: /dev/loop7 
             - path: /dev/loop8 
-            - path: /dev/loop9 
+          log:
+            - path: /dev/loop9
           meta_data: null
     m0_clients:
       - name: m0_client_other  # name of the motr client
@@ -55,7 +57,6 @@ pools:
       - { path: /dev/loop6, node: localhost }
       - { path: /dev/loop7, node: localhost }
       - { path: /dev/loop8, node: localhost }
-      - { path: /dev/loop9, node: localhost }
     data_units: 1
     parity_units: 0
     spare_units: 0

--- a/cfgen/tests/singlenode.dhall
+++ b/cfgen/tests/singlenode.dhall
@@ -43,6 +43,11 @@ in
                            , path : Optional Text
                            , size : Optional Natural
                            }
+                , log = [] : List
+                           { blksize: Optional Natural
+                           , path: Optional Text
+                           , size: Optional Natural
+                           }
                 }
             }
           , { runs_confd = None Bool
@@ -85,7 +90,9 @@ in
                       , path = Some "/dev/loop8"
                       , size = None Natural
                       }
-                    , { blksize = None Natural
+                    ]
+                , log =
+                    [ { blksize = None Natural
                       , path = Some "/dev/loop9"
                       , size = None Natural
                       }
@@ -117,7 +124,6 @@ in
           , { node = Some "localhost", path = "/dev/loop6" }
           , { node = Some "localhost", path = "/dev/loop7" }
           , { node = Some "localhost", path = "/dev/loop8" }
-          , { node = Some "localhost", path = "/dev/loop9" }
           ]
       , data_units = 1
       , parity_units = 0

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -521,10 +521,13 @@ class CdfGenerator:
             servers = DList([
                 M0ServerDesc(
                     io_disks=DisksDesc(
-                        data=self.utils.get_drives_info_for(cvg, machine_id),
+                        data=self.utils.get_data_drives_info_for(cvg,
+                                                                 machine_id),
                         meta_data=Maybe(
                             self._get_metadata_device(
-                                machine_id, cvg), 'Text')),
+                                machine_id, cvg), 'Text'),
+                        log=self.utils.get_log_drives_info_for(cvg,
+                                                               machine_id)),
                     runs_confd=Maybe(False, 'Bool'))
                 # node>{machine_id}>cvg
                 for cvg in range(len(store.get(
@@ -538,6 +541,7 @@ class CdfGenerator:
             servers.value.append(M0ServerDesc(
                 io_disks=DisksDesc(
                     data=DList([], 'List Disk'),
+                    log=DList([], 'List Disk'),
                     meta_data=Maybe(None, 'Text')),
                 runs_confd=Maybe(True, 'Bool')))
 

--- a/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
+++ b/provisioning/miniprov/hare_mp/dhall/gencdf.dhall
@@ -14,6 +14,7 @@ let Disk =
 let IODisks =
       { meta_data : Optional Text
       , data : List Disk
+      , log : List Disk
       }
 
 let M0ServerDesc =

--- a/provisioning/miniprov/hare_mp/types.py
+++ b/provisioning/miniprov/hare_mp/types.py
@@ -101,6 +101,7 @@ class Disk(DhallTuple):
 class DisksDesc(DhallTuple):
     meta_data: Maybe[Text]
     data: DList[Disk]
+    log: DList[Disk]
 
 
 @dataclass(repr=False)

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -132,6 +132,15 @@ class Utils:
         return data_devices
 
     @func_log(func_enter, func_leave)
+    def get_log_devices(self, machine_id: str, cvg: int) -> DList[Text]:
+        log_devices = DList(
+            [Text(device) for device in self.provider.get(
+                f'node>{machine_id}>'
+                f'cvg[{cvg}]>devices>log',
+                allow_null=True) or []], 'List Text')
+        return log_devices
+
+    @func_log(func_enter, func_leave)
     def _get_drive_info_form_os(self, path: str) -> Disk:
         drive_size = 0
         with open(path, 'rb') as f:
@@ -235,6 +244,10 @@ class Utils:
                 data_devs = self.get_data_devices(machine_id, cvg)
                 for dev_path in data_devs.value:
                     self._save_drive_info(dev_path.s)
+                log_devs = self.get_log_devices(machine_id, cvg)
+                if log_devs:
+                    for dev_path in log_devs.value:
+                        self._save_drive_info(dev_path.s)
 
     @func_log(func_enter, func_leave)
     @repeat_if_fails()
@@ -257,8 +270,16 @@ class Utils:
                      blksize=Maybe(drive_info['blksize'], 'Natural')))
 
     @func_log(func_enter, func_leave)
-    def get_drives_info_for(self, cvg: int, machine_id: str) -> DList[Disk]:
+    def get_data_drives_info_for(self, cvg: int,
+                                 machine_id: str) -> DList[Disk]:
         data_devs = self.get_data_devices(machine_id, cvg)
+        return DList([self.get_drive_info_from_consul(dev_path, machine_id)
+                      for dev_path in data_devs.value], 'List Disk')
+
+    @func_log(func_enter, func_leave)
+    def get_log_drives_info_for(self, cvg: int,
+                                machine_id: str) -> DList[Disk]:
+        data_devs = self.get_log_devices(machine_id, cvg)
         return DList([self.get_drive_info_from_consul(dev_path, machine_id)
                       for dev_path in data_devs.value], 'List Disk')
 


### PR DESCRIPTION
**Solution:**
Added support for log device in CDF fotmat.
Also modified mini-provisioning code to read log device info from confstore and use
it to generated CDF.

**Test:**
Tested 3 node deployment,
Since confstore do not contain 'log' devices as of now, tested it by manually adding log device entry in confstore and running hare 'prepare' and 'config' stage.
```
cvg:
    - devices:
        log:
        - /dev/sdd
        data:
        - /dev/sdd
        - /dev/sde
        metadata:
        - /dev/sdc
        num_data: 2
```
CDF generated with following entry for log devices
```
nodes:
- transport_type: libfab
  m0_servers:
  - io_disks:
      log:
      - path: /dev/sdd
        size: 0
        blksize: 4096
      data:
      - path: /dev/sdd
        size: 0
        blksize: 4096
      - path: /dev/sde
```

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>