### PR TITLE
CORTX-31563 Export ConsulUtil as ConfigManager & refactor hax consul interface

### DIFF
--- a/hax/hax/bytecount.py
+++ b/hax/hax/bytecount.py
@@ -27,13 +27,15 @@ from hax.exception import (BytecountException, HAConsistencyException,
 from hax.motr import Motr, log_exception
 from hax.types import (ByteCountStats, Fid, ObjHealth, PverInfo,
                        StoppableThread)
-from hax.util import ConsulUtil, wait_for_event
+from hax.util import wait_for_event
+from hax.configmanager import ConsulConfigManager
 
 LOG = logging.getLogger('hax')
 
 
 class ByteCountUpdater(StoppableThread):
-    def __init__(self, motr: Motr, consul_util: ConsulUtil, interval_sec=5):
+    def __init__(self, motr: Motr, consul_util: ConsulConfigManager,
+                 interval_sec=5):
         super().__init__(target=self._execute,
                          name='byte-count-updater',
                          args=(motr, ))

--- a/hax/hax/configmanager/__init__.py
+++ b/hax/hax/configmanager/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from .base import ConfigManager
+from .consul import ConsulConfigManager
+
+__all__ = ['ConfigManager', 'ConsulConfigManager']

--- a/hax/hax/configmanager/base.py
+++ b/hax/hax/configmanager/base.py
@@ -1,0 +1,691 @@
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple
+from threading import Event
+
+from hax.exception import HAConsistencyException
+from hax.types import (ByteCountStats, ConfHaProcess, Fid, FsStatsWithTime,
+                       ObjT, ObjHealth, Profile, PverInfo,
+                       m0HaProcessEvent, m0HaProcessType,
+                       HaNoteStruct, m0HaObjState)
+from hax.util import (repeat_if_fails, mk_fid, ServiceData,
+                      get_motr_processes_status,
+                      FidWithType, create_service_fid,
+                      create_process_fid, PutKV,
+                      ha_process_events, MotrConsulProcInfo,
+                      wait_for_event)
+from hax.consul.cache import uses_consul_cache
+
+LOG = logging.getLogger('hax')
+
+
+class ConfigManager(ABC):
+    # Interface to be implemented by subclasses
+
+    @abstractmethod
+    def _service_by_name(self, hostname: str,
+                         svc_name: str) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _service_data(self, kv_cache=None) -> ServiceData:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_nodes(self, kv_cache=None):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_local_nodename(self) -> str:
+        """
+        Returns the logical name of the current node. This is the name that
+        the ConfigManager is aware of. In other words, whenever the
+        ConfigManager references a node, it will use the names that this
+        function can return.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_node_alive(self, node: str, kv_cache=None) -> bool:
+        """
+        Checks whether the given node is alive.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_hax_ssl_config(self, kv_cache=None) -> Optional[Dict[str, str]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_m0d_statuses(self,
+                         motr_services=None,
+                         kv_cache=None
+                         ) -> List[Tuple[ServiceData, ObjHealth]]:
+        """
+        Return the list of all Motr service statuses according to
+        ConfigManager. The following services are
+        considered [default]: ios, confd.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_conf_obj_status(self,
+                            obj_t: ObjT,
+                            fidk: int,
+                            kv_cache=None) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_service_data_by_name(self, name: str) -> List[ServiceData]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_services_by_parent_process(self,
+                                       process_fid: Fid,
+                                       kv_cache=None) -> List[FidWithType]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_disks_by_parent_process(self,
+                                    process_fid: Fid,
+                                    svc_fid: Fid) -> List[Fid]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_rm_fid(self, kv_cache=None) -> Fid:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_fid(self, node: str, kv_cache=None) -> Optional[Fid]:
+        """
+        Returns the fid of the given node.
+
+        Parameters:
+            node : hostname of the node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_name_by_fid(self,
+                             node_fid: Fid,
+                             kv_cache=None) -> Optional[str]:
+        """
+        Returns the node name by its FID value or None if the given FID doesn't
+        correspond to any node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_name_by_machineid(self,
+                                   machineid: str,
+                                   kv_cache=None,
+                                   allow_null=False) -> Optional[str]:
+        """
+        Returns the node name by its machine id value or None if the given
+        machine id doesn't correspond to any node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_machineid_by_nodename(self,
+                                  nodename: str,
+                                  kv_cache=None,
+                                  allow_null=False):
+        """
+        Returns the machine id by its node-name value or None if the given
+        node-name doesn't correspond to any node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_ctrl_fids(self,
+                           node: str,
+                           kv_cache=None) -> Optional[List[Fid]]:
+        """
+        Parameters:
+            node : hostname of the node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_io_service_devices(self,
+                               ioservice_fid: Fid,
+                               kv_cache=None) -> Optional[List[str]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_device_controller(self, sdev_fid, kv_cache=None):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_encl_fid(self, node: str, kv_cache=None) -> Optional[Fid]:
+        """
+        Returns the fid of the enclosure for the given node.
+
+        Parameters:
+            node : hostname of the node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def all_io_services_failed(self, node: str, kv_cache=None) -> bool:
+        """
+        Checks if all the IO services of given node are in failed state.
+
+        Parameters:
+            node : hostname of the node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_node_state(self,
+                       node_fid: Fid,
+                       status: ObjHealth,
+                       kv_cache=None) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_encl_state(self,
+                       encl_fid: Fid,
+                       status: ObjHealth,
+                       kv_cache=None) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_ctrl_state_updates(self,
+                               ctrl_fid: Fid,
+                               status: ObjHealth,
+                               kv_cache=None) -> List[PutKV]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_ctrl_state(self, obj_t: ObjT, fidk: int, kv_cache=None) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_encl_state(self, obj_t: ObjT, fidk: int, kv_cache=None) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_state(self, obj_t: ObjT, fidk: int, kv_cache=None) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_proc_restart_count(self, proc_fid: Fid) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_proc_restart_count(self, proc_fid: Fid, count: int):
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_fs_stats(self, stats_data: FsStatsWithTime) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_pver_bc(self, data: ByteCountStats) -> None:
+        """
+        Updates bytecount stats per pool versions for all pvers
+        under the ios service in consul kv.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_bc_for_dg_category(self,
+                                  pver_bc: Dict[str, int],
+                                  pver_state: Dict[str, PverInfo]):
+        '''
+        This function will update bytecount for subsequent dg state/category
+        which will reflect on cluster status.
+        '''
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_process_status(self, event: ConfHaProcess) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_drive_state(self,
+                           drive_fids: List[Fid],
+                           status: ObjHealth,
+                           device_event=True,
+                           kv_cache=None) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_sdev_state_update(self,
+                              sdev_fid: Fid,
+                              state: str,
+                              device_event=True,
+                              kv_cache=None) -> List[PutKV]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_sdev_state(self, obj_t: ObjT, fidk: int, kv_cache=None) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def drive_to_sdev_fid(self, drive_fid: Fid, kv_cache=None) -> Fid:
+        raise NotImplementedError
+
+    @abstractmethod
+    def sdev_to_drive_fid(self, sdev_fid: Fid):
+        raise NotImplementedError
+
+    @abstractmethod
+    def node_to_drive_fid(self, node_name: str, drive: str):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_process_status(self,
+                           fid: Fid,
+                           proc_node=None,
+                           kv_cache=None) -> MotrConsulProcInfo:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_process_status_local(self,
+                                 fid: Fid,
+                                 proc_node=None,
+                                 kv_cache=None) -> MotrConsulProcInfo:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_process_full_fid(self, proc_base_fid: Fid) -> Optional[Fid]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_process_status_local(self, event: ConfHaProcess) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_service_health(self,
+                           node: str,
+                           svc_id: int,
+                           kv_cache=None) -> ObjHealth:
+        """
+        Returns current status of a service identified by the given
+        svc_id for a given node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_process_node(self, proc_fid: Fid, kv_cache=None) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_encl_node(self, encl: Fid, kv_cache=None) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_ctrl_encl(self, ctrl: Fid, kv_cache=None) -> Fid:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_ctrl_node(self, ctrl: Fid, kv_cache=None) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_service_process_fid(self, svc_fid: Fid, kv_cache=None) -> Fid:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_profiles(self, kv_cache=None) -> List[Profile]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_process_based_node_state(self, node_fid: Fid) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_process_state(self,
+                          process_fid: Fid,
+                          state: ObjHealth) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_configpath(self, allow_null=False):
+        raise NotImplementedError
+
+    @abstractmethod
+    def init_motr_processes_status(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def alloc_next_process_fid(self, process_fid: Fid) -> Fid:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_health_status(self, node: str, kv_cache=None) -> str:
+        """
+        Returns the node health status string returned by Consul.
+        Possible return values: passing, warning, critical
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_hare_motr_s3_fids(self, node: str) -> List[Fid]:
+        """
+        Parameters:
+            node : hostname of the node
+        response:
+            returns list of fids for hax, ioservices, confd and s3services
+            configured and running on @node.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_proc_client(self, process_fid: Fid) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_leader_node(self) -> str:
+        """
+        Returns the node name of RC leader.
+        Note: in case when RC leader is not elected yet, the node name may be
+        just a randomly generated string (see hare-node-join script for
+        more details).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_leader_session_no_wait(self) -> str:
+        """
+        Returns the RC leader session. HAConsistencyException is raised
+        immediately if there is no RC leader selected at the moment.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_leader_value_present_for_session(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_session_node(self, session_id: str) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def destroy_session(self, session: str) -> None:
+        """
+        Destroys the given ConfigManager Session by name.
+        The method doesn't raise any exception if the session doesn't exist.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def fid_to_endpoint(self, proc_fid: Fid) -> Optional[str]:
+        raise NotImplementedError
+
+    # Common functionality
+
+    @uses_consul_cache
+    def _local_service_by_name(self,
+                               name: str,
+                               kv_cache=None) -> Optional[Dict[str, Any]]:
+        """
+        Returns the service data by its name assuming that it runs at the same
+        node to the current hax process.
+        """
+        local_nodename = self.get_local_nodename()
+        return self._service_by_name(local_nodename, name)
+
+    @uses_consul_cache
+    def get_hax_fid(self, kv_cache=None) -> Fid:
+        """
+        Returns the fid of the current hax process (in other words, returns
+        "my own" fid)
+        """
+        svc: Optional[Dict[str, Any]] = self._local_service_by_name('hax')
+        if not svc or svc is None:
+            raise HAConsistencyException('Error fetching hax svc')
+        return mk_fid(ObjT.PROCESS, int(svc['ServiceID']))
+
+    @uses_consul_cache
+    def get_ha_fid(self, kv_cache=None) -> Fid:
+        svc = self._local_service_by_name('hax')
+        if not svc or svc is None:
+            raise HAConsistencyException('Error fetching hax svc')
+        return mk_fid(ObjT.SERVICE, int(svc['ServiceID']) + 1)
+
+    @uses_consul_cache
+    def get_hax_endpoint(self, kv_cache=None) -> str:
+        hax_ep = self._service_data(kv_cache=kv_cache).address
+        if not hax_ep or hax_ep is None:
+            raise HAConsistencyException('Error fetching hax endpoint')
+        return hax_ep
+
+    @uses_consul_cache
+    @repeat_if_fails()
+    def get_hax_ip_address(self, kv_cache=None) -> str:
+        hax_ip = self._service_data(kv_cache=kv_cache).ip_addr
+        if not hax_ip or hax_ip is None:
+            raise HAConsistencyException('Error fetching hax ip address')
+        return str(hax_ip)
+
+    @uses_consul_cache
+    @repeat_if_fails()
+    def get_hax_hostname(self, kv_cache=None) -> str:
+        hax_hostname = self._service_data(kv_cache=kv_cache).node
+        if not hax_hostname or hax_hostname is None:
+            raise HAConsistencyException('Error fetching hax hostname')
+        return str(hax_hostname)
+
+    def get_hax_http_port(self) -> int:
+        service_data = self._local_service_by_name('hax')
+        if not service_data:
+            raise HAConsistencyException('Error fetching hax svc')
+        return int(service_data['ServiceMeta'].get('http_port', 8008))
+
+    @repeat_if_fails()
+    def get_leader_session(self) -> str:
+        """
+        Blocking version of `get_leader_session_no_wait()`.
+        The method either returns the RC leader session or blocks until the
+        session becomes available.
+        """
+        return str(self.get_leader_session_no_wait())
+
+    def get_svc_status(self, srv_fid: Fid, kv_cache=None) -> str:
+        try:
+            return self.get_process_status(srv_fid,
+                                           kv_cache=kv_cache).proc_status
+        except Exception:
+            return 'Unknown'
+
+    def get_confd_list(self) -> List[ServiceData]:
+        return self.get_service_data_by_name('confd')
+
+    def get_proc_fids_with_status(self,
+                                  proc_names: List[str]
+                                  ) -> List[Tuple[Fid, ObjHealth]]:
+        """
+        Fetches all the process fids and their statuses across the cluster
+        for a given process name.
+        """
+        statuses = self.get_m0d_statuses(proc_names)
+        LOG.debug('The following statuses received for %s: %s',
+                  proc_names, statuses)
+        return [(item.fid, status) for item, status in statuses]
+
+    @repeat_if_fails()
+    def is_process_confd(self, proc_fid: Fid, kv_cache=None) -> bool:
+        confds = self.get_confd_list()
+        for confd in confds:
+            if proc_fid == confd.fid:
+                return True
+        return False
+
+    @uses_consul_cache
+    def get_proc_svc_conf_obj_status(self,
+                                     obj_t: ObjT,
+                                     fidk: int,
+                                     kv_cache=None) -> int:
+        if ObjT.SERVICE.name == obj_t.name:
+            svc_fid = create_service_fid(fidk)
+            pfid = self.get_service_process_fid(svc_fid, kv_cache=kv_cache)
+        else:
+            pfid = create_process_fid(fidk)
+        proc_node = self.get_process_node(pfid, kv_cache=kv_cache)
+        proc_status: ObjHealth = self.get_service_health(proc_node, pfid.key,
+                                                         kv_cache=kv_cache)
+        # Report ONLINE for hax and confd if they are already started.
+        hax_fid = self.get_hax_fid(kv_cache=kv_cache)
+        if (proc_status == ObjHealth.RECOVERING and
+                (self.is_process_confd(pfid) or
+                 pfid == hax_fid)):
+            return HaNoteStruct.M0_NC_ONLINE
+        return proc_status.to_ha_note_status()
+
+    @repeat_if_fails()
+    @uses_consul_cache
+    def get_ioservice_ctrl_fid(self,
+                               ioservice_fid: Fid,
+                               kv_cache=None) -> Optional[Fid]:
+        """
+        Returns the fid of the controller for the given IOservice.
+
+        Parameters:
+            ioservice_fid : Fid of IO service for which ctrl fid is required.
+
+        TODO: Instead of comparing devices, add a mapping from controller
+              to I/O service
+        """
+        if not ioservice_fid:
+            return None
+
+        sdev_fids = self.get_io_service_devices(ioservice_fid,
+                                                kv_cache=kv_cache)
+
+        if not sdev_fids:
+            return None
+
+        sdev_fid = sdev_fids[0]
+
+        ctrl_fid = self.get_device_controller(sdev_fid, kv_cache=kv_cache)
+
+        if ctrl_fid is None:
+            return None
+        else:
+            return Fid.parse(ctrl_fid)
+
+    def get_device_ha_state(self, status: ObjHealth) -> str:
+
+        device_ha_state_map = {
+            ObjHealth.UNKNOWN: m0HaObjState.M0_NC_TRANSIENT,
+            ObjHealth.RECOVERING: m0HaObjState.M0_NC_DTM_RECOVERING,
+            ObjHealth.OK: m0HaObjState.M0_NC_ONLINE,
+            ObjHealth.OFFLINE: m0HaObjState.M0_NC_TRANSIENT,
+            ObjHealth.FAILED: m0HaObjState.M0_NC_FAILED,
+            ObjHealth.REPAIR: m0HaObjState.M0_NC_REPAIR,
+            ObjHealth.REPAIRED: m0HaObjState.M0_NC_REPAIRED,
+            ObjHealth.REBALANCE: m0HaObjState.M0_NC_REBALANCE
+            }
+        return device_ha_state_map[status].name
+
+    def is_proc_local(self, pfid: Fid) -> bool:
+        local_node = self.get_local_nodename()
+        proc_node = self.get_process_node(pfid)
+        return bool(proc_node == local_node)
+
+    @repeat_if_fails()
+    def ensure_ioservices_running(self) -> List[bool]:
+        statuses = self.get_m0d_statuses()
+        LOG.debug('The following statuses received: %s', statuses)
+        # started = ['M0_CONF_HA_PROCESS_STARTED' == v[1] for v in statuses]
+        started = [ObjHealth.OK == v[1] for v in statuses]
+        return started
+
+    @repeat_if_fails()
+    def ensure_motr_all_started(self, event: Event):
+        while True:
+            started = self.ensure_ioservices_running()
+            if all(started):
+                LOG.debug('According to Consul all confds have been started')
+                return
+            wait_for_event(event, 2)
+
+    def m0ds_stopping(self) -> bool:
+        # statuses = self.get_m0d_statuses()
+        statuses = self.get_m0d_statuses()
+        LOG.debug('The following statuses received: %s', statuses)
+        # stopping = [v[1] in ('M0_CONF_HA_PROCESS_STOPPING',
+        #                      'M0_CONF_HA_PROCESS_STOPPED') for v in statuses]
+        stopping = [v[1] in (ObjHealth.OFFLINE,
+                             ObjHealth.STOPPED) for v in statuses]
+        return all(stopping)
+
+    def get_process_current_status(self, status_reported: ObjHealth,
+                                   proc_fid: Fid) -> ObjHealth:
+        status_current = status_reported
+        # Reconfirm the process status only if the reported status is FAILED.
+        node = self.get_process_node(proc_fid)
+        status_current = self.get_service_health(node,
+                                                 proc_fid.key)
+        LOG.info('node: %s proc: %s current status: %s',
+                 node, proc_fid, status_current)
+        return status_current
+
+    def svcHealthToM0Status(self, svc_health: ObjHealth):
+        svcHealthToM0status: dict = {
+            ObjHealth.OK: m0HaProcessEvent.M0_CONF_HA_PROCESS_STARTED,
+            ObjHealth.FAILED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
+            ObjHealth.UNKNOWN: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED,
+            ObjHealth.STOPPED: m0HaProcessEvent.M0_CONF_HA_PROCESS_STOPPED
+        }
+        return svcHealthToM0status[svc_health]
+
+    def service_health_to_m0dstatus_update(self, proc_fid: Fid,
+                                           svc_health: ObjHealth):
+        ev = ConfHaProcess(chp_event=self.svcHealthToM0Status(svc_health),
+                           chp_type=int(
+                                m0HaProcessType.M0_CONF_HA_PROCESS_M0D),
+                           chp_pid=0,
+                           fid=proc_fid)
+        self.update_process_status(ev)
+
+    def is_confd_failed(self, proc_fid: Fid) -> bool:
+        status = self.get_process_status(proc_fid).proc_status
+        return status in ('M0_CONF_HA_PROCESS_STOPPING',
+                          'M0_CONF_HA_PROCESS_STOPPED',
+                          'M0_CONF_HA_PROCESS_STARTING')
+
+    def am_i_rc(self):
+        # The call is already marked with @repeat_if_fails
+        leader = self.get_leader_node()
+        # The call doesn't communicate via Consul REST API
+        this_node = self.get_local_nodename()
+        return leader == this_node
+
+    def get_local_node_status(self):
+        total_processes = 0
+        started_processes = 0
+        for item in get_motr_processes_status().values():
+            total_processes += 1
+            # Checking if status is M0_CONF_HA_PROCESS_STARTED
+            if item == ha_process_events[1]:
+                started_processes += 1
+
+        if total_processes == started_processes:
+            return 'online'
+        elif started_processes == 0:
+            return 'offline'
+        else:
+            return 'degraded'

--- a/hax/hax/filestats.py
+++ b/hax/hax/filestats.py
@@ -23,13 +23,14 @@ from threading import Event
 from hax.exception import HAConsistencyException, InterruptedException
 from hax.motr import Motr, log_exception
 from hax.types import FsStatsWithTime, StoppableThread
-from hax.util import ConsulUtil, wait_for_event
+from hax.util import wait_for_event
+from hax.configmanager import ConfigManager
 
 LOG = logging.getLogger('hax')
 
 
 class FsStatsUpdater(StoppableThread):
-    def __init__(self, motr: Motr, consul_util: ConsulUtil, interval_sec=5):
+    def __init__(self, motr: Motr, consul_util: ConfigManager, interval_sec=5):
         super().__init__(target=self._execute,
                          name='fs-stats-updater',
                          args=(motr, ))

--- a/hax/hax/ha/__init__.py
+++ b/hax/hax/ha/__init__.py
@@ -21,7 +21,7 @@ import logging
 
 from hax.motr.planner import WorkPlanner
 from hax.types import StoppableThread
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager
 
 __all__ = ['create_ha_thread']
 
@@ -45,7 +45,7 @@ class StubEventThread(StoppableThread):
 
 
 def create_ha_thread(planner: WorkPlanner,
-                     util: ConsulUtil) -> StoppableThread:
+                     util: ConfigManager) -> StoppableThread:
     """Creates the proper HA-aware thread, handling possible import errors."""
     try:
         LOG.info('Inside create_ha_thread')
@@ -56,7 +56,7 @@ def create_ha_thread(planner: WorkPlanner,
         return StubEventThread()
 
 
-def get_producer(util: ConsulUtil):
+def get_producer(util: ConfigManager):
     try:
         from hax.ha.ha import Ha
         LOG.info('Getting instance of Ha')

--- a/hax/hax/ha/event/event.py
+++ b/hax/hax/ha/event/event.py
@@ -18,7 +18,7 @@
 import logging
 from hax.ha.const import HEALTH_EVENT_SOURCES, NOT_DEFINED
 from hax.ha.utils import HaUtils
-from hax.util import ConsulUtil
+from hax.configmanager import ConsulConfigManager
 from cortx.utils.event_framework.health import HealthAttr, HealthEvent
 
 
@@ -56,7 +56,7 @@ class HaEvent():
     def send(self, util):
         raise NotImplementedError()
 
-    def get_subscribers(self, consul_util: ConsulUtil,
+    def get_subscribers(self, consul_util: ConsulConfigManager,
                         resourse_type: str):
         ha_util = HaUtils(consul_util)
         subscriber_list = ha_util.get_subscribers(consul_util, resourse_type)

--- a/hax/hax/ha/ha.py
+++ b/hax/hax/ha/ha.py
@@ -21,7 +21,7 @@ from hax.types import HAState, ObjHealth, ObjT, Fid
 from hax.ha.resource.node import Node
 from hax.ha.resource.resource import ResourceType
 from hax.ha.event.event import HaEvent
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager
 from cortx.utils.conf_store import Conf
 
 LOG = logging.getLogger('hax')
@@ -32,7 +32,7 @@ Resource = NamedTuple('Resource', [('type', ResourceType), ('id', str),
 
 
 class Ha():
-    def __init__(self, util: ConsulUtil):
+    def __init__(self, util: ConfigManager):
         self.util = util
 
     def send_event(self, res: Resource):
@@ -71,6 +71,8 @@ class Ha():
 
             node_name = cns.get_process_node(ha_state.fid)
             node_fid = cns.get_node_fid(node_name)
+            # silence mypy
+            assert node_fid is not None
             state = cns.get_process_based_node_state(node_fid)
             LOG.debug('received node state=%s node=%s', state, node_name)
             # since the node event is not always for local node

--- a/hax/hax/ha/handler/node.py
+++ b/hax/hax/ha/handler/node.py
@@ -24,7 +24,7 @@ from hax.ha.handler import EventHandler
 from hax.message import BroadcastHAStates
 from hax.motr.planner import WorkPlanner
 from hax.types import HAState, ObjHealth
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager
 
 LOG = logging.getLogger('hax')
 
@@ -45,7 +45,7 @@ class NodeEventHandler(EventHandler):
     As a result of such HA event the corresponding BroadcastHAStates is
     offered to WorkPlanner.
     """
-    def __init__(self, consul: ConsulUtil, planner: WorkPlanner):
+    def __init__(self, consul: ConfigManager, planner: WorkPlanner):
         """Constructor."""
         self.cns = consul
         self.planner = planner

--- a/hax/hax/ha/message_interface/message_interface.py
+++ b/hax/hax/ha/message_interface/message_interface.py
@@ -19,7 +19,7 @@ import json
 import logging
 from typing import Optional
 from dataclasses import dataclass
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager
 from cortx.utils.message_bus import MessageBus
 from cortx.utils.message_bus import (MessageConsumer, MessageProducer,
                                      MessageBusAdmin)
@@ -58,7 +58,7 @@ class MessageInterface():
 
 
 class MessageBusInterface(MessageInterface):
-    def __init__(self, util: ConsulUtil):
+    def __init__(self, util: ConfigManager):
         logging.debug('Inside  MessageBusInterface')
         self.initialize_bus(util)
 
@@ -70,7 +70,7 @@ class MessageBusInterface(MessageInterface):
                             message_type=message_type)
         return self.producer
 
-    def initialize_bus(self, util: ConsulUtil):
+    def initialize_bus(self, util: ConfigManager):
         """
         This creates a MessageBus internal global in-memory object which is
         indirectly part of the process address space. Thus

--- a/hax/hax/ha/message_interface/thread.py
+++ b/hax/hax/ha/message_interface/thread.py
@@ -27,7 +27,8 @@ from hax.ha.message_interface.message_interface import (MessageBusInterface,
 from hax.ha.message_interface.message_interface import Event
 from hax.motr.planner import WorkPlanner
 from hax.types import StoppableThread
-from hax.util import ConsulUtil, InterruptedException, wait_for_event
+from hax.util import InterruptedException, wait_for_event
+from hax.configmanager import ConfigManager
 
 LOG = logging.getLogger('hax')
 
@@ -40,7 +41,7 @@ class EventPollingThread(StoppableThread):
     """
     def __init__(self,
                  planner: WorkPlanner,
-                 consul: ConsulUtil,
+                 consul: ConfigManager,
                  listener: Optional[MessageInterface] = None,
                  interval_sec: float = 1.0):
         """Constructor."""

--- a/hax/hax/ha/message_type/message_type.py
+++ b/hax/hax/ha/message_type/message_type.py
@@ -16,7 +16,7 @@
 # opensource@seagate.com or cortx-questions@seagate.com.
 
 import logging
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager
 from hax.ha.message_interface.message_interface import MessageBusInterface
 
 
@@ -25,7 +25,7 @@ class MessageType():
         """Message base class with abstract send method."""
         logging.debug('Inside MessageType')
 
-    def send(self, event, util: ConsulUtil):
+    def send(self, event, util: ConfigManager):
         raise NotImplementedError()
 
 
@@ -35,8 +35,8 @@ class HealthMessage(MessageType):
     def __init__(self):
         logging.debug('Inside HealthMessage')
 
-    def send(self, event, util: ConsulUtil):
-        logging.info('Sending HealthMessage: %s', event)
+    def send(self, event, util: ConfigManager):
+        logging.debug('Sending HealthMessage: %s', event)
         for interface in self.topic_list.items():
             sender = interface[1](util)
             message_type = interface[0]

--- a/hax/hax/ha/utils.py
+++ b/hax/hax/ha/utils.py
@@ -17,7 +17,7 @@
 
 import json
 from typing import Dict, List, Optional
-from hax.util import ConsulUtil
+from hax.configmanager import ConsulConfigManager
 
 cached_subscriber_list: List = []
 is_subscriber_list_cached: bool = False
@@ -27,12 +27,12 @@ class HaUtils:
     resource_types = ['node']
     interface_types = ['health_message']
 
-    def __init__(self, consul_util: ConsulUtil):
+    def __init__(self, consul_util: ConsulConfigManager):
         self.util = consul_util
         self.get_subscribers(self.util, None)
 
     # If resourse_type is None then all resource_types will be fetched
-    def get_subscribers(self, consul_util: ConsulUtil,
+    def get_subscribers(self, consul_util: ConsulConfigManager,
                         resourse_type: Optional[str]):
         global cached_subscriber_list, is_subscriber_list_cached
         subscriber_list: List = []

--- a/hax/hax/handler.py
+++ b/hax/hax/handler.py
@@ -34,8 +34,9 @@ from hax.queue.publish import EQPublisher, BQPublisher
 from hax.types import (ConfHaProcess, HAState, HaLinkMessagePromise,
                        MessageId, ObjT, ObjHealth, StoppableThread,
                        m0HaProcessEvent, m0HaProcessType)
-from hax.util import (ConsulUtil, ProcessGroup, dump_json, repeat_if_fails,
+from hax.util import (ProcessGroup, dump_json, repeat_if_fails,
                       ha_process_events)
+from hax.configmanager import ConfigManager, ConsulConfigManager
 from hax.ha import get_producer
 
 
@@ -53,7 +54,7 @@ class ConsumerThread(StoppableThread):
     """
 
     def __init__(self, planner: WorkPlanner, motr: Motr,
-                 herald: DeliveryHerald, consul: ConsulUtil,
+                 herald: DeliveryHerald, consul: ConfigManager,
                  process_groups: ProcessGroup, idx: int):
         super().__init__(target=self._do_work,
                          name=f'qconsumer-{idx}',
@@ -133,7 +134,7 @@ class ConsumerThread(StoppableThread):
         if (event.chp_event ==
                 m0HaProcessEvent.M0_CONF_HA_PROCESS_DTM_RECOVERED):
             try:
-                util: ConsulUtil = ConsulUtil()
+                util: ConfigManager = ConsulConfigManager()
                 producer = get_producer(util)
                 if producer:
                     producer.check_and_send(parent_resource_type=ObjT.NODE,

--- a/hax/hax/hax.py
+++ b/hax/hax/hax.py
@@ -43,7 +43,8 @@ from hax.motr.planner import WorkPlanner
 from hax.motr.rconfc import RconfcStarter
 from hax.server import ServerRunner
 from hax.types import Fid, Profile, StoppableThread
-from hax.util import ConsulUtil, ProcessGroup, repeat_if_fails
+from hax.util import ProcessGroup, repeat_if_fails
+from hax.configmanager import ConfigManager, ConsulConfigManager
 
 
 __all__ = ['main']
@@ -70,7 +71,7 @@ def _run_thread(thread: StoppableThread) -> StoppableThread:
 
 
 def _run_qconsumer_thread(planner: WorkPlanner, motr: Motr,
-                          herald: DeliveryHerald, consul: ConsulUtil,
+                          herald: DeliveryHerald, consul: ConfigManager,
                           process_groups: ProcessGroup,
                           idx: int) -> StoppableThread:
     return _run_thread(ConsumerThread(planner, motr, herald, consul,
@@ -80,19 +81,20 @@ def _run_qconsumer_thread(planner: WorkPlanner, motr: Motr,
 # TODO this is work around and once the proper fix for CORTX-27707 is in
 # place, this will be reverted
 def _run_stats_updater_thread(motr: Motr,
-                              consul_util: ConsulUtil) -> StoppableThread:
+                              consul_util: ConfigManager) -> StoppableThread:
     return _run_thread(FsStatsUpdater(motr, consul_util, interval_sec=600))
 
 
 # TODO this is work around and once the proper fix for CORTX-27707 is in
 # place, this will be reverted
 def _run_bc_updater_thread(motr: Motr,
-                           consul_util: ConsulUtil) -> StoppableThread:
+                           consul_util: ConsulConfigManager
+                           ) -> StoppableThread:
     return _run_thread(ByteCountUpdater(motr, consul_util, interval_sec=600))
 
 
 @repeat_if_fails()
-def _remove_stale_session(util: ConsulUtil) -> None:
+def _remove_stale_session(util: ConsulConfigManager) -> None:
     """
     Destroys a stale RC leader session if it exists or does nothing otherwise.
 
@@ -127,7 +129,7 @@ def _remove_stale_session(util: ConsulUtil) -> None:
 
 @log_exception
 @repeat_if_fails()
-def _get_motr_fids(util: ConsulUtil) -> HL_Fids:
+def _get_motr_fids(util: ConfigManager) -> HL_Fids:
     try:
         hax_ep: str = util.get_hax_endpoint()
         hax_fid: Fid = util.get_hax_fid()
@@ -142,7 +144,7 @@ def _get_motr_fids(util: ConsulUtil) -> HL_Fids:
 
 
 def _run_rconfc_starter_thread(motr: Motr,
-                               consul_util: ConsulUtil) -> RconfcStarter:
+                               consul_util: ConfigManager) -> RconfcStarter:
     rconfc_starter = RconfcStarter(motr, consul_util)
     rconfc_starter.start()
     return rconfc_starter
@@ -185,7 +187,7 @@ def main():
     # process needs to shutdown).
     signal.signal(signal.SIGINT, handle_signal)
 
-    util: ConsulUtil = ConsulUtil()
+    util: ConsulConfigManager = ConsulConfigManager()
     # Avoid removing session on hax start as this will happen
     # on every node, thus leader election will keep re-triggering
     # until the final hax node starts, this will delay further

--- a/hax/hax/motr/__init__.py
+++ b/hax/hax/motr/__init__.py
@@ -36,7 +36,8 @@ from hax.types import (ByteCountStats, ConfHaProcess, Fid, FidStruct, FsStats,
                        MessageId, ObjT, FidTypeToObjT, Profile, PverInfo,
                        ReprebStatus, ObjHealth,
                        m0HaProcessEvent, m0HaProcessType)
-from hax.util import ConsulUtil, repeat_if_fails, FidWithType, PutKV
+from hax.util import repeat_if_fails, FidWithType, PutKV
+from hax.configmanager import ConfigManager, ConsulConfigManager
 
 LOG = logging.getLogger('hax')
 
@@ -58,7 +59,7 @@ class Motr:
                  ffi: HaxFFI,
                  planner: WorkPlanner,
                  herald: DeliveryHerald,
-                 consul_util: ConsulUtil,
+                 consul_util: ConsulConfigManager,
                  node_uuid: str = ''):
         self._ffi = ffi or HaxFFI()
         # [KN] Note that node_uuid is currently ignored by the corresponding
@@ -516,7 +517,7 @@ class Motr:
     @supports_consul_cache
     def _generate_sub_services(self,
                                note: HaNoteStruct,
-                               cns: ConsulUtil,
+                               cns: ConfigManager,
                                update_kv: bool,
                                notify_devices=True,
                                kv_cache=None) -> List[HaNoteStruct]:
@@ -540,7 +541,7 @@ class Motr:
     def _generate_sub_disks(self,
                             note: HaNoteStruct,
                             services: List[FidWithType],
-                            cns: ConsulUtil,
+                            cns: ConfigManager,
                             update_kv: bool,
                             kv_cache=None) -> List[HaNoteStruct]:
         disk_list = []

--- a/hax/hax/motr/rconfc.py
+++ b/hax/hax/motr/rconfc.py
@@ -4,7 +4,8 @@ from threading import Event
 from hax.exception import InterruptedException
 from hax.motr import Motr, log_exception
 from hax.types import StoppableThread
-from hax.util import ConsulUtil, wait_for_event
+from hax.util import wait_for_event
+from hax.configmanager import ConfigManager
 
 LOG = logging.getLogger('hax')
 
@@ -19,7 +20,7 @@ class RconfcStarter(StoppableThread):
     will not appear until confd's will receive entrypoint reply but that reply
     can happen when Motr is initialized in hax).
     """
-    def __init__(self, motr: Motr, consul_util: ConsulUtil):
+    def __init__(self, motr: Motr, consul_util: ConfigManager):
         """Rconfc starter's thread constructor."""
         super().__init__(target=self._execute,
                          name='rconfc-starter',

--- a/hax/hax/queue/confobjutil.py
+++ b/hax/hax/queue/confobjutil.py
@@ -1,14 +1,14 @@
 from typing import Optional
 
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager, ConsulConfigManager
 
 
 # TODO [KN] Do we realy need this class?
 # FIXME remove me
 class ConfObjUtil:
-    def __init__(self, consul_util: Optional[ConsulUtil]):
+    def __init__(self, consul_util: Optional[ConfigManager]):
         """ConfObjUtil constructor with consul util dependency injection."""
-        self.consul = consul_util or ConsulUtil()
+        self.consul = consul_util or ConsulConfigManager()
 
     def drive_to_sdev_fid(self, node: str, drive: str):
         return self.consul.node_to_drive_fid(node, drive)

--- a/hax/hax/server.py
+++ b/hax/hax/server.py
@@ -45,7 +45,8 @@ from hax.queue import BQProcessor
 from hax.queue.confobjutil import ConfObjUtil
 from hax.queue.offset import InboxFilter, OffsetStorage
 from hax.types import Fid, HAState, ObjHealth, StoppableThread
-from hax.util import ConsulUtil, create_process_fid, dump_json
+from hax.util import create_process_fid, dump_json
+from hax.configmanager import ConfigManager, ConsulConfigManager
 from helper.exec import Executor, Program
 from hax.util import repeat_if_fails
 from hax.ha.utils import HaUtils
@@ -123,7 +124,7 @@ def hctl_fetch_fids(request):
     return json_response(text=result)
 
 
-def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
+def to_ha_states(data: Any, consul_util: ConfigManager) -> List[HAState]:
     """
     converts dictionary into list of HA states.
 
@@ -151,7 +152,7 @@ def to_ha_states(data: Any, consul_util: ConsulUtil) -> List[HAState]:
     return ha_states
 
 
-def process_ha_states(planner: WorkPlanner, consul_util: ConsulUtil):
+def process_ha_states(planner: WorkPlanner, consul_util: ConfigManager):
     async def _process(request):
         data = await request.json()
 
@@ -297,7 +298,7 @@ def process_state_update(planner: WorkPlanner):
     return _process
 
 
-def event_subscription_handle(consul_util: ConsulUtil):
+def event_subscription_handle(consul_util: ConsulConfigManager):
     async def _process(request):
         data = await request.json()
 
@@ -314,7 +315,7 @@ def event_subscription_handle(consul_util: ConsulUtil):
     return _process
 
 
-def event_unsubscription_handle(consul_util: ConsulUtil):
+def event_unsubscription_handle(consul_util: ConsulConfigManager):
     async def _process(request):
         data = await request.json()
 
@@ -361,7 +362,7 @@ class ServerRunner:
         planner: WorkPlanner,
         herald: DeliveryHerald,
         motr: Motr,
-        consul_util: ConsulUtil,
+        consul_util: ConsulConfigManager,
         hax_state: HaxGlobalState
     ):
         self.consul_util = consul_util

--- a/hax/test/integration/conftest.py
+++ b/hax/test/integration/conftest.py
@@ -2,12 +2,12 @@ import logging
 
 import pytest
 from hax.log import setup_logging
-from hax.util import ConsulUtil
+from hax.configmanager import ConsulConfigManager
 
 
 @pytest.fixture
 def consul_util(mocker):
-    consul = ConsulUtil()
+    consul = ConsulConfigManager()
     exc = RuntimeError('Not allowed')
     mock = mocker.patch.object
     mock(consul.kv, 'kv_get', side_effect=exc)

--- a/hax/test/test_failure.py
+++ b/hax/test/test_failure.py
@@ -29,7 +29,8 @@ from hax.log import TRACE
 from hax.motr import Motr
 from hax.types import (Fid, HaNoteStruct, HAState, MessageId,
                                ObjHealth, m0HaObjState)
-from hax.util import (FidWithType, PutKV, ConsulUtil)
+from hax.util import (FidWithType, PutKV)
+from hax.configmanager import ConsulConfigManager
 from hax.consul.cache import InvocationCache
 
 
@@ -63,7 +64,7 @@ class TestFailure(unittest.TestCase):
         logging.getLogger('hax').setLevel(TRACE)
 
     def test_process_failure(self):
-        consul_util = ConsulUtil()
+        consul_util = ConsulConfigManager()
         consul_cache = InvocationCache()
         ffi = Mock(spec=['init_motr_api'])
         motr = Motr(ffi, None, None, consul_util)
@@ -133,7 +134,7 @@ class TestFailure(unittest.TestCase):
                 broadcast_hax_only=False,
                 kv_cache=consul_cache)
 
-        # ConsulUtil is responsible for the actual KV updates, just check
+        # ConfigManager is responsible for the actual KV updates, just check
         # here that the appropriate util function is called for each
         # component.
         consul_util.update_drive_state.assert_called_with(
@@ -163,7 +164,7 @@ class TestFailure(unittest.TestCase):
         self.assertTrue(_has_offline_note(broadcast_list, drive_fid))
 
     def test_drive_failure(self):
-        consul_util = ConsulUtil()
+        consul_util = ConsulConfigManager()
         consul_cache = InvocationCache()
         ffi = Mock(spec=['init_motr_api'])
         motr = Motr(ffi, None, None, consul_util)
@@ -203,7 +204,7 @@ class TestFailure(unittest.TestCase):
         # Send the mock event for drive failure.
         bqprocessor.handle_device_state_set(payload)
 
-        # ConsulUtil is responsible for the actual KV updates, just check
+        # ConfigManager is responsible for the actual KV updates, just check
         # here that the appropriate util function is called for drive state
         # update.
         consul_util.update_drive_state.assert_called_with(

--- a/provisioning/miniprov/hare_mp/consul_starter.py
+++ b/provisioning/miniprov/hare_mp/consul_starter.py
@@ -21,7 +21,7 @@ import logging.handlers
 from typing import List
 from threading import Event
 from hax.types import StoppableThread
-from hax.util import ConsulUtil
+from hax.configmanager import ConfigManager
 from hare_mp.utils import (execute_no_communicate, func_log, func_enter,
                            func_leave, LogWriter, Utils)
 
@@ -34,8 +34,9 @@ class ConsulStarter(StoppableThread):
     """
     Starts consul agent and blocks until terminated.
     """
-    def __init__(self, utils: Utils, cns_utils: ConsulUtil, stop_event: Event,
-                 log_dir: str, data_dir: str, config_dir: str, node_name: str,
+    def __init__(self, utils: Utils, cns_utils: ConfigManager,
+                 stop_event: Event, log_dir: str, data_dir: str,
+                 config_dir: str, node_name: str,
                  node_id: str,
                  peers: List[str],
                  bind_addr: str = '0.0.0.0',  # nosec

--- a/provisioning/miniprov/hare_mp/main.py
+++ b/provisioning/miniprov/hare_mp/main.py
@@ -42,7 +42,8 @@ import yaml
 from cortx.utils.cortx import Const
 from hax.common import di_configuration
 from hax.types import KeyDelete, Fid
-from hax.util import ConsulUtil, repeat_if_fails, KVAdapter
+from hax.util import repeat_if_fails, KVAdapter
+from hax.configmanager import ConfigManager, ConsulConfigManager
 from helper.generate_sysconf import Generator
 
 from hare_mp.cdf import CdfGenerator
@@ -232,7 +233,8 @@ def has_process_stopped(proc_name: str) -> bool:
 
 
 @repeat_if_fails()
-def save_consul_node_name(cns_utils: ConsulUtil, consul_nodename: str,
+def save_consul_node_name(cns_utils: ConsulConfigManager,
+                          consul_nodename: str,
                           hostname: str):
     cns_utils.kv.kv_put(f'consul/node/{hostname}', consul_nodename)
 
@@ -250,7 +252,7 @@ def _start_consul(utils: Utils,
     provider = ConfStoreProvider(url)
     node_id = uuid.uuid4()
     num_ep = int(provider.get('cortx>external>consul>num_endpoints'))
-    cns_utils: ConsulUtil = ConsulUtil()
+    cns_utils: ConsulConfigManager = ConsulConfigManager()
     hostname = utils.get_local_hostname()
 
     # remove tcp://
@@ -367,7 +369,7 @@ def prepare(args):
     utils.save_node_facts()
     utils.save_drives_info()
     try:
-        util: ConsulUtil = ConsulUtil()
+        util: ConfigManager = ConsulConfigManager()
         sess = util.get_leader_session_no_wait()
         util.destroy_session(sess)
     except Exception:
@@ -376,7 +378,8 @@ def prepare(args):
     stop_consul_blocking(consul_starter)
 
 
-def get_hare_motr_s3_processes(utils: ConsulUtil) -> Dict[str, List[Fid]]:
+def get_hare_motr_s3_processes(
+        utils: ConsulConfigManager) -> Dict[str, List[Fid]]:
     nodes = utils.catalog.get_node_names()
     processes: Dict[str, List[Fid]] = {}
     for node in nodes:
@@ -507,7 +510,7 @@ def start_mkfs_parallel(hostname: str, hare_config_dir: str):
 
 @repeat_if_fails()
 def is_mkfs_done_on_all_nodes(utils: Utils,
-                              cns_utils: ConsulUtil,
+                              cns_utils: ConsulConfigManager,
                               nodes: List[str]) -> bool:
     for node in nodes:
         if not cns_utils.kv.kv_get(f'mkfs_done/{node}',
@@ -519,7 +522,7 @@ def is_mkfs_done_on_all_nodes(utils: Utils,
 
 @func_log(func_enter, func_leave)
 @repeat_if_fails()
-def cleanup_mkfs_state(utils: Utils, cns_utils: ConsulUtil):
+def cleanup_mkfs_state(utils: Utils, cns_utils: ConsulConfigManager):
     hostname = utils.get_local_hostname()
     keys: List[KeyDelete] = [
         KeyDelete(name=f'mkfs_done/{hostname}', recurse=True),
@@ -531,7 +534,7 @@ def cleanup_mkfs_state(utils: Utils, cns_utils: ConsulUtil):
 
 @func_log(func_enter, func_leave)
 @repeat_if_fails()
-def set_mkfs_done_for(node: str, cns_utils: ConsulUtil):
+def set_mkfs_done_for(node: str, cns_utils: ConsulConfigManager):
     cns_utils.kv.kv_put(f'mkfs_done/{node}', 'true')
 
 
@@ -542,7 +545,7 @@ def init(args):
 
         conf = ConfStoreProvider(url)
         utils = Utils(conf)
-        cns_utils = ConsulUtil()
+        cns_utils = ConsulConfigManager()
         stop_event = Event()
         config_dir = get_config_dir(url)
         log_dir = get_log_dir(url)
@@ -637,7 +640,7 @@ def reset(args):
 
 @func_log(func_enter, func_leave)
 @repeat_if_fails()
-def cleanup_node_facts(utils: Utils, cns_utils: ConsulUtil):
+def cleanup_node_facts(utils: Utils, cns_utils: ConsulConfigManager):
     hostname = utils.get_local_hostname()
     keys: List[KeyDelete] = [
         KeyDelete(name=f'{hostname}/facts', recurse=True),
@@ -649,7 +652,7 @@ def cleanup_node_facts(utils: Utils, cns_utils: ConsulUtil):
 
 @func_log(func_enter, func_leave)
 @repeat_if_fails()
-def cleanup_disks_info(utils: Utils, cns_utils: ConsulUtil):
+def cleanup_disks_info(utils: Utils, cns_utils: ConsulConfigManager):
     hostname = utils.get_local_hostname()
     keys: List[KeyDelete] = [
         KeyDelete(name=f'{hostname}/drives', recurse=True),
@@ -661,7 +664,7 @@ def cleanup_disks_info(utils: Utils, cns_utils: ConsulUtil):
 
 @func_log(func_enter, func_leave)
 def kv_cleanup(url):
-    util: ConsulUtil = ConsulUtil()
+    util: ConsulConfigManager = ConsulConfigManager()
     conf = ConfStoreProvider(url)
     utils = Utils(conf)
     cleanup_disks_info(utils, util)
@@ -886,7 +889,7 @@ def bootstrap_cluster(path_to_cdf: str, domkfs=False):
 
 
 def wait_for_cluster_start(url: str):
-    util: ConsulUtil = ConsulUtil()
+    util: ConsulConfigManager = ConsulConfigManager()
     processes: Dict[str, List[Fid]] = {}
     while not processes:
         processes = get_hare_motr_s3_processes(util)

--- a/utils/hare-fetch-fids
+++ b/utils/hare-fetch-fids
@@ -32,7 +32,8 @@ import inject
 from socket import getfqdn
 from hax.types import ObjT
 from hax.common import di_configuration
-from hax.util import ConsulUtil, repeat_if_fails
+from hax.util import repeat_if_fails
+from hax.configmanager import ConsulConfigManager
 from hax.exception import HAConsistencyException
 
 from utils import get_node_name
@@ -78,7 +79,7 @@ class Node:
 
 @repeat_if_fails(max_retries=2)
 def get_log_path():
-    cns_utils = ConsulUtil()
+    cns_utils = ConsulConfigManager()
     hostname = getfqdn()
     log_path_key = cns_utils.kv.kv_get(f'{hostname}/log_path')
 
@@ -331,7 +332,7 @@ def read_file(path: str) -> List[Dict[str, str]]:
 
 @repeat_if_fails(max_retries=5)
 def read_kv() -> Optional[List[Dict[str, str]]]:
-    cns_utils = ConsulUtil()
+    cns_utils = ConsulConfigManager()
     data: List[Dict[str, str]] = []
     for key in ["m0conf", "m0_client_types"]:
         kv_data = cns_utils.kv.kv_get(key, recurse=True)

--- a/utils/hare-shutdown
+++ b/utils/hare-shutdown
@@ -26,7 +26,8 @@ from typing import Dict, List, Tuple
 
 from consul import Consul
 from hax.common import di_configuration
-from hax.util import ConsulUtil, repeat_if_fails
+from hax.util import repeat_if_fails
+from hax.configmanager import ConsulConfigManager
 
 import utils
 
@@ -50,7 +51,7 @@ def _get_processes_for_cluster() -> Tuple[Dict[str, List[utils.Process]], str]:
 @repeat_if_fails()
 def _get_processes_for_node() -> Dict[str, List[utils.Process]]:
     cns = Consul()
-    cns_util = ConsulUtil(raw_client=cns)
+    cns_util = ConsulConfigManager(raw_client=cns)
     node = cns_util.get_local_nodename()
     processes = utils.processes_node(cns, node)
     return processes
@@ -58,7 +59,7 @@ def _get_processes_for_node() -> Dict[str, List[utils.Process]]:
 
 @repeat_if_fails()
 def erase_rc_leader() -> None:
-    cns_util = ConsulUtil()
+    cns_util = ConsulConfigManager()
     # fake leader value must match r'^elect[0-9]+$'
     logging.info('Making sure that RC leader can be re-elected next time')
     cns_util.kv.kv_put('leader', 'elect2805')

--- a/utils/hare-status
+++ b/utils/hare-status
@@ -33,7 +33,8 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from consul import Consul, ConsulException
 from hax.common import di_configuration
 from hax.exception import HAConsistencyException
-from hax.util import ConsulUtil, repeat_if_fails
+from hax.util import repeat_if_fails
+from hax.configmanager import ConfigManager, ConsulConfigManager
 from hax.types import Fid
 from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
@@ -164,7 +165,7 @@ def node_name2fid(cns: Consul, node_name: str) -> Any:
     raise RuntimeError(f'Cannot find Consul KV entry for node {node_name!r}')
 
 
-def processes(cns: Consul, consul_util: ConsulUtil,
+def processes(cns: Consul, consul_util: ConfigManager,
               node_name: str) -> List[Process]:
     # Get 'm0conf/nodes/<node_id>/processes/<process_fidk>/...' entries
     # from the KV.  See 'Consul KV Schema' in [4/KV](rfc/4/README.md).
@@ -310,7 +311,7 @@ def get_bytecount_status(cns: Consul) -> Dict[str, Any]:
 
 
 @repeat_if_fails(max_retries=24)
-def get_cluster_status(cns: Consul, consul_util: ConsulUtil,
+def get_cluster_status(cns: Consul, consul_util: ConfigManager,
                        devices_requested: bool) -> Dict[str, Any]:
     result: Dict[str, Any] = {
         'bytecount': get_bytecount_status(cns).get('bytecount'),
@@ -349,7 +350,7 @@ def setup_logging():
 
 
 @repeat_if_fails(max_retries=24)
-def show_text_status(cns: Consul, consul_util: ConsulUtil,
+def show_text_status(cns: Consul, consul_util: ConfigManager,
                      devices_requested: bool) -> None:
     # In-memory buffer required because an intermittent Consul exception can
     # happen right in the middle of printing something. It is good to postpone
@@ -407,7 +408,7 @@ def main(argv=None):
         print('Cluster is not running', file=sys.stderr)
         return 1
 
-    cns_util: ConsulUtil = ConsulUtil()
+    cns_util: ConfigManager = ConsulConfigManager()
     if opts.json:
         status = get_cluster_status(cns, cns_util, opts.devices)
         print(simplejson.dumps(status, indent=2, for_json=True))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -31,7 +31,8 @@ from consul import Consul, ConsulException
 from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
 from hax.exception import HAConsistencyException
-from hax.util import ConsulUtil, consul_to_local_nodename
+from hax.util import consul_to_local_nodename
+from hax.configmanager import ConsulConfigManager
 
 Process = NamedTuple('Process', [('node', str), ('consul_name', str),
                                  ('systemd_name', str), ('fidk', int),
@@ -76,7 +77,7 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
     """Processes grouped by Consul service name."""
     try:
         processes: Dict[str, List[Process]] = {}
-        cns_util = ConsulUtil(raw_client=cns)
+        cns_util = ConsulConfigManager(raw_client=cns)
 
         # TODO Can we replace cns_util.get_local_nodename()
         # with get_node_name() function?
@@ -115,7 +116,7 @@ def processes_node(cns: Consul, node_name: str) -> Dict[str, List[Process]]:
 def processes_by_consul_svc_name(cns: Consul) -> Dict[str, List[Process]]:
     """Processes grouped by Consul service name."""
     try:
-        cns_util = ConsulUtil(raw_client=cns)
+        cns_util = ConsulConfigManager(raw_client=cns)
 
         processes: Dict[str, List[Process]] = {}
         for node in cns.catalog.nodes()[1]:


### PR DESCRIPTION
Problem:
Consul utils are placed in common utils module hax directly interacts
with consul utils without any config abstraction.

Solution:
1. ConfigManager was exported as helper abstraction for consul
helpers in utils module.
2. Direct usage of consul util was replaced by ConfigManager