### PR TITLE
CORTX-33030: In Hare, Set default log level to INFO

### DIFF
--- a/hax/hax/bytecount.py
+++ b/hax/hax/bytecount.py
@@ -71,7 +71,7 @@ class ByteCountUpdater(StoppableThread):
                     pver_info: PverInfo = motr.get_pver_status(
                         Fid.parse(p_ver))
                     pver_items[p_ver] = pver_info
-            LOG.debug('Received pool version and status: %s', pver_items)
+            LOG.info('Received pool version and status: %s', pver_items)
         return pver_items
 
     def _calculate_bc_per_pver(
@@ -105,13 +105,13 @@ class ByteCountUpdater(StoppableThread):
                 else:
                     pver_bc[pver_fid] = byte_count
 
-        LOG.debug('Bytecount with parity buffer: %s', pver_bc)
+        LOG.info('Bytecount with parity buffer: %s', pver_bc)
 
         bc_without_parity: Dict[str, int] = {}
         for pver, bc in pver_bc.items():
             bc_without_parity[pver] = \
                 bc - self._get_parity_buffers(bc, pver_state[pver])
-        LOG.debug('Bytecount without parity buffer: %s', bc_without_parity)
+        LOG.info('Bytecount without parity buffer: %s', bc_without_parity)
         return bc_without_parity
 
     def _get_parity_buffers(self, bc: int, state: PverInfo) -> int:
@@ -140,7 +140,7 @@ class ByteCountUpdater(StoppableThread):
                         if status == ObjHealth.OK:
                             byte_count: ByteCountStats = \
                                 motr.get_proc_bytecount(ios)
-                            LOG.debug('Received bytecount: %s', byte_count)
+                            LOG.info('Received bytecount: %s', byte_count)
                             if not byte_count:
                                 continue
                             self.consul.update_pver_bc(byte_count)

--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -58,7 +58,7 @@ class FsStatsUpdater(StoppableThread):
                 stats = motr.get_filesystem_stats()
                 if not stats:
                     continue
-                LOG.debug('FS stats are as follows: %s', stats)
+                LOG.info('FS stats are as follows: %s', stats)
                 now_time = datetime.datetime.now()
                 data = FsStatsWithTime(stats=stats,
                                        timestamp=now_time.timestamp(),
@@ -66,10 +66,10 @@ class FsStatsUpdater(StoppableThread):
                 try:
                     self.consul.update_fs_stats(data)
                 except HAConsistencyException:
-                    LOG.debug('Failed to update Consul KV '
-                              'due to an intermittent error. The '
-                              'error is swallowed since new attempts '
-                              'will be made timely')
+                    LOG.info('Failed to update Consul KV '
+                             'due to an intermittent error. The '
+                             'error is swallowed since new attempts '
+                             'will be made timely')
                 wait_for_event(self.event, self.interval_sec)
         except InterruptedException:
             # No op. _sleep() has interrupted before the timeout exceeded:

--- a/hax/hax/ha/message_type/message_type.py
+++ b/hax/hax/ha/message_type/message_type.py
@@ -35,7 +35,7 @@ class HealthMessage(MessageType):
         logging.debug('Inside HealthMessage')
 
     def send(self, event, util: ConsulUtil):
-        logging.debug('Sending HealthMessage: %s', event)
+        logging.info('Sending HealthMessage: %s', event)
         for interface in self.topic_list.items():
             sender = interface[1](util)
             message_type = interface[0]

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -253,7 +253,7 @@ class ConsumerThread(StoppableThread):
                         # Check if process node is online
                         proc_node_status: ObjHealth = (
                             cns.get_proc_node_health(state.fid))
-                        LOG.debug('Process node status: %s', proc_node_status)
+                        LOG.info('Process node status: %s', proc_node_status)
                         # If process node is online, we assume corresponding
                         # hax is also online. Let the local hax process it.
                         if proc_node_status == ObjHealth.OK:

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -113,16 +113,16 @@ def _remove_stale_session(util: ConsulUtil) -> None:
     if util.is_leader_value_present_for_session():
         node = util.get_leader_node()
         if re.match(r'^elect[\d]+$', node):
-            LOG.debug(
+            LOG.info(
                 'Stale leader session found: RC leader session %s is '
                 'found while the leader node seems to be '
                 'stub: %s', sess, node)
             util.destroy_session(sess)
-            LOG.debug('Stale session %s destroyed '
-                      'to enable RC re-election', sess)
+            LOG.info('Stale session %s destroyed '
+                     'to enable RC re-election', sess)
     else:
         util.destroy_session(sess)
-        LOG.debug('Stale session %s destroyed to enable RC re-election', sess)
+        LOG.info('Stale session %s destroyed to enable RC re-election', sess)
 
 
 @log_exception

--- a/hax/hax/motr/delivery.py
+++ b/hax/hax/motr/delivery.py
@@ -177,8 +177,8 @@ class DeliveryHerald:
     def notify_delivered(self, message_id: MessageId):
         # [KN] This function is expected to be called from Motr.
         with self.lock:
-            LOG.debug('received msg id %s, notify waiting clients %s',
-                      message_id, self.waiting_clients.items())
+            LOG.info('received msg id %s, notify waiting clients %s',
+                     message_id, self.waiting_clients.items())
             for promise, client in self.waiting_clients.items():
                 LOG.debug('waiting promise %s', promise)
                 if message_id in promise:

--- a/hax/hax/queue/__init__.py
+++ b/hax/hax/queue/__init__.py
@@ -34,15 +34,15 @@ class BQProcessor:
 
     def process(self, message: Tuple[int, Any]) -> None:
         (i, msg) = message
-        LOG.debug('Message #%d received: %s (type: %s)', i, msg,
-                  type(msg).__name__)
+        LOG.info('Message #%d received: %s (type: %s)', i, msg,
+                 type(msg).__name__)
         try:
             self.payload_process(msg)
         except Exception:
             LOG.exception(
                 'Failed to process a message #%d.'
                 ' The message is skipped.', i)
-        LOG.debug('Message #%d processed', i)
+        LOG.info('Message #%d processed', i)
 
     def payload_process(self, msg: str) -> None:
         data = None
@@ -79,8 +79,8 @@ class BQProcessor:
             return HAState(fid, status=state)
 
         hastate: Optional[HAState] = _get_ha_state()
-        LOG.debug('ProcessStateUpdate process fid: %s state: %s, type: %s',
-                  payload['fid'], payload['state'], payload['type'])
+        LOG.info('ProcessStateUpdate process fid: %s state: %s, type: %s',
+                 payload['fid'], payload['state'], payload['type'])
         self.planner.add_command(
             ProcessHaEvent(fid=Fid.parse(payload['fid']),
                            proc_type=getattr(m0HaProcessType,
@@ -92,12 +92,12 @@ class BQProcessor:
         # for objinfo in payload:
         hastate: Optional[HAState] = self.to_ha_state(payload)
         if not hastate:
-            LOG.debug('No ha states to broadcast.')
+            LOG.info('No ha states to broadcast.')
             return
 
         q: Queue = Queue(1)
-        LOG.debug('HA broadcast, node: %s device: %s state: %s',
-                  payload['node'], payload['device'], payload['state'])
+        LOG.info('HA broadcast, node: %s device: %s state: %s',
+                 payload['node'], payload['device'], payload['state'])
         self.planner.add_command(
             BroadcastHAStates(states=[hastate], reply_to=q))
         ids: List[MessageId] = q.get()
@@ -127,7 +127,7 @@ class BQProcessor:
             'disk-detach': create_handler(SnsDiskDetach),
         }
 
-        LOG.debug(f'process_sns_operation: {op_name}')
+        LOG.info(f'process_sns_operation: {op_name}')
         if op_name not in msg_factory:
             LOG.error('Invalid sns operation, (%s) ', op_name)
         message = msg_factory[op_name](payload)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -146,7 +146,7 @@ def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
                 ha_states.append(HAState(
                     fid=create_process_fid(int(svc_id)),
                     status=svc_status))
-    LOG.debug('Reporting ha states: %s', ha_states)
+    LOG.info('Reporting ha states: %s', ha_states)
     return ha_states
 
 
@@ -159,7 +159,7 @@ def process_ha_states(planner: WorkPlanner, consul_util: ConsulUtil):
         def fn():
             # import pudb.remote
             # pudb.remote.set_trace(term_size=(80, 40), port=9998)
-            LOG.debug('Service health from Consul: %s', data)
+            LOG.info('Service health from Consul: %s', data)
             planner.add_command(
                 BroadcastHAStates(states=to_ha_states(data, consul_util),
                                   reply_to=None))
@@ -197,7 +197,7 @@ def process_sns_operation(planner: WorkPlanner):
             'disk-detach': create_handler(SnsDiskDetach),
         }
 
-        LOG.debug(f'process_sns_operation: {op_name}')
+        LOG.info(f'process_sns_operation: {op_name}')
         if op_name not in msg_factory:
             raise HTTPNotFound()
         data = await request.json()
@@ -271,7 +271,7 @@ def process_state_update(planner: WorkPlanner):
             LOG.debug('process status: %s', data)
             proc_status_val = base64.b64decode(data['Value']).decode("utf-8")
             proc_status = json.loads(proc_status_val)
-            LOG.debug('process status %s', proc_status)
+            LOG.info('process status %s', proc_status)
             proc_fid = Fid.parse(data['Key'].split('/')[1])
             proc_state = proc_status['state']
             proc_type = proc_status['type']

--- a/hax/hax/util.py
+++ b/hax/hax/util.py
@@ -652,8 +652,8 @@ class ConsulUtil:
         for a given process name.
         """
         statuses = self.get_m0d_statuses(proc_names)
-        LOG.debug('The following statuses received for %s: %s',
-                  proc_names, statuses)
+        LOG.info('The following statuses received for %s: %s',
+                 proc_names, statuses)
         return [(item.fid, status) for item, status in statuses]
 
     @uses_consul_cache
@@ -2161,8 +2161,8 @@ class ConsulUtil:
     def set_process_state(self,
                           process_fid: Fid,
                           state: ObjHealth) -> None:
-        LOG.debug('Setting process=%s in KV with state=%s',
-                  process_fid, state)
+        LOG.info('Setting process=%s in KV with state=%s',
+                 process_fid, state)
         process_state_map = {
             ObjHealth.OK: 'online',
             ObjHealth.FAILED: 'failed',
@@ -2185,7 +2185,7 @@ class ConsulUtil:
                 continue
             value = json.loads(item['Value'])
             value['state'] = process_state_map[state]
-            LOG.debug('set_process_state: %s', json.dumps(value))
+            LOG.info('set_process_state: %s', json.dumps(value))
             self.kv.kv_put(item['Key'], json.dumps(value))
 
     @repeat_if_fails()
@@ -2267,8 +2267,8 @@ class ConsulUtil:
 
     def get_motr_processes_status(self):
         with self.lock:
-            LOG.debug('Current motr_processes_status: %s',
-                      motr_processes_status)
+            LOG.info('Current motr_processes_status: %s',
+                     motr_processes_status)
             return motr_processes_status
 
     # bAdd indicate whether new entry should be added or status should be
@@ -2277,8 +2277,8 @@ class ConsulUtil:
         with self.lock:
             if fid in motr_processes_status or bAdd:
                 motr_processes_status[fid] = status
-            LOG.debug('Updated motr_processes_status: %s',
-                      motr_processes_status)
+            LOG.info('Updated motr_processes_status: %s',
+                     motr_processes_status)
 
     @repeat_if_fails()
     def process_dynamic_fidk_lock(self) -> bool:

--- a/utils/hare_cov/hare_coverage.py
+++ b/utils/hare_cov/hare_coverage.py
@@ -112,7 +112,7 @@ class Utility:
         :param max_split: maximum number split
         :return: tuple(stdout, stderr)
         """
-        logging.debug(f"Executing Command : {command!a}")
+        logging.info(f"Executing Command : {command!a}")
         process: Popen[bytes] = Popen(
             command.split(sep=delimiter, maxsplit=max_split),
             stdout=PIPE,


### PR DESCRIPTION
Problem:
As of now, much of the default logging in HARE is at DEBUG level. Its
recommended to use INFO as default log level, to generate just good enough logs
in production releases, and enable DEBUG log level only in development
systems. This enable system to more relevant logs in less number of lines and
hence size.

Solution:
Convert the DEBUG level of such logging to INFO level.

Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>