### PR TITLE
CORTX-32741: HARE - Consul Support for GCONF

### DIFF
--- a/hax/hax/ha/message_interface/message_interface.py
+++ b/hax/hax/ha/message_interface/message_interface.py
@@ -79,10 +79,16 @@ class MessageBusInterface(MessageInterface):
         configpath = util.get_configpath(allow_null=True)
         if configpath:
             Conf.load('cortx_conf', configpath, skip_reload=True)
-
-            message_server_endpoints = Conf.get(
-                            'cortx_conf',
-                            'cortx>external>kafka>endpoints')
+            # cortx>external>kafka>num_endpoints
+            num_kafka = int(Conf.get(
+                'cortx_conf',
+                'cortx>external>kafka>num_endpoints'))
+            message_server_endpoints = []
+            # cortx>external>kafka>endpoints[0]
+            for i in range(num_kafka):
+                message_server_endpoints.append(Conf.get(
+                    'cortx_conf',
+                    f'cortx>external>kafka>endpoints[{i}]'))
             MessageBus.init(message_server_endpoints)
         else:
             logging.warning('initialize_bus skipped as configpath not found')

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -96,14 +96,10 @@ class CdfGenerator:
             'hare_mp', resource_path)
         return raw_content.decode('utf-8')
 
-    # node>{machine-id}>cluster_id
+    # cluster>id
     def _get_cluster_id(self) -> str:
         conf = self.provider
-
-        # We will read 'cluster_id' of 1st 'machine_id' present in 'node'
-        server_node = conf.get('node')
-        machine_id = list(server_node.keys())[0]
-        cluster_id = server_node[machine_id]['cluster_id']
+        cluster_id = conf.get('cluster>id')
         return cluster_id
 
     def _create_node_descriptions(self) -> List[NodeDesc]:
@@ -113,11 +109,16 @@ class CdfGenerator:
         machines = conf.get_machine_ids_for_service(
             Const.SERVICE_MOTR_IO.value)
         # Get all the pods which runs the client components
+        # cortx>motr>num_clients
+        # cortx>motr>clients[N]>name
         client_machines = []
-        for client in conf.get_motr_clients():
-            name = str(client.get('name'))
-            client_machines.extend(conf.get_machine_ids_for_service(name))
-            client_machines.extend(conf.get_machine_ids_for_component(name))
+        num_clients = int(conf.get('cortx>motr>num_clients'))
+        for i in range(num_clients):
+            if int(conf.get(f'cortx>motr>clients[{i}]>num_instances')) > 0:
+                name = conf.get(f'cortx>motr>clients[{i}]>name')
+                client_machines.extend(conf.get_machine_ids_for_service(name))
+                client_machines.extend(
+                    conf.get_machine_ids_for_component(name))
 
         # Avoid adding duplicate machine ids if client and data node
         # are the same. We do not use list(set()) mechanism as it
@@ -148,15 +149,7 @@ class CdfGenerator:
                      f'durability>{pool_type}>{prop_name}'))
 
     def _get_layout(self, pool: PoolHandle) -> Optional[Layout]:
-        conf = self.provider
         (cluster_id, pool_type, storage_ndx) = pool.tuple()
-        # cluster>storage_set[N]>durability>{type}
-        type_value = conf.get(
-            f'cluster>storage_set[{storage_ndx}]'
-            f'>durability>{pool_type}',
-            allow_null=True)
-        if not type_value:
-            return None
 
         def prop(name: str) -> int:
             return self._get_pool_property(pool, name)
@@ -175,9 +168,12 @@ class CdfGenerator:
         if pool_type == 'dix':
             prop_name = 'metadata'
         for i in range(cvg_num):
-            # node>{machine-id}>cvg[N]>devices>name
-            all_cvg_devices += conf.get(
-                f'node>{node}>cvg[{i}]>devices>{prop_name}')
+            prop_num = int(conf.get(
+                f'node>{node}>cvg[{i}]>devices>num_{prop_name}'))
+            for j in range(prop_num):
+                # node>{machine-id}>cvg[N]>devices>data/metadata[N]
+                all_cvg_devices.append(conf.get(
+                    f'node>{node}>cvg[{i}]>devices>{prop_name}[{j}]'))
         return all_cvg_devices
 
     def _validate_pool(self, pool: PoolHandle) -> None:
@@ -312,44 +308,51 @@ class CdfGenerator:
         m0client_ports = []
         for srv in NetworkPorts.__annotations__.keys():
             if srv == 'hax':
-                url = conf.get('cortx>hare>hax>endpoints', allow_null=True)
+                num_ep = int(conf.get('cortx>hare>hax>num_endpoints'))
                 _hax = None
                 _hax_http = None
-                for u in url or ():
-                    _parsed_url = urlparse(u)
+                for i in range(num_ep):
+                    url = conf.get(f'cortx>hare>hax>endpoints[{i}]')
+                    _parsed_url = urlparse(url)
                     if _parsed_url.scheme in ('http', 'https'):
                         _hax_http = _parsed_url.port
                     else:
                         if _parsed_url.hostname == hostname:
                             _hax = round(_parsed_url.port / 100) * 100
             elif srv == 'm0_client_other':
-                for client in self.provider.get_motr_clients():
-                    url = client.get('endpoints')
-                    if url:
-                        for u in url or ():
-                            _parsed_url = urlparse(u)
+                num_clients = int(conf.get('cortx>motr>num_clients'))
+                for i in range(num_clients):
+                    # Note: every client will not have endpoints
+                    num_endpoints = conf.get(
+                        f'cortx>motr>clients[{i}]>num_endpoints',
+                        allow_null=True)
+                    if num_endpoints:
+                        for j in range(int(num_endpoints)):
+                            url = conf.get(
+                                f'cortx>motr>clients[{i}]>endpoints[{j}]')
+                            _parsed_url = urlparse(url)
                             if _parsed_url.hostname == hostname:
                                 port = round(_parsed_url.port / 100) * 100
-                                client_name = str(client.get('name'))
+                                client_name = conf.get(
+                                    f'cortx>motr>clients[{i}]>name')
                                 m0client_ports.append(
                                     ClientPort(name=Text(client_name),
                                                port=int(port)))
             elif srv == 'm0_server':
                 for server in m0serverT:
-                    url = conf.get(f'cortx>motr>{server}>endpoints',
-                                   allow_null=True)
+                    num_ep = int(conf.get(
+                        f'cortx>motr>{server}>num_endpoints'))
                     port = 0
-                    for u in url or ():
-                        _parsed_url = urlparse(u)
+                    for i in range(num_ep):
+                        url = conf.get(f'cortx>motr>{server}>endpoints[{i}]')
+                        _parsed_url = urlparse(url)
                         if _parsed_url.hostname == hostname:
                             port = round(_parsed_url.port / 100) * 100
                     m0server_ports.append(
                         ServerPort(name=Text(server),
                                    port=int(port)))
             else:
-                url = conf.get('cortx>motr>client>endpoints', allow_null=True)
-                _client_s3 = url if url is None else \
-                    round(urlparse(url[0]).port / 100) * 100
+                _client_s3 = None
 
         return NetworkPorts(
             hax=Maybe(_hax, 'Natural'),
@@ -425,12 +428,7 @@ class CdfGenerator:
         return ifaces[0]
 
     def _get_iface_type(self, machine_id: str) -> Optional[Protocol]:
-        endpoints = self.provider.get(
-            'cortx>hare>hax>endpoints',
-            allow_null=True)
-
-        if endpoints is None:
-            return None
+        num_ep = int(self.provider.get('cortx>hare>hax>num_endpoints'))
 
         hostname = self.utils.get_hostname(machine_id)
 
@@ -439,8 +437,9 @@ class CdfGenerator:
         # e.g. endpoints:
         #      - tcp://data1-node1:22001  # For motr and Hax communication
         #      - tcp://data1-node2:22001  # For motr and Hax communication
-        for e in endpoints:
-            key = e.split(':')
+        for i in range(num_ep):
+            endpoint = self.provider.get(f'cortx>hare>hax>endpoints[{i}]')
+            key = endpoint.split(':')
 
             if key[0] in ('http', 'https'):
                 continue
@@ -453,14 +452,17 @@ class CdfGenerator:
             return None
         return Protocol[proto]
 
-    # node>{machine -id}>cvg[N]>devices>data
+    # node>{machine -id}>cvg[N]>devices>num_data
+    # node>{machine -id}>cvg[N]>devices>data[N]
     def _get_data_devices(self, machine_id: str, cvg: int) -> DList[Text]:
         store = self.provider
-        data_devices = DList(
-            [Text(device) for device in store.get(
-                f'node>{machine_id}>'
-                f'cvg[{cvg}]>devices>data')], 'List Text')
-        return data_devices
+        data_devices = []
+        num_data = int(store.get(
+            f'node>{machine_id}>cvg[{cvg}]>devices>num_data'))
+        for i in range(num_data):
+            data_devices.append(Text(store.get(
+                f'node>{machine_id}>cvg[{cvg}]>devices>data[{i}]')))
+        return DList(data_devices, 'List Text')
 
     # conf-store returns a list of devices, thus, the function
     # must return a single metadata device path instead of a string of
@@ -470,7 +472,7 @@ class CdfGenerator:
                              cvg: int) -> Text:
         store = self.provider
         metadata_device = Text(store.get(
-            f'node>{machine_id}>cvg[{cvg}]>devices>metadata')[0])
+            f'node>{machine_id}>cvg[{cvg}]>devices>metadata[0]'))
         return metadata_device
 
     # This function is kept as place holder with length returning 1,
@@ -489,15 +491,18 @@ class CdfGenerator:
         clients that are present in the components list for the given
         node>{machine_id} according to the ConfStore.
 
-        cortx>motr>clients=[rgw, other]
-        node>{machine_id}>components=[motr, other]
+        cortx>motr>clients=[rgw_s3, other]
+        node>{machine_id}>components=[rgw, other]
 
         return 'other' only.
         """
-        for client in self.provider.get_motr_clients():
-            name = str(client.get('name'))
-            no_instances = int(str(client.get('num_instances')))
-            if no_instances:
+        conf = self.provider
+        num_clients = int(conf.get('cortx>motr>num_clients'))
+        for i in range(num_clients):
+            no_instances = int(conf.get(
+                f'cortx>motr>clients[{i}]>num_instances'))
+            if no_instances > 0:
+                name = str(conf.get(f'cortx>motr>clients[{i}]>name'))
                 if self.utils.is_component_or_service(machine_id, name):
                     yield M0ClientDesc(
                         name=Text(name),
@@ -529,9 +534,10 @@ class CdfGenerator:
                         log=self.utils.get_log_drives_info_for(cvg,
                                                                machine_id)),
                     runs_confd=Maybe(False, 'Bool'))
+                # node>{machine_id}>num_cvg
                 # node>{machine_id}>cvg
-                for cvg in range(len(store.get(
-                    f'node>{machine_id}>cvg')))
+                for cvg in range(int(store.get(
+                    f'node>{machine_id}>num_cvg')))
                 for m0d in range(self._get_m0d_per_cvg(machine_id, cvg))
             ], 'List M0ServerDesc')
 

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -249,13 +249,14 @@ def _start_consul(utils: Utils,
 
     provider = ConfStoreProvider(url)
     node_id = uuid.uuid4()
-    consul_endpoints = provider.get('cortx>external>consul>endpoints')
+    num_ep = int(provider.get('cortx>external>consul>num_endpoints'))
     cns_utils: ConsulUtil = ConsulUtil()
     hostname = utils.get_local_hostname()
 
     # remove tcp://
     peers = []
-    for endpoint in consul_endpoints:
+    for i in range(num_ep):
+        endpoint = provider.get(f'cortx>external>consul>endpoints[{i}]')
         key = endpoint.split('/')
         # Considering tcp endpoints only. Ignoring all other endpoints.
         if key[0] != 'tcp:':

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -93,9 +93,9 @@ class ConfStoreProvider(ValueProvider):
         Const.SERVICE_S3_SERVER.value etc
         """
         types = {
-            'io'    : 'motr',
+            'io': 'motr',
             'rgw_s3': 'rgw',
-            'agent' : 'csm'
+            'agent': 'csm'
         }
         node_info = str(types.get(service_type))
         return self.get_machine_ids_for_attribute('name', node_info)

--- a/provisioning/miniprov/hare_mp/store.py
+++ b/provisioning/miniprov/hare_mp/store.py
@@ -17,7 +17,7 @@
 #
 
 from cortx.utils.conf_store import Conf
-from typing import List, Dict, Any
+from typing import List, Any
 from cortx.utils.cortx import Const
 from hare_mp.types import MissingKeyError
 
@@ -60,9 +60,6 @@ class ValueProvider:
                    search_val: str) -> List[str]:
         raise NotImplementedError()
 
-    def get_motr_clients(self) -> List[Dict[str, Any]]:
-        raise NotImplementedError()
-
 
 class ConfStoreProvider(ValueProvider):
     def __init__(self, url: str, index='hare'):
@@ -95,7 +92,13 @@ class ConfStoreProvider(ValueProvider):
         service_type will be like Const.SERVICE_MOTR_IO.value,
         Const.SERVICE_S3_SERVER.value etc
         """
-        return self.get_machine_ids_for_attribute('services', service_type)
+        types = {
+            'io'    : 'motr',
+            'rgw_s3': 'rgw',
+            'agent' : 'csm'
+        }
+        node_info = str(types.get(service_type))
+        return self.get_machine_ids_for_attribute('name', node_info)
 
     def get_hostnames_for_service(self, service_type: str) -> List[str]:
         """
@@ -125,13 +128,20 @@ class ConfStoreProvider(ValueProvider):
         attribute type can be like service, node, etc.
         """
         nodes: List[str] = []
-        machines: Dict[str, Any] = self.get('node')
+        machines = []
+        num_storage_sets = int(self.get('cluster>num_storage_set'))
+        for i in range(num_storage_sets):
+            num_nodes = int(self.get(f'cluster>storage_set[{i}]>num_nodes'))
+            for j in range(num_nodes):
+                machines.append(self.get(
+                    f'cluster>storage_set[{i}]>nodes[{j}]'))
+
         # example ouput for search_val()
         # attr_type = services
         # ['node>32bdeac034fe4155af4ca66951d410e9>components[1]>services[0]']
         values = self.search_val('node', attr_type, name)
 
-        for machine_id in machines.keys():
+        for machine_id in machines:
             result = [val for val in values if machine_id in val]
             if result:
                 nodes.append(machine_id)
@@ -151,10 +161,11 @@ class ConfStoreProvider(ValueProvider):
         storage_set_id = self.get((f'node>{machine_id}>'
                                    f'storage_set'))
 
-        for storage_set in self.get('cluster>storage_set'):
-            if storage_set['name'] == storage_set_id:
-                return i
-            i += 1
+        for j in range(int(self.get('cluster>num_storage_set'))):
+            for storage_set in self.get(f'cluster>storage_set[{j}]'):
+                if storage_set['name'] == storage_set_id:
+                    return i
+                i += 1
 
         raise RuntimeError('No storage set found. Is ConfStore data valid?')
 
@@ -167,25 +178,6 @@ class ConfStoreProvider(ValueProvider):
         Searches a given key value under the given parent key.
         """
         return self.conf.search(self.index, parent_key, search_key, search_val)
-
-    def get_motr_clients(self) -> List[Dict[str, Any]]:
-        """
-        Returns a list of all motr clients with their name and instances.
-        Example
-        clients:
-        -   name: rgw
-            num_instances: 1
-        -   name: other
-            num_instances: 2
-        """
-        clients = self.get('cortx>motr>clients', allow_null=True)
-        if clients is None:
-            return []
-        for client in clients:
-            instances = int(str(client.get('num_instances')))
-            if instances == 0:
-                clients.remove(client)
-        return clients
 
 
 def get_machine_id() -> str:

--- a/provisioning/miniprov/hare_mp/utils.py
+++ b/provisioning/miniprov/hare_mp/utils.py
@@ -125,11 +125,14 @@ class Utils:
 
     @func_log(func_enter, func_leave)
     def get_data_devices(self, machine_id: str, cvg: int) -> DList[Text]:
-        data_devices = DList(
-            [Text(device) for device in self.provider.get(
+        data_devices = []
+        num_data = int(self.provider.get(
+            f'node>{machine_id}>cvg[{cvg}]>devices>num_data'))
+        for i in range(num_data):
+            data_devices.append(Text(self.provider.get(
                 f'node>{machine_id}>'
-                f'cvg[{cvg}]>devices>data')], 'List Text')
-        return data_devices
+                f'cvg[{cvg}]>devices>data[{i}]')))
+        return DList(data_devices, 'List Text')
 
     @func_log(func_enter, func_leave)
     def get_log_devices(self, machine_id: str, cvg: int) -> DList[Text]:
@@ -186,11 +189,12 @@ class Utils:
         list for the given node>{machine_id} according to the
         ConfStore (ValueProvider).
         """
-        comp_names = self.provider.get(f'node>{machine_id}>'
-                                       f'components')
+        num_comp = int(self.provider.get(f'node>{machine_id}>num_components'))
         found = False
-        for component in comp_names:
-            if(component.get('name') == name):
+        for i in range(num_comp):
+            comp_name = self.provider.get(
+                f'node>{machine_id}>components[{i}]>name')
+            if(comp_name == name):
                 found = True
                 break
         return found
@@ -223,13 +227,16 @@ class Utils:
         list for the given node>{machine_id} according to the
         ConfStore (ValueProvider).
         """
-        comp_names = self.provider.get(f'node>{machine_id}>'
-                                       f'components')
         found: bool = False
-        for component in comp_names:
-            svc_names = component.get('services')
-            if svc_names:
-                for service in svc_names:
+        num_comp = int(self.provider.get(f'node>{machine_id}>num_components'))
+        for i in range(num_comp):
+            num_svc = self.provider.get(
+                f'node>{machine_id}>components[{i}]>num_services',
+                allow_null=True)
+            if num_svc:
+                for j in range(int(num_svc)):
+                    service = self.provider.get(
+                        f'node>{machine_id}>components[{i}]>services[{j}]')
                     if(service == svc_name):
                         found = True
                         break
@@ -239,8 +246,8 @@ class Utils:
     def save_drives_info(self):
         machine_id = self.provider.get_machine_id()
         if(self.is_motr_io_present(machine_id)):
-            cvgs_key: str = f'node>{machine_id}>cvg'
-            for cvg in range(len(self.provider.get(cvgs_key))):
+            num_cvg = int(self.provider.get(f'node>{machine_id}>num_cvg'))
+            for cvg in range(num_cvg):
                 data_devs = self.get_data_devices(machine_id, cvg)
                 for dev_path in data_devs.value:
                     self._save_drive_info(dev_path.s)
@@ -355,10 +362,11 @@ class Utils:
     @func_log(func_enter, func_leave)
     @repeat_if_fails()
     def save_ssl_config(self):
-        url = self.provider.get('cortx>hare>hax>endpoints', allow_null=True)
         http_protocol = 'http'
-        for u in url or ():
-            scheme = urlparse(u).scheme
+        num_ep = int(self.provider.get('cortx>hare>hax>num_endpoints'))
+        for i in range(num_ep):
+            url = self.provider.get(f'cortx>hare>hax>endpoints[{i}]')
+            scheme = urlparse(url).scheme
             if scheme in ('http', 'https'):
                 http_protocol = scheme
                 break

--- a/provisioning/miniprov/test/test_cdf.py
+++ b/provisioning/miniprov/test/test_cdf.py
@@ -113,7 +113,6 @@ class TestCDF(unittest.TestCase):
 
             store.get_machine_id = Mock(return_value='1114a50a6bf6f9c93ebd3c49d07d3fd4')
             store.get_machine_ids_for_service = Mock(return_value=['1114a50a6bf6f9c93ebd3c49d07d3fd4'])
-            store.get_motr_clients = Mock(return_value=[])
             utils = Utils(store)
             kv = KVAdapter()
             def my_get(key: str, recurse: bool = False, allow_null: bool = False):
@@ -249,7 +248,6 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
-        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False, allow_null: bool = False):
@@ -358,9 +356,6 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
-        store.get_motr_clients = Mock(return_value=
-                                      [{'name': 'other',
-                                        'num_instances' : 2}])
         store.get_machine_ids_for_component = Mock(return_value=['MACH_ID'])
         utils = Utils(store)
         kv = KVAdapter()
@@ -641,7 +636,6 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
-        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         cdf._get_m0d_per_cvg = Mock(return_value=1)
         utils = Utils(store)
@@ -975,7 +969,6 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
-        store.get_motr_clients = Mock(return_value=[])
         utils = Utils(store)
         kv = KVAdapter()
         def my_get(key: str, recurse: bool = False, allow_null: bool = False):
@@ -1111,9 +1104,6 @@ class TestCDF(unittest.TestCase):
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID',
                                                                'MACH_2_ID'])
-        store.get_motr_clients = Mock(return_value=
-                                [{'name': 'other',
-                                'num_instances' : 2}])
         store.get_machine_ids_for_component = Mock(return_value=['MACH_ID',
                                                                  'MACH_2_ID'])
         utils = Utils(store)
@@ -1243,7 +1233,6 @@ class TestCDF(unittest.TestCase):
         store._raw_get = Mock(side_effect=ret_values)
         store.get_machine_id = Mock(return_value='MACH_ID')
         store.get_machine_ids_for_service = Mock(return_value=['MACH_ID'])
-        store.get_motr_clients = Mock(return_value=[])
         cdf = CdfGenerator(provider=store)
         utils = Utils(store)
         kv = KVAdapter()


### PR DESCRIPTION
Problem:
Provisioner team is planning to migrate file based Gconf to consule based Gconf.
In order to do this, hare component needs some changes to support this migration.

Solution:
There are changes required in way we fetch the keys and its values from Gconf
 e.g. endpoints, Hostname, machineIDs.
Approach we took is,
a) for any key we want to fetch, first we need to fetch num_XXX key from Gconf.
b) based on this number, we need to iterate over each key and get desired value of key.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>