### PR TITLE
bootstrap: client consul configuration is not updated

### DIFF
--- a/utils/hare-bootstrap
+++ b/utils/hare-bootstrap
@@ -443,7 +443,15 @@ while read node _; do
         ssh_error_info "$node" "PATH=$PATH $(which update-consul-conf)" --server --xprt $xprt &
         pids+=($!)
     fi
-done < <(get_all_nodes | grep -vw $(node-name) || true)
+done < <(get_server_nodes | grep -vw $(node-name) || true)
+wait4 ${pids[@]}
+echo ' OK'
+
+while read node _; do
+    scp -qr /var/lib/hare/consul-kv.json $node:/var/lib/hare/
+    ssh_error_info "$node" "PATH=$PATH $(which update-consul-conf)" --xprt $xprt &
+    pids+=($!)
+done < <(get_client_nodes | grep -vw $(node-name) || true)
 wait4 ${pids[@]}
 echo ' OK'
 


### PR DESCRIPTION
Hare bootstrap script, hare-bootstrap, presently does not invoke update-consul-conf for client nodes. Presently the script invokes update-consul-conf with `--server` parameter always, which prevents it from updating consul-client-conf.json file by replacing the HAX_HTTP_PROTOCOL variable with corresponding value. This leads to invalid http URL and consul is not able to update the relevant node status.

Solution:
Invoke update-consul-conf for servers and clients separately.