### PR TITLE
CORTX-34086: m0crate IO failure

### DIFF
--- a/utils/m0crate-io-conf
+++ b/utils/m0crate-io-conf
@@ -135,7 +135,7 @@ WORKLOAD_SPEC:                # Workload specification section
       WORKLOAD_TYPE: 1        # Index(0), IO(1)
       WORKLOAD_SEED: tstamp   # SEED to the random number generator
       OPCODE: 3               # Operation(s) to test: 2-WRITE, 3-WRITE+READ
-      IOSIZE: 10m      # Total Size of IO to perform per object
+      IOSIZE: 2m              # Total Size of IO to perform per object
       BLOCK_SIZE: 2m          # In N+K conf set to (N * UNIT_SIZE) for max perf
       BLOCKS_PER_OP: 1        # Number of blocks per motr operation
       MAX_NR_OPS: 1           # Max concurrent operations per thread


### PR DESCRIPTION
Probleam:
Hare PreMerge Jenkins Job failing due to m0crate IO failuers.
` [io_req.c:1551:device_check] <! rc=-5 [0x23724c0] too many failures `

Solution:
Added workaround to unblock pre-merged job:
Workaround: Keep IO size and block size same in m0crate-io-conf as below
 ```
IOSIZE: 2m      # Total Size of IO to perform per object
BLOCK_SIZE: 2m          # In N+K conf set to (N * UNIT_SIZE) for max perf
 ```
 Signed-off-by: pavankrishnat <pavan.k.thunuguntla@seagate.com>