### PR TITLE
CORTX-31897: Handle Recovery Coordinator node failure

### DIFF
--- a/hax/hax/message.py
+++ b/hax/hax/message.py
@@ -71,6 +71,11 @@ class BroadcastHAStates(BaseMessage):
 
 
 @dataclass
+class ProcessKVUpdate(BaseMessage):
+    states: List[HAState]
+
+
+@dataclass
 class HaNvecGetEvent(BaseMessage):
     hax_msg: int
     nvec: List[HaNote]

--- a/hax/hax/queue/publish.py
+++ b/hax/hax/queue/publish.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 
 import simplejson
 from hax.util import KVAdapter, TxPutKV, repeat_if_fails
@@ -21,12 +21,17 @@ class Publisher:
         self.kv = kv or KVAdapter()
         self.epoch_key = epoch_key
 
-    @repeat_if_fails(wait_seconds=0.1)
-    def publish(self, message_type: str, payload: str) -> int:
-        """Publishes the given message to the queue."""
+    @staticmethod
+    def _get_payload_with_type(message_type: str, payload: str) -> str:
         data = simplejson.loads(payload)
         message = Message(message_type=message_type, payload=data)
         data = simplejson.dumps(message)
+        return str(data)
+
+    @repeat_if_fails(wait_seconds=0.1)
+    def publish(self, message_type: str, payload: str) -> int:
+        """Publishes the given message to the queue."""
+        data = Publisher._get_payload_with_type(message_type, payload)
 
         while True:
             index, value = self.kv.kv_get_raw(self.epoch_key)
@@ -42,6 +47,22 @@ class Publisher:
             ])
             if ok:
                 return next_epoch
+
+    def publish_no_duplicate(self,
+                             message_type: str,
+                             payload: str,
+                             key_suffix: str,
+                             checks: Optional[List[TxPutKV]] = None) -> bool:
+        """Drop the event if the event is already present in the queue."""
+        data = Publisher._get_payload_with_type(message_type, payload)
+        # import pdb; pdb.set_trace()
+        new_key = f'{self.queue_prefix}/{key_suffix}'
+        tx_list = []
+        if checks:
+            tx_list.extend(checks)
+        tx_list.append(TxPutKV(key=new_key, value=data, cas=0))
+        ok = self.kv.kv_put_in_transaction(tx_list)
+        return ok
 
 
 class BQPublisher(Publisher):

--- a/hax/test/test_queue.py
+++ b/hax/test/test_queue.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# flake8: noqa
+import json
+import logging
+import unittest
+from hax.log import TRACE
+from hax.message import ProcessKVUpdate
+from hax.motr.planner import WorkPlanner
+from hax.queue import BQProcessor
+from hax.queue.publish import Publisher
+from hax.types import Fid, HAState, ObjHealth
+from hax.util import KVAdapter, TxPutKV, dump_json, ha_state_to_json
+from unittest.mock import Mock, MagicMock
+
+
+def transaction_helper(data):
+    store = [('test_queue/1', '{"message_type": "dummy_type", "payload": {"key": "val"}}', 0),
+             ('cached_key', 'True', 0)]
+
+    for d in data:
+        if d in store:
+            return False
+    return True
+
+
+class TestPublisher(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # It seems like when unittest is invoked from setup.py,
+        # some default logging configuration is already applied;
+        # invoking setup_logging() will make the log messages to appear twice.
+        logging.addLevelName(TRACE, 'TRACE')
+        logging.getLogger('hax').setLevel(TRACE)
+
+    def test_publish_no_duplicate(self):
+        kv = KVAdapter(cns=MagicMock())
+
+        publisher = Publisher('test_queue', kv)
+        publisher.kv.kv_put_in_transaction =  Mock(side_effect=transaction_helper)
+        payload = dump_json({'key':'val'})
+        ans = publisher.publish_no_duplicate('dummy_type', payload, '2')
+        self.assertTrue(ans)
+
+    def test_publish_duplicate(self):
+        kv = KVAdapter(cns=MagicMock())
+
+        publisher = Publisher('test_queue', kv)
+        publisher.kv.kv_put_in_transaction =  Mock(side_effect=transaction_helper)
+        payload = dump_json({'key':'val'})
+        ans = publisher.publish_no_duplicate('dummy_type', payload, '1')
+        self.assertFalse(ans)
+
+    def test_publish_duplicate_with_checks(self):
+        kv = KVAdapter(cns=MagicMock())
+
+        publisher = Publisher('test_queue', kv)
+        publisher.kv.kv_put_in_transaction =  Mock(side_effect=transaction_helper)
+        payload = dump_json({'key':'val'})
+        checks = [TxPutKV(key='cached_key', value='True', cas=0)]
+        ans = publisher.publish_no_duplicate('dummy_type', payload, '2', checks)
+        self.assertFalse(ans)
+
+
+class TestBQProcessor(unittest.TestCase):
+    # todo can be changed to check payload processed.. and assert for all calls
+    def test_valid_payload_process_handlers(self):
+        mm = MagicMock()
+        bqprocessor = BQProcessor(mm, mm, mm, mm)
+        bqprocessor.handle_process_kv_update = MagicMock()
+        payload = {
+            'message_type' : 'PROCESS_KV_UPDATE',
+            'payload' : 'dummy'
+        }
+        bqprocessor.payload_process(dump_json(payload))
+        bqprocessor.handle_process_kv_update.assert_called()
+
+    def test_payload_process_invalid_handlers(self):
+        mm = MagicMock()
+        bqprocessor = BQProcessor(mm, mm, mm, mm)
+        payload = {
+            'message_type' : 'unsupported type',
+            'payload' : 'dummy'
+        }
+        with self.assertLogs('hax', level='WARNING') as log:
+            bqprocessor.payload_process(dump_json(payload))
+
+
+    def test_invalid_payload_process(self):
+        mm = MagicMock()
+        bqprocessor = BQProcessor(mm, mm, mm, mm)
+        payload = ''
+
+        with self.assertLogs('hax', level='ERROR') as log:
+            bqprocessor.payload_process(payload)
+
+    def test_process_kv_update(self):
+        def fake_add(cmd):
+            self.assertIsInstance(cmd, ProcessKVUpdate)
+
+        mm = MagicMock()
+        planner = WorkPlanner()
+        bqprocessor = BQProcessor(planner, mm, mm, mm)
+        planner.add_command = Mock(side_effect=fake_add)
+        process_fid = Fid(0x7200000000000001, 0x6)
+        payload = ha_state_to_json(HAState(fid=process_fid,
+                                           status=ObjHealth.OFFLINE))
+        bqprocessor.handle_process_kv_update(json.loads(payload))
+
+    def test_process_kv_update_invalid_payload(self):
+        mm = MagicMock()
+        bqprocessor = BQProcessor(mm, mm, mm, mm)
+        payload = {
+            'invalid_key':None
+        }
+        with self.assertLogs('hax', level='ERROR') as log:
+            bqprocessor.handle_process_kv_update(payload)

--- a/rules/process-kv-update
+++ b/rules/process-kv-update
@@ -22,9 +22,10 @@ set -e -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 log() {
-    # logger --tag "hare/${0##*/}" --stderr "$*"
     echo -n "$*"
 }
-log "Default RC rule handler called for event \
-type: ${HARE_RC_EVENT_TYPE} and payload ${HARE_RC_EVENT_PAYLOAD}. \
-No action."
+
+log "Process kv update event is called for \
+payload ${HARE_RC_EVENT_PAYLOAD}."
+
+h0q bq PROCESS_KV_UPDATE "$HARE_RC_EVENT_PAYLOAD"


### PR DESCRIPTION
Description: RC node failure may lead to missing of corresponding Consul updates.

- Cache the process kv update events to the Event Queue. Avoid caching duplicate events in the Event Queue.
- Consume the events from Event Queue and push to Broadcast Queue.
- Track the events after being consumed from EQ via cached PROCESS_FID:state key until the state of the process is correctly updated in consul KV.
- Added UTs to test the same.

Signed-off-by: Shreya Karmakar <shreya.karmakar@seagate.com>