### PR TITLE
CORTX-33936 perf: hax memory and cpu stats are missing

### DIFF
--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -41,6 +41,7 @@ from hax.motr.delivery import DeliveryHerald
 from hax.motr.ffi import HaxFFI
 from hax.motr.planner import WorkPlanner
 from hax.motr.rconfc import RconfcStarter
+from hax.profiler import Profiler
 from hax.server import ServerRunner
 from hax.types import Fid, Profile, StoppableThread
 from hax.util import ConsulUtil, ProcessGroup, repeat_if_fails
@@ -148,6 +149,10 @@ def _run_rconfc_starter_thread(motr: Motr,
     return rconfc_starter
 
 
+def _run_profiler() -> StoppableThread:
+    return _run_thread(Profiler())
+
+
 def set_locale():
     try:
         if codecs.lookup('UTF-8').name == 'utf-8':
@@ -230,6 +235,7 @@ def main():
         stats_updater = _run_stats_updater_thread(motr, consul_util=util)
         bc_updater = _run_bc_updater_thread(motr, consul_util=util)
         event_poller = _run_thread(create_ha_thread(planner, util))
+        profiler = _run_profiler()
         # [KN] This is a blocking call. It will work until the program is
         # terminated by signal
 
@@ -242,7 +248,8 @@ def main():
                                     stats_updater,
                                     bc_updater,
                                     rconfc_starter,
-                                    event_poller
+                                    event_poller,
+                                    profiler
                                     ],
                    port=hax_http_port)
     except Exception:

--- a/hax/hax/profiler.py
+++ b/hax/hax/profiler.py
@@ -1,0 +1,55 @@
+import logging
+import psutil
+import os
+
+from threading import Event
+
+from hax.exception import InterruptedException
+from hax.motr import log_exception
+from hax.types import StoppableThread
+
+LOG = logging.getLogger('hax')
+
+
+class Profiler(StoppableThread):
+
+    """
+    Hax Profiler thread that periodically logs hax's cpu and
+    memory usage.
+    """
+    def __init__(self):
+        super().__init__(target=self._execute,
+                         name='hax profiler',
+                         args=())
+        self.stopped = False
+        self.event = Event()
+
+    def stop(self) -> None:
+        LOG.debug('Stop signal received')
+        self.stopped = True
+        self.event.set()
+
+    @log_exception
+    def _execute(self):
+        try:
+            LOG.debug('Hax profiler has started')
+            while not self.stopped:
+                memory_actual = psutil.Process(
+                    os.getpid()).memory_full_info()
+                # cpu_usage = psutil.Process(
+                #      os.getpid()).cpu_percent(interval=2)
+                memory_virutal = psutil.virtual_memory()
+                # wait_for_event(self.event, 2)
+                LOG.info("Actual memory in bytes = {0!r}".format(
+                             memory_actual))
+                LOG.info("Virtual memory in bytes = {0!r}".format(
+                             memory_virutal))
+        except InterruptedException:
+            # No op. sleep() has interrupted before the timeout exceeded:
+            # the application is shutting down.
+            # There are no resources that we need to dispose specially.
+            pass
+        except Exception:
+            LOG.exception('Aborting due to an error')
+        finally:
+            LOG.debug('profiler exited')


### PR DESCRIPTION
Presently hax process does not log any periodical memory or cpu
consumption information.

Solution:
Save and log hax memory and cpu consumption numbers periodically.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>