### PR TITLE
CORTX-33637: Multi-data pod deployment failed for 24N with 2CVG

### DIFF
--- a/hax/hax/motr/hax.h
+++ b/hax/hax/motr/hax.h
@@ -27,6 +27,7 @@
 #define __HAX_H__
 
 #include "lib/mutex.h"
+#include "net/ip.h" /* M0_NET_IP_STRLEN_MAX */
 #include <Python.h>
 
 struct m0_halon_interface;
@@ -46,7 +47,7 @@ struct hax_context {
 };
 
 enum {
-	EP_ADDR_BUF_SIZE = 64
+	EP_ADDR_BUF_SIZE = M0_NET_IP_STRLEN_MAX
 };
 
 struct hax_link {


### PR DESCRIPTION
Problem: motr halon interface code assumes a size of 0x40 for the EP_ADDR_BUF_SIZE

Solution:
The size of the EP_ADDR_BUF_SIZE so used should ideally come from libfabric #define (M0_NET_IP_STRLEN_MAX)

Signed-off-by: Swapnil Gaonkar <swapnil.gaonkar@seagate.com>