### PR TITLE
CORTX-33705: confd and ios ports are not aligned with cluster

### DIFF
--- a/cfgen/cfgen
+++ b/cfgen/cfgen
@@ -1001,15 +1001,15 @@ class m0ProcT(Enum):
 
 
 class PortalGroup(Enum):
-    hax = 22000
+    hax = 22001
     m0_server = [{'name': 'confd', 'port': m0ProcT.confd},
                  {'name': 'ios', 'port': m0ProcT.ios}]
-    m0_client_s3 = 22500
-    m0_client_other = [{'name': 'default', 'port': 22500}]
+    m0_client_s3 = 22501
+    m0_client_other = [{'name': 'default', 'port': 22501}]
 
 
 class Portals:
-    def __init__(self, hax=22000,
+    def __init__(self, hax=22001,
                  m0_server=[{'name': 'confd', 'port': m0ProcT.confd},
                             {'name': 'ios', 'port': m0ProcT.ios}],
                  m0_client_s3=22500,
@@ -1033,27 +1033,27 @@ def get_lnet_portal_group(
         m0_client_s3=3,
         m0_client_other=[]
         ) -> Portals:
-    protal_group = Portals(hax=hax, m0_server=m0_server,
+    portal_group = Portals(hax=hax, m0_server=m0_server,
                            m0_client_s3=m0_client_s3,
                            m0_client_other=m0_client_other)
-    protal_group.m0_client_other.append({'name': 'default',
+    portal_group.m0_client_other.append({'name': 'default',
                                          'port': 4})
-    return protal_group
+    return portal_group
 
 
 def get_libfab_portal_group(
-        hax=22000,
+        hax=22001,
         m0_server=[{'name': 'confd', 'port': m0ProcT.confd},
                    {'name': 'ios', 'port': m0ProcT.ios}],
-        m0_client_s3=22500,
+        m0_client_s3=22501,
         m0_client_other=[]
         ) -> Portals:
-    protal_group = Portals(hax=hax, m0_server=m0_server,
+    portal_group = Portals(hax=hax, m0_server=m0_server,
                            m0_client_s3=m0_client_s3,
                            m0_client_other=m0_client_other)
-    protal_group.m0_client_other.append({'name': 'default',
-                                         'port': 22500})
-    return protal_group
+    portal_group.m0_client_other.append({'name': 'default',
+                                         'port': 22501})
+    return portal_group
 
 
 class Endpoint:
@@ -1116,7 +1116,7 @@ class LibfabricEndpoint(Endpoint):
         assert portal > 0
         self.portal = 0
         self.portal = self.ep_map.setdefault((ipaddr, portal),
-                                             (portal + 1))
+                                             (portal))
         self.ep_map[(ipaddr, portal)] += 1
 
     def __repr__(self):

--- a/cfgen/examples/multipools.yaml
+++ b/cfgen/examples/multipools.yaml
@@ -25,7 +25,7 @@ nodes:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run
     # network_ports:
-    #   hax: 22000
+    #   hax: 22001
     #   hax_http: 8008
     #   m0_server:
     #   - name: ios
@@ -34,8 +34,8 @@ nodes:
     #     port: 21000
     #   m0_client_other:
     #   - name: m0_client_other
-    #     port: 21500
-    #   m0_client_s3: 22500
+    #     port: 21501
+    #   m0_client_s3: 22501
   - hostname: srvnode-2
     node_group: srvnode-2
     data_iface: enp175s0f1_c2
@@ -62,7 +62,7 @@ nodes:
       - name: m0_client_other  # name of the motr client
         instances: 2   # Number of instances, this host will run
     # network_ports:
-    #   hax: 22000
+    #   hax: 22001
     #   hax_http: 8008
     #   m0_server:
     #   - name: ios
@@ -71,8 +71,8 @@ nodes:
     #     port: 21000
     #   m0_client_other:
     #   - name: m0_client_other
-    #     port: 21500
-    #   m0_client_s3: 22500
+    #     port: 21501
+    #   m0_client_s3: 22501
 pools:
   - name: tier1-nvme
     disk_refs:

--- a/provisioning/miniprov/hare_mp/cdf.py
+++ b/provisioning/miniprov/hare_mp/cdf.py
@@ -303,7 +303,7 @@ class CdfGenerator:
 
     def _create_ports_descriptions(self, hostname: str) -> NetworkPorts:
         conf = self.provider
-        m0serverT = ['ios', 'confd']
+        m0serverT = ['confd', 'ios']
         m0server_ports = []
         m0client_ports = []
         for srv in NetworkPorts.__annotations__.keys():
@@ -318,7 +318,7 @@ class CdfGenerator:
                         _hax_http = _parsed_url.port
                     else:
                         if _parsed_url.hostname == hostname:
-                            _hax = round(_parsed_url.port / 100) * 100
+                            _hax = _parsed_url.port
             elif srv == 'm0_client_other':
                 num_clients = int(conf.get('cortx>motr>num_clients'))
                 for i in range(num_clients):
@@ -332,7 +332,7 @@ class CdfGenerator:
                                 f'cortx>motr>clients[{i}]>endpoints[{j}]')
                             _parsed_url = urlparse(url)
                             if _parsed_url.hostname == hostname:
-                                port = round(_parsed_url.port / 100) * 100
+                                port = _parsed_url.port
                                 client_name = conf.get(
                                     f'cortx>motr>clients[{i}]>name')
                                 m0client_ports.append(
@@ -347,7 +347,7 @@ class CdfGenerator:
                         url = conf.get(f'cortx>motr>{server}>endpoints[{i}]')
                         _parsed_url = urlparse(url)
                         if _parsed_url.hostname == hostname:
-                            port = round(_parsed_url.port / 100) * 100
+                            port = _parsed_url.port
                     m0server_ports.append(
                         ServerPort(name=Text(server),
                                    port=int(port)))


### PR DESCRIPTION
Problem:
The confd and ios Port information in hctl status is not matching with 
cluster.conf in both Both basic Linux and K8s

in basic Linux:
ios Port in hctl status is 21003 instead of 21001 (as per cluster.conf):
```Services:
    ssc-vm-rhev4-2906.colo.seagate.com  (RC)
    [started]  hax                 0x7200000000000001:0x0          inet:tcp:10.230.240.238@22001
    [started]  confd               0x7200000000000001:0x1          inet:tcp:10.230.240.238@21002
    [started]  ioservice           0x7200000000000001:0x2          inet:tcp:10.230.240.238@21003
    [unknown]  m0_client_other     0x7200000000000001:0x3          inet:tcp:10.230.240.238@22501
    [unknown]  m0_client_other     0x7200000000000001:0x4          inet:tcp:10.230.240.238@22502
```
In K8s:
both confd and ios Port are not matching with cluster.conf
```Services:
    cortx-data-g1-1.cortx-data-headless.default.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x0          inet:tcp:cortx-data-g1-1.cortx-data-headless.default.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0x1          inet:tcp:cortx-data-g1-1.cortx-data-headless.default.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0x2          inet:tcp:cortx-data-g1-1.cortx-data-headless.default.svc.cluster.local@21002
```
Solution:
Modified ios and confd port info to fetch default port.

For K8s, just by changing order in list fixes this issue.
 `provisioning\miniprov\hare_mp\cdf.py`  `m0serverT = ['confd', 'ios'] `

but to fix in basic Linux, updated the default ports and avoid rounding off to fetch actual ports from cluster.conf.

After changes:
on  basic Linux:
```
Services:
    ssc-vm-rhev4-2906.colo.seagate.com  (RC)
    [started]  hax                 0x7200000000000001:0x0          inet:tcp:10.230.240.238@22001
    [started]  confd               0x7200000000000001:0x1          inet:tcp:10.230.240.238@21001
    [started]  ioservice           0x7200000000000001:0x2          inet:tcp:10.230.240.238@21002
    [unknown]  m0_client_other     0x7200000000000001:0x3          inet:tcp:10.230.240.238@22501
    [unknown]  m0_client_other     0x7200000000000001:0x4          inet:tcp:10.230.240.238@22502
```
On K8s
```
Services:
    cortx-data-g0-0.cortx-data-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x0          inet:tcp:cortx-data-g0-0.cortx-data-headless.cortx.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0x1          inet:tcp:cortx-data-g0-0.cortx-data-headless.cortx.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0x2          inet:tcp:cortx-data-g0-0.cortx-data-headless.cortx.svc.cluster.local@21002
    cortx-data-g0-1.cortx-data-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x3          inet:tcp:cortx-data-g0-1.cortx-data-headless.cortx.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0x4          inet:tcp:cortx-data-g0-1.cortx-data-headless.cortx.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0x5          inet:tcp:cortx-data-g0-1.cortx-data-headless.cortx.svc.cluster.local@21002
    cortx-data-g0-2.cortx-data-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x6          inet:tcp:cortx-data-g0-2.cortx-data-headless.cortx.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0x7          inet:tcp:cortx-data-g0-2.cortx-data-headless.cortx.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0x8          inet:tcp:cortx-data-g0-2.cortx-data-headless.cortx.svc.cluster.local@21002
    cortx-data-g1-0.cortx-data-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x9          inet:tcp:cortx-data-g1-0.cortx-data-headless.cortx.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0xa          inet:tcp:cortx-data-g1-0.cortx-data-headless.cortx.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0xb          inet:tcp:cortx-data-g1-0.cortx-data-headless.cortx.svc.cluster.local@21002
    cortx-data-g1-1.cortx-data-headless.cortx.svc.cluster.local  (RC)
    [started]  hax                 0x7200000000000001:0xc          inet:tcp:cortx-data-g1-1.cortx-data-headless.cortx.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0xd          inet:tcp:cortx-data-g1-1.cortx-data-headless.cortx.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0xe          inet:tcp:cortx-data-g1-1.cortx-data-headless.cortx.svc.cluster.local@21002
    cortx-data-g1-2.cortx-data-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0xf          inet:tcp:cortx-data-g1-2.cortx-data-headless.cortx.svc.cluster.local@22001
    [started]  ioservice           0x7200000000000001:0x10         inet:tcp:cortx-data-g1-2.cortx-data-headless.cortx.svc.cluster.local@21001
    [started]  confd               0x7200000000000001:0x11         inet:tcp:cortx-data-g1-2.cortx-data-headless.cortx.svc.cluster.local@21002
    cortx-server-0.cortx-server-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x12         inet:tcp:cortx-server-0.cortx-server-headless.cortx.svc.cluster.local@22001
    [started]  rgw_s3              0x7200000000000001:0x13         inet:tcp:cortx-server-0.cortx-server-headless.cortx.svc.cluster.local@22501
    cortx-server-1.cortx-server-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x14         inet:tcp:cortx-server-1.cortx-server-headless.cortx.svc.cluster.local@22001
    [started]  rgw_s3              0x7200000000000001:0x15         inet:tcp:cortx-server-1.cortx-server-headless.cortx.svc.cluster.local@22501
    cortx-server-2.cortx-server-headless.cortx.svc.cluster.local
    [started]  hax                 0x7200000000000001:0x16         inet:tcp:cortx-server-2.cortx-server-headless.cortx.svc.cluster.local@22001
    [started]  rgw_s3              0x7200000000000001:0x17         inet:tcp:cortx-server-2.cortx-server-headless.cortx.svc.cluster.local@22501
```

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>